### PR TITLE
Fix: Clicking on weight pass chat message

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/FarmingWeightDisplay.kt
@@ -362,7 +362,7 @@ object FarmingWeightDisplay {
                 "§eClick to open your Farming Weight",
                 "§eprofile on §celitebot.dev",
             ),
-            "shfarmingprofile ${LorenzUtils.getPlayerName()}",
+            "/shfarmingprofile ${LorenzUtils.getPlayerName()}",
         )
     }
 


### PR DESCRIPTION
## What
Fixed clicking on a passed player in chat sending a chat message instead of a command due to a missing /

## Changelog Fixes
+ Fixed command sent in chat for Farming Weight Display - not-a-cow