### PR TITLE
Improvement: Add "Never" for Chat Update Interval

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/PathfindConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/PathfindConfig.kt
@@ -24,6 +24,7 @@ class PathfindConfig {
         MID("Every second", 1.seconds),
         A_BIT_LONGER("Every 2 second", 2.seconds),
         LONG("5 seconds", 5.seconds),
+        NEVER("§c§lNever", Duration.INFINITE),
         ;
 
         override fun toString() = displayName

--- a/src/main/java/at/hannibal2/skyhanni/data/IslandGraphs.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/IslandGraphs.kt
@@ -45,6 +45,7 @@ import net.minecraft.client.entity.EntityPlayerSP
 import net.minecraft.util.ChatComponentText
 import java.awt.Color
 import java.io.File
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
 /**
@@ -303,9 +304,11 @@ object IslandGraphs {
         if (event.isMod(2)) {
             update()
         }
+        val updateInterval = config.chatUpdateInterval.duration
+        if (updateInterval == Duration.INFINITE) return
         updateChat()
         nextChatMessage?.let {
-            if (lastMessageSent.passedSince() > config.chatUpdateInterval.duration) {
+            if (lastMessageSent.passedSince() > updateInterval) {
                 it.send(pathFindMessageId)
                 nextChatMessage = null
                 lastMessageSent = SimpleTimeMark.now()


### PR DESCRIPTION
## What
Added a "Never" option for Chat Update Interval during pathfinding.

I've read as many counterarguments about this as I could, from "this will become a `Renderable` soon" to "please stop using Chat Patches, it causes more problems than it's supposed to fix". But at the end of the day, I just want to get from Point A to Point B without wanting to know my navigation progress.

To discourage people from selecting this "Never" option, I went ahead and gave it the `§c§l` formatting codes (see "Images").

This wouldn't affect the logic of updating the pathfinder itself, only the logic for sending chat messages.

<details>
<summary>Images</summary>

<img src="https://github.com/user-attachments/assets/3fce83ed-5224-4ce8-83a3-22e6f4f184a2" />

</details>

## Changelog Improvements
+ Added a "Never" option for Chat Update Interval during pathfinding. - Erymanthus
    * The pathfinder will still update based on player position when using the "Never" option, there just won't be any chat messages being sent about pathfinder navigation progress.
