### PR TITLE
Red Number Scoreboard Hider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Features
 + Adding green line around items that are clickable. (Inside the **Not Clickable Items Feature**)
 + Added **Odger waypoint** - Show the Odger waypoint when trophy fishes are in the inventory and no lava rod in hand.
++ Added the option to hide the red numbers in the scoreboard sidebar at the right side of the screen.
 
 ## Changes
 + Hide reputation boss waypoint when damage indicator is present.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## Features
 + Adding green line around items that are clickable. (Inside the **Not Clickable Items Feature**)
 + Added **Odger waypoint** - Show the Odger waypoint when trophy fishes are in the inventory and no lava rod in hand.
-+ Added the option to hide the red numbers in the scoreboard sidebar at the right side of the screen.
++ Added the option to hide the red numbers in the scoreboard sidebar on the right side of the screen.
 
 ## Changes
 + Hide reputation boss waypoint when damage indicator is present.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -167,3 +167,4 @@
 - Wishing compass uses amount display.
 - Brewing Stand Overlay.
 - Crimson Isle Reputation Helper.
+- Red Scoreboard Numbers - Hides the red numbers in the scoreboard sidebar at the right side of the screen.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -167,4 +167,4 @@
 - Wishing compass uses amount display.
 - Brewing Stand Overlay.
 - Crimson Isle Reputation Helper.
-- Red Scoreboard Numbers - Hides the red numbers in the scoreboard sidebar at the right side of the screen.
+- Red Scoreboard Numbers - Hides the red numbers in the scoreboard sidebar on the right side of the screen.

--- a/src/main/java/at/hannibal2/skyhanni/config/features/Misc.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/Misc.java
@@ -167,4 +167,9 @@ public class Misc {
     @ConfigOption(name = "Config Button", desc = "Add a button to the pause menu to configure SkyHanni.")
     @ConfigEditorBoolean
     public boolean configButtonOnPause = true;
+
+    @Expose
+    @ConfigOption(name = "Red Scoreboard Numbers", desc = "Hide the red scoreboard numbers at the right side of the screen.")
+    @ConfigEditorBoolean
+    public boolean hideScoreboardNumbers = false;
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinGuiIngame.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinGuiIngame.java
@@ -1,0 +1,23 @@
+package at.hannibal2.skyhanni.mixins.transformers;
+
+import at.hannibal2.skyhanni.SkyHanniMod;
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.gui.GuiIngame;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(GuiIngame.class)
+public class MixinGuiIngame {
+
+    @Redirect(method = "renderScoreboard", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/FontRenderer;drawString(Ljava/lang/String;III)I"))
+    private int renderItemOverlayPost(FontRenderer instance, String text, int x, int y, int color) {
+        if (SkyHanniMod.feature.misc.hideScoreboardNumbers) {
+            if (text.startsWith("§c") && text.length() <= 4) {
+                return 0;
+            }
+        }
+
+        return instance.drawString(text, x, y, color);
+    }
+}

--- a/src/main/resources/mixins.skyhanni.json
+++ b/src/main/resources/mixins.skyhanni.json
@@ -17,6 +17,7 @@
     "tileentity.TileEntitySignMixin"
   ],
   "client": [
+    "MixinGuiIngame",
     "gui.MixinGuiNewChat"
   ]
 }


### PR DESCRIPTION
Added the option to hide the red numbers in the scoreboard sidebar on the right side of the screen.

This implements the feature request #9 