### PR TITLE
Backend: Fix changelog command injection in Modrinth Version Upload

### DIFF
--- a/.github/workflows/modrinth-version-upload.yml
+++ b/.github/workflows/modrinth-version-upload.yml
@@ -55,13 +55,17 @@ jobs:
                     echo "EOF" >> $GITHUB_OUTPUT
 
             -   name: Print environment variables
+                env:
+                    CHANGELOG: ${{ steps.get_changelog.outputs.changelog }}
                 run: |
                     echo "UPDATE_VERSION=${UPDATE_VERSION}"
                     echo "REPO=${REPO}"
-                    echo "CHANGELOG=${{ steps.get_changelog.outputs.changelog }}"
+                    echo "CHANGELOG=${CHANGELOG}"
 
             -   name: Build Shared Variables Submodule
                 run: ./gradlew :sharedVariables:build
 
             -   name: Publish to Modrinth
-                run: ./gradlew publishToModrinth -Pchangelog="${{ steps.get_changelog.outputs.changelog }}" -PmodVersion="${UPDATE_VERSION}" -PmodrinthToken="${MODRINTH_TOKEN}"
+                env:
+                    CHANGELOG: ${{ steps.get_changelog.outputs.changelog }}
+                run: ./gradlew publishToModrinth -Pchangelog="${CHANGELOG}" -PmodVersion="${UPDATE_VERSION}" -PmodrinthToken="${MODRINTH_TOKEN}"


### PR DESCRIPTION
## What
Fixes a command injection vulnerability in the Modrinth Version Upload action. Thankfully, to actually trigger it, a maintainer would have to actually publish a release with a malicious payload left intact in the changelog and then run the workflow. But this also fixes the workflow breaking on backticks and other characters.

exclude_from_changelog