### PR TITLE
Backend: Entity Features Cleanup

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/VanquisherApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/VanquisherApi.kt
@@ -21,7 +21,7 @@ import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addAll
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
-import at.hannibal2.skyhanni.utils.compat.getStandHelmet
+import at.hannibal2.skyhanni.utils.compat.EntityCompat.getHelmet
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.world.entity.decoration.ArmorStand
@@ -31,7 +31,6 @@ import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object VanquisherApi {
-
     data class VanquisherData(
         val isOwn: Boolean,
         val mob: Mob,
@@ -41,7 +40,7 @@ object VanquisherApi {
         fun postDespawn() {
             if (hasSentDespawn) return
             hasSentDespawn = true
-            VanquisherEvent.DeSpawn(this).post()
+            VanquisherEvent.Despawn(this).post()
         }
     }
 
@@ -92,7 +91,7 @@ object VanquisherApi {
     @HandleEvent(onlyOnIsland = IslandType.CRIMSON_ISLE)
     fun onEntityHealthUpdate(event: EntityMaxHealthUpdateEvent) {
         val entity = event.entity as? ArmorStand ?: return
-        val helmet = entity.getStandHelmet() ?: return
+        val helmet = entity.getHelmet() ?: return
         if (!helmet.`is`(Items.WITHER_SKELETON_SKULL)) return
         lastSpawnEntityPos = entity.getLorenzVec()
         lastPossibleSpawnEntity = entity

--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
@@ -14,7 +14,6 @@ import at.hannibal2.skyhanni.data.jsonobjects.local.FriendsJson
 import at.hannibal2.skyhanni.data.jsonobjects.local.JacobContestsJson
 import at.hannibal2.skyhanni.data.jsonobjects.local.KnownFeaturesJson
 import at.hannibal2.skyhanni.data.jsonobjects.local.VisualWordsJson
-import at.hannibal2.skyhanni.features.misc.ContributorManager
 import at.hannibal2.skyhanni.features.misc.update.UpdateManager
 import at.hannibal2.skyhanni.features.pets.PetDisplayConfigGuiManager
 import at.hannibal2.skyhanni.test.command.ErrorManager
@@ -72,7 +71,6 @@ class ConfigManager {
             logger.log("Loading config despite config being already loaded?")
         }
         configDirectory.mkdirs()
-
 
         for (fileType in ConfigFileType.entries) {
             val clazzInstance = fileType.clazz.getDeclaredConstructor().newInstance()
@@ -290,8 +288,6 @@ enum class ConfigFileType(val fileName: String, val clazz: Class<*>, val propert
 }
 
 class BlockingMoulConfigProcessor : MoulConfigProcessor<SkyHanniConfig>(SkyHanniMod.feature) {
-    val isDev by lazy { ContributorManager.isSelfDeveloper() }
-
     override fun createOptionGui(
         processedOption: ProcessedOption,
         field: Field,
@@ -313,10 +309,10 @@ class BlockingMoulConfigProcessor : MoulConfigProcessor<SkyHanniConfig>(SkyHanni
             return GuiOptionEditorBlocked(default, extraMessage)
         }
 
-        if (!isDev) {
-            if (field.isAnnotationPresent(OnlyDebug::class.java)) {
-                return GuiOptionEditorHidden(default)
-            }
+        if (field.isAnnotationPresent(OnlyDevEnv::class.java) &&
+            !PlatformUtils.isDevEnvironment
+        ) {
+            return GuiOptionEditorHidden(default)
         }
 
         return default

--- a/src/main/java/at/hannibal2/skyhanni/config/OnlyDebug.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/OnlyDebug.kt
@@ -1,5 +1,0 @@
-package at.hannibal2.skyhanni.config
-
-@Retention(AnnotationRetention.RUNTIME)
-@Target(AnnotationTarget.FIELD)
-annotation class OnlyDebug

--- a/src/main/java/at/hannibal2/skyhanni/config/OnlyDevEnv.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/OnlyDevEnv.kt
@@ -1,0 +1,14 @@
+package at.hannibal2.skyhanni.config
+
+/**
+ * Hides the annotated config option outside the development environment. This
+ * should be used for options that cannot work in production, as well as options
+ * that are useful for debugging but may also be abused to cheat.
+ *
+ * Callers are still responsible for checking if the user is in a development
+ * environment; the annotation alone does not prevent someone from manually
+ * setting the option using `/shconfig` or in `config.json`.
+ */
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FIELD)
+annotation class OnlyDevEnv

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/DebugConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/DebugConfig.kt
@@ -15,7 +15,7 @@ import org.lwjgl.glfw.GLFW
 
 class DebugConfig {
     @Expose
-    @ConfigOption(name = "Enable Debug", desc = "Enable Test logic")
+    @ConfigOption(name = "Enable Debug", desc = "Enable test logic")
     @ConfigEditorBoolean
     var enabled: Boolean = false
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/dev/DebugMobConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/dev/DebugMobConfig.kt
@@ -1,5 +1,6 @@
 package at.hannibal2.skyhanni.config.features.dev
 
+import at.hannibal2.skyhanni.config.OnlyDevEnv
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.Accordion
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
@@ -7,9 +8,16 @@ import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDropdown
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 
 class DebugMobConfig {
+    @Expose
+    @ConfigOption(
+        name = "Mob Name & Category",
+        desc = "Shows mob names and categories in the world.",
+    )
+    @ConfigEditorBoolean
+    var mobDisplay: Boolean = false
 
     @Expose
-    @ConfigOption(name = "Mob Detection", desc = "Debug feature to check the Mob Detection.")
+    @ConfigOption(name = "Mob Detection", desc = "Debug feature to test Mob Detection.")
     @Accordion
     val mobDetection: MobDetection = MobDetection()
 
@@ -17,7 +25,8 @@ class DebugMobConfig {
         OFF("Off"),
         ONLY_NAME("Only Name"),
         ONLY_HIGHLIGHT("Only Highlight"),
-        NAME_AND_HIGHLIGHT("Both");
+        NAME_AND_HIGHLIGHT("Both"),
+        ;
 
         override fun toString() = displayName
     }
@@ -81,6 +90,7 @@ class DebugMobConfig {
             desc = "Shows invisible mobs (due to invisibility effect) if looked at directly.",
         )
         @ConfigEditorBoolean
+        @OnlyDevEnv
         var showInvisible: Boolean = false
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/EntityMovementData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/EntityMovementData.kt
@@ -12,7 +12,6 @@ import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
-import at.hannibal2.skyhanni.utils.compat.deceased
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.player.LocalPlayer
@@ -22,7 +21,6 @@ import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object EntityMovementData {
-
     /**
      * REGEX-TEST: §7Sending a visit request...
      * REGEX-TEST: §7Finding player...
@@ -92,7 +90,7 @@ object EntityMovementData {
         addToTrack(MinecraftCompat.localPlayerOrThrow)
 
         for (entity in entityLocation.keys) {
-            if (entity.deceased) continue
+            if (entity.isRemoved) continue
 
             val newLocation = entity.getLorenzVec()
             val oldLocation = entityLocation[entity]!!

--- a/src/main/java/at/hannibal2/skyhanni/data/OtherPlayersSlayerApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/OtherPlayersSlayerApi.kt
@@ -7,17 +7,16 @@ import at.hannibal2.skyhanni.events.entity.slayer.SlayerDeathEvent
 import at.hannibal2.skyhanni.features.slayer.SlayerType
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
-import at.hannibal2.skyhanni.utils.compat.findHealthReal
+import at.hannibal2.skyhanni.utils.compat.EntityCompat.realHealth
 
 @SkyHanniModule
 object OtherPlayersSlayerApi {
-
     @HandleEvent
     fun onMobDespawn(event: MobEvent.DeSpawn.SkyblockMob) {
         val mob = event.mob
 
         // no death, rather despawn because too far away
-        if (mob.baseEntity.findHealthReal() != 0f) return
+        if (mob.baseEntity.realHealth != 0f) return
 
         if (mob.category != MobCategory.SLAYER) return
 

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/IslandExceptions.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/IslandExceptions.kt
@@ -6,7 +6,6 @@ import at.hannibal2.skyhanni.utils.EntityUtils.baseMaxHealth
 import at.hannibal2.skyhanni.utils.EntityUtils.cleanName
 import at.hannibal2.skyhanni.utils.EntityUtils.isNpc
 import at.hannibal2.skyhanni.utils.EntityUtils.wearingSkullTexture
-import at.hannibal2.skyhanni.utils.ItemUtils.getSkullTexture
 import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.MobUtils
 import at.hannibal2.skyhanni.utils.MobUtils.getNextEntity
@@ -15,7 +14,7 @@ import at.hannibal2.skyhanni.utils.MobUtils.takeNonDefault
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
-import at.hannibal2.skyhanni.utils.compat.EntityCompat.getEntityHelmet
+import at.hannibal2.skyhanni.utils.collection.CollectionUtils.equalsOneOf
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import net.minecraft.client.player.RemotePlayer
@@ -60,34 +59,33 @@ object IslandExceptions {
         baseEntity: LivingEntity,
         armorStand: ArmorStand?,
         nextEntity: LivingEntity?,
-    ) = when {
-        baseEntity is Zombie &&
-            armorStand != null &&
-            (armorStand.name.formattedTextCompatLessResets() == "§e﴾ §5♃ §c§lThe Watcher§r§r §e﴿" || armorStand.name.formattedTextCompatLessResets() == "§3§lWatchful Eye§r") ->
+    ) = when (baseEntity) {
+        is Zombie if armorStand != null &&
+            armorStand.cleanName.equalsOneOf("﴾ ♃ The Watcher ﴿", "Watchful Eye") ->
             MobData.MobResult.found(
                 MobFactories.special(baseEntity, armorStand.cleanName, armorStand),
             )
 
-        baseEntity is CaveSpider -> MobUtils.getClosestArmorStand(baseEntity, 2.0).takeNonDefault()
+        is CaveSpider -> MobUtils.getClosestArmorStand(baseEntity, 2.0).takeNonDefault()
             .makeMobResult { MobFactories.dungeon(baseEntity, it) }
 
-        baseEntity is RemotePlayer && baseEntity.isNpc() && baseEntity.name.formattedTextCompatLessResets() == "Shadow Assassin" ->
+        is RemotePlayer if baseEntity.isNpc() && baseEntity.cleanName == "Shadow Assassin" ->
             MobUtils.getClosestArmorStandWithName(baseEntity, 3.0, "Shadow Assassin")
                 .makeMobResult { MobFactories.dungeon(baseEntity, it) }
 
-        baseEntity is RemotePlayer && baseEntity.isNpc() && baseEntity.name.formattedTextCompatLessResets() == "The Professor" ->
+        is RemotePlayer if baseEntity.isNpc() && baseEntity.cleanName == "The Professor" ->
             MobUtils.getArmorStand(baseEntity, 9)
                 .makeMobResult { MobFactories.boss(baseEntity, it) }
 
-        baseEntity is RemotePlayer &&
-            baseEntity.isNpc() &&
+        is RemotePlayer if baseEntity.isNpc() &&
             (nextEntity is Giant || nextEntity == null) &&
-            baseEntity.name.formattedTextCompatLessResets().contains("Livid") -> MobUtils.getArmorStand(baseEntity, 10)
-            ?.takeIf { getNextEntity(it, -1)?.takeIf { entity -> entity.name.formattedTextCompatLessResets().contains("Livid") } == null }
+            baseEntity.cleanName.contains("Livid") -> MobUtils.getArmorStand(baseEntity, 10)
+            ?.takeIf { getNextEntity(it, -1)?.takeIf { entity -> entity.cleanName.contains("Livid") } == null }
             .makeMobResult { MobFactories.boss(baseEntity, it, overriddenName = "Real Livid") }
 
-        baseEntity is IronGolem && MobFilter.wokeSleepingGolemPattern.matches(armorStand?.name.formattedTextCompatLessResets().orEmpty()) ->
-            MobData.MobResult.found(Mob(baseEntity, MobCategory.DUNGEON, armorStand, "Sleeping Golem")) // Consistency fix
+        // Consistency fix
+        is IronGolem if MobFilter.wokeSleepingGolemPattern.matches(armorStand?.cleanName) ->
+            MobData.MobResult.found(Mob(baseEntity, MobCategory.DUNGEON, armorStand, "Sleeping Golem"))
 
         else -> null
     }
@@ -109,14 +107,14 @@ object IslandExceptions {
         baseEntity: LivingEntity,
         nextEntity: LivingEntity?,
         armorStand: ArmorStand?,
-    ) = when {
-        baseEntity is Slime && nextEntity is Slime ->
+    ) = when (baseEntity) {
+        is Slime if nextEntity is Slime ->
             MobData.MobResult.found(Mob(baseEntity, MobCategory.SPECIAL, armorStand, "Bacte Tentacle"))
 
-        baseEntity is Slime && armorStand != null && armorStand.cleanName.startsWith("﴾ [Lv10] B") ->
+        is Slime if armorStand != null && armorStand.cleanName.startsWith("﴾ [Lv10] B") ->
             MobData.MobResult.found(Mob(baseEntity, MobCategory.BOSS, armorStand, name = "Bacte"))
 
-        baseEntity is RemotePlayer && baseEntity.isNpc() && baseEntity.name.formattedTextCompatLessResets() == "Branchstrutter " ->
+        is RemotePlayer if baseEntity.isNpc() && baseEntity.cleanName == "Branchstrutter " ->
             MobData.MobResult.found(Mob(baseEntity, MobCategory.DISPLAY_NPC, name = "Branchstrutter"))
 
         else -> null
@@ -126,24 +124,22 @@ object IslandExceptions {
         baseEntity: LivingEntity,
         armorStand: ArmorStand?,
         nextEntity: LivingEntity?,
-    ) = when {
-        baseEntity is Pig && nextEntity is Pig -> MobData.MobResult.illegal // Matriarch Tongue
-        baseEntity is RemotePlayer && baseEntity.isNpc() && baseEntity.name.string == "BarbarianGuard " ->
+    ) = when (baseEntity) {
+        is Pig if nextEntity is Pig -> MobData.MobResult.illegal // Matriarch Tongue
+        is RemotePlayer if baseEntity.isNpc() && baseEntity.name.string == "BarbarianGuard " ->
             MobData.MobResult.found(Mob(baseEntity, MobCategory.DISPLAY_NPC, name = "Barbarian Guard"))
 
-        baseEntity is RemotePlayer && baseEntity.isNpc() && baseEntity.name.string == "MageGuard " ->
+        is RemotePlayer if baseEntity.isNpc() && baseEntity.name.string == "MageGuard " ->
             MobData.MobResult.found(Mob(baseEntity, MobCategory.DISPLAY_NPC, name = "Mage Guard"))
 
-        baseEntity is RemotePlayer && baseEntity.isNpc() && baseEntity.name.string == "Mage Outlaw" ->
+        is RemotePlayer if baseEntity.isNpc() && baseEntity.name.string == "Mage Outlaw" ->
             // fix for wierd name
             MobData.MobResult.found(Mob(baseEntity, MobCategory.BOSS, armorStand, name = "Mage Outlaw"))
 
-        baseEntity is ZombifiedPiglin &&
-            MobFilter.NPC_TURD_SKULL != null &&
-            baseEntity.getEntityHelmet()?.getSkullTexture() == MobFilter.NPC_TURD_SKULL ->
+        is ZombifiedPiglin if baseEntity.wearingSkullTexture(MobFilter.NPC_TURD_SKULL) ->
             MobData.MobResult.found(Mob(baseEntity, MobCategory.DISPLAY_NPC, name = "Turd"))
 
-        baseEntity is Ocelot -> if (MobFilter.createDisplayNpc(baseEntity)) {
+        is Ocelot -> if (MobFilter.createDisplayNpc(baseEntity)) {
             MobData.MobResult.illegal
         } else {
             MobData.MobResult.notYetFound // Maybe a problem in the future
@@ -186,33 +182,28 @@ object IslandExceptions {
         baseEntity: LivingEntity,
         armorStand: ArmorStand?,
         nextEntity: LivingEntity?,
-    ) = when {
-        baseEntity is Ocelot &&
-            armorStand?.isDefaultValue() == false &&
-            // TODO fix pattern
-            armorStand.name.formattedTextCompatLessResets().startsWith("§8[§7Lv155§8] §cAzrael§r") ->
+    ) = when (baseEntity) {
+        // TODO this check most likely needs updating
+        is Ocelot if armorStand?.isDefaultValue() == false && armorStand.cleanName.startsWith("[Lv155] Azrael") ->
             MobUtils.getArmorStand(baseEntity, 1)
                 .makeMobResult { MobFactories.basic(baseEntity, it) }
 
-        baseEntity is Ocelot && (nextEntity is Ocelot || nextEntity == null) ->
+        is Ocelot if (nextEntity is Ocelot || nextEntity == null) ->
             MobUtils.getArmorStand(baseEntity, 3)
                 .makeMobResult { MobFactories.basic(baseEntity, it) }
 
-        baseEntity is RemotePlayer &&
-            baseEntity.name.formattedTextCompatLessResets()
-                .let { it == "Minos Champion" || it == "Minos Inquisitor" || it == "Minotaur " } &&
+        is RemotePlayer if baseEntity.cleanName.equalsOneOf("Minos Champion", "Minos Inquisitor", "Minotaur ") &&
             armorStand != null ->
             MobUtils.getArmorStand(baseEntity, 2)
                 .makeMobResult { MobFactories.basic(baseEntity, it, listOf(armorStand)) }
 
-        baseEntity is Zombie &&
-            armorStand?.isDefaultValue() == true &&
-            MobUtils.getNextEntity(baseEntity, 4)?.name.formattedTextCompatLessResets().startsWith("§e") ->
+        is Zombie if armorStand?.isDefaultValue() == true &&
+            getNextEntity(baseEntity, 4)?.name.formattedTextCompatLessResets().startsWith("§e") ->
             petCareHandler(baseEntity)
 
-        baseEntity is Zombie && armorStand != null && !armorStand.isDefaultValue() -> null // Impossible Rat
-        baseEntity is Zombie -> ratHandler(baseEntity, nextEntity) // Possible Rat
-        baseEntity is Pig && MobFilter.shinyPig.matches(armorStand?.cleanName) -> MobData.MobResult.found(
+        is Zombie if armorStand != null && !armorStand.isDefaultValue() -> null // Impossible Rat
+        is Zombie -> ratHandler(baseEntity, nextEntity) // Possible Rat
+        is Pig if MobFilter.shinyPig.matches(armorStand?.cleanName) -> MobData.MobResult.found(
             Mob(
                 baseEntity,
                 MobCategory.SPECIAL,
@@ -234,11 +225,10 @@ object IslandExceptions {
     private fun kuudraArena(
         baseEntity: LivingEntity,
         nextEntity: LivingEntity?,
-    ) = when {
-        baseEntity is MagmaCube && nextEntity is MagmaCube -> MobData.MobResult.illegal
-        baseEntity is Zombie && nextEntity is Zombie -> MobData.MobResult.illegal
-        baseEntity is Zombie && nextEntity is Giant -> MobData.MobResult.illegal
-
+    ) = when (baseEntity) {
+        is MagmaCube if nextEntity is MagmaCube -> MobData.MobResult.illegal
+        is Zombie if nextEntity is Zombie -> MobData.MobResult.illegal
+        is Zombie if nextEntity is Giant -> MobData.MobResult.illegal
         else -> null
     }
 
@@ -246,7 +236,7 @@ object IslandExceptions {
         val armorStand = MobUtils.getArmorStand(baseEntity, 2)
         return when {
             baseEntity is MagmaCube &&
-                MobFilter.jerryMagmaCubePattern.matches(armorStand?.name.formattedTextCompatLessResets()) ->
+                MobFilter.jerryMagmaCubePattern.matches(armorStand?.cleanName) ->
                 MobData.MobResult.found(Mob(baseEntity, MobCategory.BOSS, armorStand, "Jerry Magma Cube"))
 
             else -> null

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/Mob.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/Mob.kt
@@ -9,6 +9,7 @@ import at.hannibal2.skyhanni.utils.ColorUtils.toColor
 import at.hannibal2.skyhanni.utils.EntityUtils.baseMaxHealth
 import at.hannibal2.skyhanni.utils.EntityUtils.canBeSeen
 import at.hannibal2.skyhanni.utils.EntityUtils.cleanName
+import at.hannibal2.skyhanni.utils.EntityUtils.hasVisibleEquipment
 import at.hannibal2.skyhanni.utils.EntityUtils.isCorrupted
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.LocationUtils.getBoxCenter
@@ -18,8 +19,7 @@ import at.hannibal2.skyhanni.utils.MobUtils.mob
 import at.hannibal2.skyhanni.utils.PlayerUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.toSingletonListOrEmpty
-import at.hannibal2.skyhanni.utils.compat.EntityCompat.findHealthReal
-import at.hannibal2.skyhanni.utils.compat.EntityCompat.getAllEquipment
+import at.hannibal2.skyhanni.utils.compat.EntityCompat.realHealth
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import io.github.notenoughupdates.moulconfig.ChromaColour
@@ -85,7 +85,6 @@ class Mob(
     val levelOrTier: Int = -1,
     val hypixelTypes: String = "",
 ) {
-
     private val uniqueId: UUID = UUID.randomUUID()
     val id = baseEntity.id
 
@@ -94,7 +93,6 @@ class Mob(
     val ownerNameOrEmpty: String get() = owner?.ownerName.orEmpty()
 
     companion object {
-
         fun Entity?.belongsToPlayer(): Boolean = this?.mob.belongsToPlayer()
         fun Mob?.belongsToPlayer(): Boolean = this?.owner?.equals(PlayerUtils.getName()) ?: false
     }
@@ -127,9 +125,9 @@ class Mob(
 
     fun canBeSeen(viewDistance: Number = 150) = baseEntity.canBeSeen(viewDistance)
 
-    fun isInvisible() = baseEntity !is Zombie &&
-        baseEntity.isInvisible &&
-        baseEntity.getAllEquipment().isEmpty()
+    // TODO remove hardcoded Zombie check and use it only in specific features that need it
+    fun isFullyInvisible(): Boolean =
+        baseEntity !is Zombie && baseEntity.isInvisible && !baseEntity.hasVisibleEquipment()
 
     private var highlightColor: Color? = null
     private var condition: () -> Boolean = { true }
@@ -166,9 +164,13 @@ class Mob(
 
     private fun internalHighlight() {
         highlightColor?.let { color ->
-            RenderLivingEntityHelper.setEntityColor(baseEntity, color) { !isInvisible() && condition() }
+            RenderLivingEntityHelper.setEntityColor(baseEntity, color) {
+                !isFullyInvisible() && condition()
+            }
             extraEntities.forEach {
-                RenderLivingEntityHelper.setEntityColor(it, color) { !isInvisible() && condition() }
+                RenderLivingEntityHelper.setEntityColor(it, color) {
+                    !isFullyInvisible() && condition()
+                }
             }
         }
     }
@@ -188,7 +190,7 @@ class Mob(
             baseEntity.position().z,
         ) ?: baseEntity.boundingBox
 
-    val health: Float get() = baseEntity.findHealthReal()
+    val health: Float get() = baseEntity.realHealth
     val maxHealth: Int get() = baseEntity.baseMaxHealth
 
     init {
@@ -215,10 +217,9 @@ class Mob(
         relativeBoundingBox = if (extraEntities.isNotEmpty()) makeRelativeBoundingBox() else null
     }
 
-    private fun makeRelativeBoundingBox() = baseEntity.boundingBox.union(
-        extraEntities.filter { it !is ArmorStand }
-            .mapNotNull { it.boundingBox },
-    )?.move(-baseEntity.position().x, -baseEntity.position().y, -baseEntity.position().z)
+    private fun makeRelativeBoundingBox() = baseEntity.boundingBox
+        .union(extraEntities.filter { it !is ArmorStand }.map { it.boundingBox })
+        ?.move(-baseEntity.position().x, -baseEntity.position().y, -baseEntity.position().z)
 
     fun fullEntityList() =
         baseEntity.toSingletonListOrEmpty() +

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/MobData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/MobData.kt
@@ -10,12 +10,13 @@ import at.hannibal2.skyhanni.utils.getLorenzVec
 import net.minecraft.world.entity.LivingEntity
 import net.minecraft.world.entity.decoration.ArmorStand
 import java.util.TreeMap
+import java.util.concurrent.ConcurrentHashMap
 
 @SkyHanniModule
 object MobData {
-
-    class MobSet : HashSet<Mob>() {
-        val entityList get() = this.flatMap { listOf(it.baseEntity) + (it.extraEntities) }
+    class MobSet : MutableSet<Mob> by ConcurrentHashMap.newKeySet() {
+        val entityList: List<LivingEntity>
+            get() = flatMap { listOf(it.baseEntity) + (it.extraEntities) }
     }
 
     val players = MobSet()

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/MobDebug.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/MobDebug.kt
@@ -12,52 +12,61 @@ import at.hannibal2.skyhanni.utils.LocationUtils.getTopCenter
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.LorenzDebug
 import at.hannibal2.skyhanni.utils.MobUtils
+import at.hannibal2.skyhanni.utils.collection.CollectionUtils.equalsOneOf
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawFilledBoundingBox
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawString
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.expandBlock
+import at.hannibal2.skyhanni.utils.system.PlatformUtils
 import io.github.notenoughupdates.moulconfig.ChromaColour
 import net.minecraft.client.player.LocalPlayer
 
 @SkyHanniModule
 object MobDebug {
-
     private val config get() = SkyHanniMod.feature.dev.mobDebug.mobDetection
 
     private var lastRayHit: Mob? = null
 
     private fun HowToShow.isHighlight() =
-        this == HowToShow.ONLY_HIGHLIGHT || this == HowToShow.NAME_AND_HIGHLIGHT
+        equalsOneOf(HowToShow.ONLY_HIGHLIGHT, HowToShow.NAME_AND_HIGHLIGHT)
 
     private fun HowToShow.isName() =
-        this == HowToShow.ONLY_NAME || this == HowToShow.NAME_AND_HIGHLIGHT
+        equalsOneOf(HowToShow.ONLY_NAME, HowToShow.NAME_AND_HIGHLIGHT)
 
-    private fun Mob.isNotInvisible() = !this.isInvisible() || (config.showInvisible && this == lastRayHit)
+    private fun Mob.shouldShow(ignoreRayHit: Boolean = false): Boolean {
+        if (!isFullyInvisible()) return true
+        if (!PlatformUtils.isDevEnvironment) return false
+        return ignoreRayHit || this == lastRayHit
+    }
 
-    private fun MobData.MobSet.highlight(event: SkyHanniRenderWorldEvent, color: (Mob) -> (ChromaColour)) {
-        for (mob in filter { it.isNotInvisible() }) {
+    private fun MobData.MobSet.highlight(
+        event: SkyHanniRenderWorldEvent,
+        color: (Mob) -> (ChromaColour),
+    ) {
+        filter { it.shouldShow() }.forEach { mob ->
             event.drawFilledBoundingBox(mob.boundingBox.expandBlock(), color.invoke(mob), 0.3f)
         }
     }
 
     private fun MobData.MobSet.showName(event: SkyHanniRenderWorldEvent) {
-        val map = filter { it.canBeSeen() && it.isNotInvisible() }
+        filter { it.shouldShow() && it.canBeSeen() }
             .map { it.boundingBox.getTopCenter() to it.name }
-        for ((location, text) in map) {
-            event.drawString(location.up(0.5), "§5$text", seeThroughBlocks = true)
-        }
+            .forEach { (location, text) ->
+                event.drawString(location.up(0.5), "§5$text", seeThroughBlocks = true)
+            }
     }
 
     @HandleEvent
     fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
         if (config.showRayHit || config.showInvisible) {
             lastRayHit = MobUtils.raycastForMobs(MinecraftCompat.localPlayerOrThrow, event.partialTicks)
-                ?.firstOrNull { it.canBeSeen() && (!config.showInvisible || !it.isInvisible()) }
+                ?.firstOrNull { it.shouldShow(ignoreRayHit = true) }
         }
 
         if (config.skyblockMob.isHighlight()) {
             MobData.skyblockMobs.highlight(event) {
-                (if (it.category == MobCategory.BOSS) LorenzColor.DARK_GREEN else LorenzColor.GREEN).toChromaColor()
+                (if (it.category == MobCategory.BOSS) LorenzColor.DARK_GREEN else LorenzColor.GREEN)
+                    .toChromaColor()
             }
         }
         if (config.displayNPC.isHighlight()) {
@@ -65,7 +74,8 @@ object MobDebug {
         }
         if (config.realPlayerHighlight) {
             MobData.players.highlight(event) {
-                (if (it.baseEntity is LocalPlayer) LorenzColor.CHROMA else LorenzColor.BLUE).toChromaColor()
+                (if (it.baseEntity is LocalPlayer) LorenzColor.CHROMA else LorenzColor.BLUE)
+                    .toChromaColor()
             }
         }
         if (config.summon.isHighlight()) {
@@ -88,7 +98,11 @@ object MobDebug {
         }
         if (config.showRayHit) {
             lastRayHit?.let {
-                event.drawFilledBoundingBox(it.boundingBox.expandBlock(), LorenzColor.GOLD.toChromaColor(), 0.5f)
+                event.drawFilledBoundingBox(
+                    it.boundingBox.expandBlock(),
+                    LorenzColor.GOLD.toChromaColor(),
+                    0.5f,
+                )
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/MobDetection.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/MobDetection.kt
@@ -17,6 +17,7 @@ import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.drainForEach
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.drainTo
+import at.hannibal2.skyhanni.utils.collection.CollectionUtils.equalsOneOf
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.put
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.refreshReference
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
@@ -42,7 +43,6 @@ import at.hannibal2.skyhanni.events.MobEvent.Spawn as SpawnEvent
 
 @SkyHanniModule
 object MobDetection {
-
     /* Unsupported Entities
         Nicked Players
         Odonata
@@ -64,13 +64,12 @@ object MobDetection {
     private val shouldClear: AtomicBoolean = AtomicBoolean(false)
 
     private fun mobDetectionReset() {
-        MobData.currentMobs.map {
-            it.createDeSpawnEvent()
-        }.forEach { it.post() }
+        MobData.currentMobs.forEach { it.createDeSpawnEvent().post() }
         MobData.retries.clear()
     }
 
     // TODO this is a unused debug function. maybe connect with a debug command or remove
+    @Suppress("unused")
     private fun watchdog() {
         val world = MinecraftCompat.localWorldOrNull ?: return
         if (MobData.retries.any { it.value.entity.level() != world }) {
@@ -100,17 +99,19 @@ object MobDetection {
     }
 
     private fun Mob.watchdogCheck(world: Level): Boolean =
-        this.baseEntity.level() != world || (
-            this.armorStand?.let { it.level() != world } ?: false
-            ) || this.extraEntities.any { it.level() != world }
+        baseEntity.level() != world ||
+            (armorStand?.let { it.level() != world } ?: false) ||
+            extraEntities.any { it.level() != world }
 
     @OptIn(AllEntitiesGetter::class)
     @HandleEvent
     fun onTick() {
-        if (shouldClear.get()) { // Needs to work outside skyblock since it needs clearing when leaving skyblock and joining limbo
+        // Needs to work outside SkyBlock since it needs clearing when leaving SkyBlock
+        if (shouldClear.get()) {
             mobDetectionReset()
             shouldClear.set(false)
         }
+
         @Suppress("InSkyBlockEarlyReturn")
         if (!SkyBlockUtils.inSkyBlock) return
 
@@ -163,7 +164,7 @@ object MobDetection {
     private fun mobDetectionError(string: String) = MobData.logger.log(string).let { true }
 
     private fun canBeSeen(mob: Mob): Boolean {
-        val isVisible = !mob.isInvisible() && mob.canBeSeen()
+        val isVisible = !mob.isFullyInvisible() && mob.canBeSeen()
         if (isVisible) {
             when (mob.category) {
                 MobCategory.PLAYER -> FirstSeenEvent.Player(mob)
@@ -256,40 +257,40 @@ object MobDetection {
 
     @HandleEvent
     fun onEntityHealthUpdateEvent(event: EntityHealthUpdateEvent) {
-        when {
+        when (event.entity) {
             // Very high false positive rate
-            /*event.entity is Bat && event.health == 6 -> {
+            /*is Bat if event.health == 6 -> {
                 entityFromPacket.add(EntityPacketType.SPIRIT_BAT to event.entity.id)
             }*/
 
-            event.entity is Villager && event.health != 20 -> {
+            is Villager if event.health != 20 -> {
                 entityFromPacket.add(EntityPacketType.VILLAGER to event.entity.id)
             }
 
-            event.entity is Creeper && event.health == 20 -> {
+            is Creeper if event.health == 20 -> {
                 entityFromPacket.add(EntityPacketType.CREEPER_VAIL to event.entity.id)
             }
         }
     }
 
-    private fun islandException(): Boolean = when (SkyBlockUtils.currentIsland) {
-        IslandType.GARDEN_GUEST -> true
-        IslandType.PRIVATE_ISLAND_GUEST -> true
-        else -> false
-    }
+    private fun islandException(): Boolean = SkyBlockUtils.currentIsland.equalsOneOf(
+        IslandType.PRIVATE_ISLAND_GUEST,
+        IslandType.GARDEN_GUEST,
+    )
 
     private fun entityDeSpawn(entity: LivingEntity) {
         MobData.entityToMob[entity]?.createDeSpawnEvent()?.post() ?: removeRetry(entity)
         allEntitiesViaPacketId.remove(entity.id)
     }
 
-    private fun Mob.createDeSpawnEvent() = when (this.category) {
+    private fun Mob.createDeSpawnEvent() = when (category) {
         MobCategory.PLAYER -> DeSpawnEvent.Player(this)
         MobCategory.SUMMON -> DeSpawnEvent.Summon(this)
         MobCategory.SPECIAL -> DeSpawnEvent.Special(this)
         MobCategory.PROJECTILE -> DeSpawnEvent.Projectile(this)
         MobCategory.DISPLAY_NPC -> DeSpawnEvent.DisplayNpc(this)
-        MobCategory.BASIC, MobCategory.DUNGEON, MobCategory.BOSS, MobCategory.SLAYER -> DeSpawnEvent.SkyblockMob(this)
+        MobCategory.BASIC, MobCategory.DUNGEON, MobCategory.BOSS, MobCategory.SLAYER ->
+            DeSpawnEvent.SkyblockMob(this)
     }
 
     fun postMobHurtEvent(mob: Mob, source: DamageSource, amount: Float) = when (mob.category) {
@@ -403,5 +404,4 @@ object MobDetection {
             }
         }
     }
-
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/MobFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/MobFilter.kt
@@ -20,8 +20,8 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SkullTextureHolder
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.takeWhileInclusive
+import at.hannibal2.skyhanni.utils.compat.EntityCompat.getHelmet
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
-import at.hannibal2.skyhanni.utils.compat.getStandHelmet
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.player.RemotePlayer
 import net.minecraft.world.entity.Entity
@@ -118,26 +118,33 @@ object MobFilter {
      */
     val jerryPattern by patternGroup.pattern(
         "jerry",
-        "(?:\\[\\w+(?<level>\\d+)] )?... (?:(?:a(?=a ))?(?<owner>\\w+)'s (?<name>\\w+ Jerrya?)) \\d+ Hits",
+        "(?:\\[\\w+(?<level>\\d+)] )?... (?:a(?=a ))?(?<owner>\\w+)'s (?<name>\\w+ Jerrya?) \\d+ Hits",
     )
     val petCareNamePattern by patternGroup.pattern(
         "pattern.petcare",
         "^\\[\\w+ (?<level>\\d+)\\] (?<name>.*)",
     )
 
-    // TODO fix pattern
+    // TODO fix pattern (is this todo still relevant?)
+    /**
+     * REGEX-TEST: Woke Golem
+     * REGEX-TEST: Sleeping Golem
+     */
     val wokeSleepingGolemPattern by patternGroup.pattern(
-        "pattern.dungeon.woke.golem",
-        "(?:§c§lWoke|§5§lSleeping) Golem§r",
+        "pattern.dungeon.woke.golem.colorless",
+        "(?:Woke|Sleeping) Golem",
     )
+    // TODO add regex tests
+    @Suppress("RepoPatternRegexTestMissing")
     val jerryMagmaCubePattern by patternGroup.pattern(
-        "pattern.jerry.magma.cube",
-        "§c(?:Cubie|Maggie|Cubert|Cübe|Cubette|Magmalene|Lucky 7|8ball|Mega Cube|Super Cube)(?: ᛤ)? §a\\d+§8\\/§a\\d+§c${SkyblockStat.HEALTH.hypixelIcon}",
+        "pattern.jerry.magma.cube.colorless",
+        "(?:Cubie|Maggie|Cubert|Cübe|Cubette|Magmalene|Lucky 7|8ball|Mega Cube|Super Cube)(?: ᛤ)? \\d+\\/\\d+${SkyblockStat.HEALTH.hypixelIcon}",
     )
     val summonOwnerPattern by patternGroup.pattern(
         "pattern.summon.owner",
         ".*Spawned by: (?<name>.*).*",
     )
+
     /**
      * REGEX-TEST: SHINY PIG
      */
@@ -179,7 +186,6 @@ object MobFilter {
         ;
 
         companion object {
-
             val toRegexLine = DungeonAttribute.entries.joinToString("|") { it.name }
         }
     }
@@ -380,13 +386,12 @@ object MobFilter {
             baseEntity.firstPassenger is Player && MobUtils.getArmorStand(baseEntity, 2)
                 ?.wearingSkullTexture(RAT_SKULL_TEXTURE) ?: false -> return MobResult.illegal // Rat Morph
         }
-        val skullTexture = armorStand.getStandHelmet()?.getSkullTexture() ?: return null
-        when (skullTexture) {
+        return when (armorStand.getHelmet()?.getSkullTexture()) {
             HELLWISP_TENTACLE_SKULL_TEXTURE -> return MobResult.illegal // Hellwisp Tentacle
             RIFT_EYE_SKULL1_TEXTURE -> return MobResult.found(MobFactories.special(baseEntity, "Rift Teleport Eye", armorStand))
             RIFT_EYE_SKULL2_TEXTURE -> return MobResult.found(MobFactories.special(baseEntity, "Rift Teleport Eye", armorStand))
+            else -> null
         }
-        return null
     }
 
     fun LivingEntity.isFarmMob() =

--- a/src/main/java/at/hannibal2/skyhanni/events/combat/VanquisherEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/combat/VanquisherEvent.kt
@@ -2,14 +2,18 @@ package at.hannibal2.skyhanni.events.combat
 
 import at.hannibal2.skyhanni.api.VanquisherApi.VanquisherData
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 
 sealed class VanquisherEvent(val vanquisher: VanquisherData) : SkyHanniEvent() {
     /** Gets called when a Vanquisher's mob disappears, no matter the cause. */
-    class DeSpawn(vanquisher: VanquisherData) : VanquisherEvent(vanquisher)
+    @PrimaryFunction("onVanquisherDespawn")
+    class Despawn(vanquisher: VanquisherData) : VanquisherEvent(vanquisher)
 
     /** Gets called when a Vanquisher dies. */
+    @PrimaryFunction("onVanquisherDeath")
     class Death(vanquisher: VanquisherData) : VanquisherEvent(vanquisher)
 
     /** Gets called when a Vanquisher is initially detected. */
+    @PrimaryFunction("onVanquisherSpawn")
     class Spawn(vanquisher: VanquisherData) : VanquisherEvent(vanquisher)
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/Deployable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/Deployable.kt
@@ -3,7 +3,6 @@ package at.hannibal2.skyhanni.features.combat
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
-import at.hannibal2.skyhanni.utils.compat.deceased
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.world.entity.LivingEntity
@@ -55,7 +54,7 @@ enum class Deployable(
 
     fun isActive(): Boolean {
         // A mineshaft is bigger than entity render distance
-        return !expiryTime.isInPast() && isInRange() && (entity?.deceased == false || hasShaftBuff())
+        return !expiryTime.isInPast() && isInRange() && (entity?.isRemoved == false || hasShaftBuff())
     }
 
     fun reset() {

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/DamageIndicatorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/DamageIndicatorManager.kt
@@ -47,6 +47,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.formatPercentage
 import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.PlayerUtils
+import at.hannibal2.skyhanni.utils.RecalculatingValue
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.fromNow
@@ -55,8 +56,7 @@ import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.TimeUtils.ticks
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.removeIf
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
-import at.hannibal2.skyhanni.utils.compat.EntityCompat.deceased
-import at.hannibal2.skyhanni.utils.compat.EntityCompat.findHealthReal
+import at.hannibal2.skyhanni.utils.compat.EntityCompat.realHealth
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
@@ -82,8 +82,8 @@ typealias EntityData = DamageIndicatorEntityData
 @SkyHanniModule
 @Suppress("LargeClass")
 object DamageIndicatorManager {
-
     private val config get() = SkyHanniMod.feature.combat.damageIndicator
+    private val mobDebugConfig get() = SkyHanniMod.feature.dev.mobDebug
 
     // TODO use repoPattern
     private val damagePattern = "[✧✯]?(\\d+[⚔+✧❤♞☄✷ﬗ✯]*)".toPattern()
@@ -95,13 +95,22 @@ object DamageIndicatorManager {
     // EntityData is owned by the field 'data', so we can use weak keys
     private val iconCache = TimeLimitedCache<EntityData, List<String>>(1.seconds, useWeakKeys = true)
 
+    private val thirdPerson get() = PlayerUtils.isThirdPersonView()
+
+    private val sizeHealth by RecalculatingValue(1.ticks) { if (thirdPerson) 2.8 else 1.9 }
+    private val sizeNameAbove by RecalculatingValue(1.ticks) { if (thirdPerson) 2.2 else 1.8 }
+    private val sizeBossName by RecalculatingValue(1.ticks) { if (thirdPerson) 2.4 else 2.1 }
+    private val sizeFinalResults by RecalculatingValue(1.ticks) { if (thirdPerson) 1.8 else 1.4 }
+
+    private val smallestViewDistance by RecalculatingValue(1.ticks) { if (thirdPerson) 10.0 else 6.0 }
+
     private var tarantulaFoundTime = SimpleTimeMark.farPast()
     private val tarantulaErrored = mutableSetOf<UUID>()
 
     fun isDamageSplash(entity: ArmorStand): Boolean {
         if (entity.tickCount > 300) return false
         if (!entity.hasCustomName()) return false
-        if (entity.deceased) return false
+        if (entity.isRemoved) return false
         val name = entity.cleanName.replace(",", "")
 
         return damagePattern.matcher(name).matches()
@@ -129,14 +138,14 @@ object DamageIndicatorManager {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onServerTick() {
+    private fun onServerTick() {
         data.forEach {
             it.value.serverTicksAlive++
         }
     }
 
     @HandleEvent
-    fun onWorldChange() {
+    private fun onWorldChange() {
         mobFinder = MobFinder()
         data.clear()
 
@@ -145,40 +154,24 @@ object DamageIndicatorManager {
     }
 
     @HandleEvent
-    fun onChat(event: SkyHanniChatEvent.Allow) {
+    private fun onChat(event: SkyHanniChatEvent.Allow) {
         mobFinder?.handleChat(event.cleanMessage)
     }
 
+    // TODO split up this function
     @HandleEvent
-    fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
+    @Suppress("CyclomaticComplexMethod", "LongMethod")
+    private fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
         if (!isEnabled()) return
 
-        if (SkyBlockUtils.debug) {
-            list.removeIf { it.decayAt.isInPast() }
-            for (highlight in list) {
-                event.drawDynamicText(highlight.location, highlight.text, 1.5, seeThroughBlocks = false)
-            }
-        }
+        if (mobDebugConfig.mobDisplay) {
+            highlights.removeIf { it.decayAt.isInPast() }
 
-        val sizeHealth: Double
-        val sizeNameAbove: Double
-        val sizeBossName: Double
-        val sizeFinalResults: Double
-        val smallestViewDistance: Double
-        if (PlayerUtils.isThirdPersonView()) {
-            sizeHealth = 2.8
-            sizeNameAbove = 2.2
-            sizeBossName = 2.4
-            sizeFinalResults = 1.8
-
-            smallestViewDistance = 10.0
-        } else {
-            sizeHealth = 1.9
-            sizeNameAbove = 1.8
-            sizeBossName = 2.1
-            sizeFinalResults = 1.4
-
-            smallestViewDistance = 6.0
+            highlights
+                .filter { !it.mob.isFullyInvisible() && it.mob.canBeSeen() }
+                .forEach {
+                    event.drawDynamicText(it.location, it.text, 1.5, seeThroughBlocks = false)
+                }
         }
 
         for (data in data.values) {
@@ -189,7 +182,9 @@ object DamageIndicatorManager {
                 else -> 1.0
             }
 
-            if (!data.ignoreBlocks && !data.entity.canBeSeen(70.0, vecYOffset = vecYOffset)) continue
+            if (!data.ignoreBlocks &&
+                !data.entity.canBeSeen(70.0, vecYOffset = vecYOffset)
+            ) continue
             val showNameAndHealth = data.shouldShowNameAndHealth()
 
             val entity = data.entity
@@ -273,47 +268,47 @@ object DamageIndicatorManager {
                 diff += 22f
             } else diff += 4f
 
-            if (showNameAndHealth && config.showDamageOverTime) {
-                val currentDamage = data.damageCounter.currentDamage
-                val currentHealing = data.damageCounter.currentHealing
-                if (currentDamage != 0L || currentHealing != 0L) {
-                    val formatDamage = "§c${currentDamage.shortFormat()}"
-                    val formatHealing = "§a+${currentHealing.shortFormat()}"
-                    val finalResult = if (currentHealing == 0L) {
-                        formatDamage
-                    } else if (currentDamage == 0L) {
-                        formatHealing
-                    } else {
-                        "$formatDamage §7/ $formatHealing"
-                    }
-                    event.drawDynamicText(
-                        location,
-                        finalResult,
-                        sizeFinalResults,
-                        diff,
-                        smallestViewDistance = smallestViewDistance,
-                    )
-                    diff += 9f
+            if (!showNameAndHealth || !config.showDamageOverTime) continue
+
+            val currentDamage = data.damageCounter.currentDamage
+            val currentHealing = data.damageCounter.currentHealing
+            if (currentDamage != 0L || currentHealing != 0L) {
+                val formatDamage = "§c${currentDamage.shortFormat()}"
+                val formatHealing = "§a+${currentHealing.shortFormat()}"
+                val finalResult = if (currentHealing == 0L) {
+                    formatDamage
+                } else if (currentDamage == 0L) {
+                    formatHealing
+                } else {
+                    "$formatDamage §7/ $formatHealing"
                 }
-                for (damage in data.damageCounter.oldDamages) {
-                    val formatDamage = "§c${damage.damage.shortFormat()}/s"
-                    val formatHealing = "§a+${damage.healing.shortFormat()}/s"
-                    val finalResult = if (damage.healing == 0L) {
-                        formatDamage
-                    } else if (damage.damage == 0L) {
-                        formatHealing
-                    } else {
-                        "$formatDamage §7/ $formatHealing"
-                    }
-                    event.drawDynamicText(
-                        location,
-                        finalResult,
-                        sizeFinalResults,
-                        diff,
-                        smallestViewDistance = smallestViewDistance,
-                    )
-                    diff += 9f
+                event.drawDynamicText(
+                    location,
+                    finalResult,
+                    sizeFinalResults,
+                    diff,
+                    smallestViewDistance = smallestViewDistance,
+                )
+                diff += 9f
+            }
+            for (damage in data.damageCounter.oldDamages) {
+                val formatDamage = "§c${damage.damage.shortFormat()}/s"
+                val formatHealing = "§a+${damage.healing.shortFormat()}/s"
+                val finalResult = if (damage.healing == 0L) {
+                    formatDamage
+                } else if (damage.damage == 0L) {
+                    formatHealing
+                } else {
+                    "$formatDamage §7/ $formatHealing"
                 }
+                event.drawDynamicText(
+                    location,
+                    finalResult,
+                    sizeFinalResults,
+                    diff,
+                    smallestViewDistance = smallestViewDistance,
+                )
+                diff += 9f
             }
         }
     }
@@ -369,16 +364,24 @@ object DamageIndicatorManager {
         return color.getChatColor() + format
     }
 
-    val list = mutableListOf<Highlight>()
+    private val highlights = mutableSetOf<Highlight>()
 
-    class Highlight(val location: LorenzVec, val text: String, val decayAt: SimpleTimeMark)
+    private data class Highlight(
+        val mob: ShMob,
+        val decayAt: SimpleTimeMark,
+    ) {
+        val location = mob.baseEntity.getLorenzVec()
+        val text = "${mob.name} - ${mob.category}"
+    }
 
+    // Suppressed warning is a false positive
     @HandleEvent
-    fun onMobSpawn(event: MobEvent.Spawn) {
+    @Suppress("MismatchedPrimaryFunctionName")
+    private fun onMobSpawn(event: MobEvent.Spawn) {
         val mob = event.mob
 
-        if (SkyBlockUtils.debug) {
-            list.add(Highlight(mob.baseEntity.getLorenzVec(), "${mob.name} - ${mob.category}", 5.seconds.fromNow()))
+        if (mobDebugConfig.mobDisplay) {
+            highlights.add(Highlight(mob, 5.seconds.fromNow()))
         }
         if (!isEnabled()) return
         try {
@@ -396,7 +399,7 @@ object DamageIndicatorManager {
     }
 
     @HandleEvent
-    fun onTick() {
+    private fun onTick() {
         if (!isEnabled()) return
         data.values.forEach(::update)
         // TODO config to define between 100ms and 5 sec
@@ -414,7 +417,7 @@ object DamageIndicatorManager {
             if (DungeonApi.inDungeon()) {
                 checkFinalBoss(entityData.finalDungeonBoss, entity.id)
             }
-            val health = entity.findHealthReal().toLong()
+            val health = entity.realHealth.toLong()
             val maxHealth: Long
             val biggestHealth = getMaxHealthFor(entity)
             if (biggestHealth == 0L) {
@@ -470,7 +473,6 @@ object DamageIndicatorManager {
         entity: LivingEntity,
         maxHealth: Long,
     ): String? {
-
         when (entityData.bossType) {
             BossType.DUNGEON_F4_THORN -> {
                 val thorn = checkThorn(health, maxHealth)
@@ -564,9 +566,7 @@ object DamageIndicatorManager {
 
             BossType.BACTE -> return checkBacte(entityData)
 
-
             BossType.END_ENDER_DRAGON -> return checkEnderDragon(entityData)
-
 
             else -> return ""
         }
@@ -982,14 +982,14 @@ object DamageIndicatorManager {
     }
 
     @HandleEvent
-    fun onEntityJoin(event: EntityEnterWorldEvent<*>) {
+    private fun onEntityJoin(event: EntityEnterWorldEvent<*>) {
         mobFinder?.handleNewEntity(event.entity)
     }
 
     private val dummyDamageCache = mutableListOf<UUID>()
 
     @HandleEvent(priority = HandleEvent.HIGH)
-    fun onCheckRender(event: CheckRenderEntityEvent<ArmorStand>) {
+    private fun onCheckRender(event: CheckRenderEntityEvent<ArmorStand>) {
         if (!isEnabled()) return
         val entity = event.entity
 
@@ -1029,7 +1029,7 @@ object DamageIndicatorManager {
     }
 
     @HandleEvent
-    fun onEntityHealthUpdate(event: EntityHealthUpdateEvent) {
+    private fun onEntityHealthUpdate(event: EntityHealthUpdateEvent) {
         val uuid = event.entity.uuid
         val data = data[uuid] ?: return
 
@@ -1078,7 +1078,7 @@ object DamageIndicatorManager {
     }
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(2, "damageIndicator", "combat.damageIndicator")
         event.move(3, "slayer.endermanPhaseDisplay", "slayer.endermen.phaseDisplay")
         event.move(3, "slayer.blazePhaseDisplay", "slayer.blazes.phaseDisplay")
@@ -1095,7 +1095,7 @@ object DamageIndicatorManager {
     }
 
     @HandleEvent
-    fun onDebugDataCollect(event: DebugDataCollectEvent) {
+    private fun onDebugDataCollect(event: DebugDataCollectEvent) {
         event.title("Damage Indicator")
         if (!DevApi.mainToggles.damageIndicator) {
             event.addData("Damage Indicator is manually disabled!")

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/MobFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/MobFinder.kt
@@ -17,7 +17,7 @@ import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SimpleTimeMark.Companion.fromNow
-import at.hannibal2.skyhanni.utils.compat.EntityCompat.findHealthReal
+import at.hannibal2.skyhanni.utils.compat.EntityCompat.realHealth
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import net.minecraft.client.player.RemotePlayer
 import net.minecraft.world.entity.Entity
@@ -44,7 +44,6 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 class MobFinder {
-
     // F1
     private var floor1bonzo1 = false
     private var floor1bonzo1SpawnTime = SimpleTimeMark.farPast()
@@ -91,7 +90,7 @@ class MobFinder {
             if (mob.name == "Dummy") {
                 EntityResult(bossType = BossType.DUMMY)
             } else {
-                when (val entity = mob.baseEntity) {
+                when (mob.baseEntity) {
                     /*
                      * Note that the order does matter here.
                      * For example, if you put EntityZombie before EntityPigZombie,
@@ -107,7 +106,7 @@ class MobFinder {
                     is Guardian -> tryAddEntityGuardian(mob)
                     is Zombie -> tryAddEntityZombie(mob)
                     is WitherBoss -> tryAddEntityWither(mob)
-                    is EnderDragon -> tryAddEntityDragon(mob)
+                    is EnderDragon -> tryAddEntityDragon()
                     is Spider -> tryAddEntitySpider(mob)
                     is Horse -> tryAddEntityHorse(mob)
                     is Blaze -> tryAddEntityBlaze(mob)
@@ -159,7 +158,7 @@ class MobFinder {
         val entity = mob.baseEntity
         if (entity.name.string == "Summon " && entity is RemotePlayer) {
             if (floor2summons1 && !floor2summonsDiedOnce.contains(entity)) {
-                if (entity.findHealthReal().toInt() != 0) {
+                if (entity.realHealth.toInt() != 0) {
                     return EntityResult(floor2summons1SpawnTime, bossType = BossType.DUNGEON_F2_SUMMON)
                 }
                 floor2summonsDiedOnce.add(entity)
@@ -343,8 +342,7 @@ class MobFinder {
     }
 
     // TODO testing and use sidebar data
-    @Suppress("UnusedParameter")
-    private fun tryAddEntityDragon(mob: Mob) = when {
+    private fun tryAddEntityDragon() = when {
         IslandType.THE_END.isInIsland() -> EntityResult(bossType = BossType.END_ENDER_DRAGON)
         IslandType.WINTER.isInIsland() -> EntityResult(bossType = BossType.WINTER_REINDRAKE)
 
@@ -621,7 +619,7 @@ class MobFinder {
     private fun calcGuardiansTotalHealth() {
         var totalHealth = 0
         for (guardian in guardians) {
-            totalHealth += guardian.findHealthReal().toInt()
+            totalHealth += guardian.realHealth.toInt()
         }
         if (totalHealth == 0) {
             floor3GuardianShield = false

--- a/src/main/java/at/hannibal2/skyhanni/features/commands/tabcomplete/PlayerTabComplete.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/commands/tabcomplete/PlayerTabComplete.kt
@@ -20,9 +20,9 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 
 @SkyHanniModule
 object PlayerTabComplete {
-
     private val config get() = SkyHanniMod.feature.misc.commands.tabComplete
-    private var vipVisits = listOf<String>()
+
+    private var vipVisits = emptyList<String>()
 
     private val vipVisitsEntry = lazyEntry { vipVisits }
     private val allPlayers = getExcluding()
@@ -82,7 +82,6 @@ object PlayerTabComplete {
     }
 
     private fun getExcluding(vararg excluded: PlayerNameSource) = LazySuggestionEntry {
-
         fun allowed(category: PlayerNameSource): Boolean = when (category) {
             FRIENDS -> config.friends
             ISLAND_PLAYERS -> config.islandPlayers
@@ -113,9 +112,8 @@ object PlayerTabComplete {
 
     private fun lazyEntry(getter: () -> List<String>) = LazySuggestionEntry { addAll(getter()) }
 
-    fun handleTabComplete(command: String): List<String>? = suggestions.getSuggestions(command).takeIf {
-        it.isNotEmpty()
-    }?.distinct()
+    fun handleTabComplete(command: String): List<String>? =
+        suggestions.getSuggestions(command).takeUnless { it.isEmpty() }?.distinct()
 
     @HandleEvent
     fun onRepoReload(event: RepositoryReloadEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonHideItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonHideItems.kt
@@ -17,7 +17,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getSkullTexture
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkullTextureHolder
-import at.hannibal2.skyhanni.utils.compat.EntityCompat.getStandHelmet
+import at.hannibal2.skyhanni.utils.compat.EntityCompat.getHelmet
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import net.minecraft.core.particles.ParticleTypes
@@ -28,13 +28,9 @@ import kotlin.time.Duration.Companion.milliseconds
 
 @SkyHanniModule
 object DungeonHideItems {
-
     private val config get() = SkyHanniMod.feature.dungeon.objectHider
 
-    private val hideParticles = mutableMapOf<ArmorStand, SimpleTimeMark>()
-    private val movingSkeletonSkulls = mutableMapOf<ArmorStand, SimpleTimeMark>()
-
-    private val SOUL_WEAVER_HIDER by SkullTextureHolder.texture("DUNGEONS_SOUL_WEAVER")
+    private val SOUL_WEAVER_TEXTURE by SkullTextureHolder.texture("DUNGEONS_SOUL_WEAVER")
     private val BLESSING_TEXTURE by SkullTextureHolder.texture("DUNGEONS_BLESSING")
     private val REVIVE_STONE_TEXTURE by SkullTextureHolder.texture("DUNGEONS_REVIVE_STONE")
     private val PREMIUM_FLESH_TEXTURE by SkullTextureHolder.texture("DUNGEONS_PREMIUM_FLESH")
@@ -43,9 +39,12 @@ object DungeonHideItems {
     private val DAMAGE_ORB_TEXTURE by SkullTextureHolder.texture("DUNGEONS_DAMAGE_ORB")
     private val HEALER_FAIRY_TEXTURE by SkullTextureHolder.texture("DUNGEONS_HEALER_FAIRY")
 
+    private val hideParticles = mutableMapOf<ArmorStand, SimpleTimeMark>()
+    private val movingSkeletonSkulls = mutableMapOf<ArmorStand, SimpleTimeMark>()
+
     private fun String?.matchesTexture(texture: String?) = texture != null && this == texture
 
-    private fun isSkeletonSkull(entity: ArmorStand): Boolean = entity.getStandHelmet()?.cleanName == "Skeleton Skull"
+    private fun isSkeletonSkull(entity: ArmorStand): Boolean = entity.getHelmet()?.cleanName == "Skeleton Skull"
 
     @HandleEvent(onlyOnIsland = IslandType.CATACOMBS)
     fun onCheckRender(event: CheckRenderEntityEvent<Entity>) {
@@ -64,7 +63,7 @@ object DungeonHideItems {
 
         if (entity !is ArmorStand) return
 
-        val head = entity.getStandHelmet()
+        val head = entity.getHelmet()
         val skullTexture = head?.getSkullTexture()
         if (config.hideSuperboomTNT) {
             if (entity.name.formattedTextCompatLessResets().startsWith("§9Superboom TNT")) {
@@ -144,7 +143,7 @@ object DungeonHideItems {
         }
 
         if (config.hideSoulweaverSkulls) {
-            if (skullTexture.matchesTexture(SOUL_WEAVER_HIDER)) {
+            if (skullTexture.matchesTexture(SOUL_WEAVER_TEXTURE)) {
                 event.cancel()
                 return
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonMobManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonMobManager.kt
@@ -23,13 +23,15 @@ import net.minecraft.world.entity.LivingEntity
 
 @SkyHanniModule
 object DungeonMobManager {
-
     private val config get() = SkyHanniMod.feature.dungeon.objectHighlighter
     private val starredConfig get() = config.starred
     private val fel get() = config.fel
 
-    private val staredInvisible = mutableSetOf<Mob>()
-    val starredVisibleMobs = mutableSetOf<Mob>()
+    private val starredVisible = mutableSetOf<Mob>()
+    val starredVisibleMobs: Set<Mob> = starredVisible
+
+    private val starredInvisible = mutableSetOf<Mob>()
+
     private val felOnTheGround = mutableSetOf<Mob>()
     private val felMoving = mutableSetOf<Mob>()
 
@@ -44,7 +46,7 @@ object DungeonMobManager {
                 handleStar0(it, color)
             }
             if (!starredConfig.highlight.get()) {
-                staredInvisible.clear()
+                starredInvisible.clear()
             }
         }
     }
@@ -60,10 +62,10 @@ object DungeonMobManager {
     fun onMobDespawn(event: MobEvent.DeSpawn.SkyblockMob) {
         if (event.mob.category != MobCategory.DUNGEON) return
         if (starredConfig.highlight.get()) {
-            staredInvisible.remove(event.mob)
+            starredInvisible.remove(event.mob)
         }
         handleFelDespawn(event.mob)
-        starredVisibleMobs.remove(event.mob)
+        starredVisible.remove(event.mob)
     }
 
     @HandleEvent(onlyOnIsland = IslandType.CATACOMBS)
@@ -125,38 +127,36 @@ object DungeonMobManager {
 
     private fun handleInvisibleStar() {
         if (!starredConfig.highlight.get()) return
-        staredInvisible.removeIf {
-            val visible = !it.isInvisible()
-            if (visible) {
-                it.highlight(getStarColor())
+
+        val iterator = starredInvisible.iterator()
+        while (iterator.hasNext()) {
+            val next = iterator.next()
+            if (next.isFullyInvisible()) {
+                next.highlight(getStarColor())
+                iterator.remove()
             }
-            visible
         }
     }
 
     private fun getStarColor(): ChromaColour = starredConfig.color.get()
 
-    private fun handleStar0(mob: Mob, colour: ChromaColour?) {
+    private fun handleStar0(mob: Mob, color: ChromaColour?) {
         if (mob.name == "Fels") {
             if (mob in felMoving) {
-                colour?.let {
-                    mob.highlight(it)
-                } ?: run {
-                    mob.removeHighlight()
-                }
+                color?.let { mob.highlight(it) } ?: mob.removeHighlight()
             }
             return
         }
-        if (mob.isInvisible()) {
-            staredInvisible.add(mob)
+        if (mob.isFullyInvisible()) {
+            starredInvisible.add(mob)
             return
         }
-        colour?.let {
+        color?.let {
             mob.highlight(it)
         } ?: run {
             mob.removeHighlight()
         }
-        starredVisibleMobs.add(mob)
+        starredVisible.add(mob)
     }
 
     private fun handleFel(mob: Mob) {

--- a/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalZombieShootout.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalZombieShootout.kt
@@ -16,8 +16,8 @@ import at.hannibal2.skyhanni.utils.RenderUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
-import at.hannibal2.skyhanni.utils.compat.EntityCompat.findHealthReal
-import at.hannibal2.skyhanni.utils.compat.EntityCompat.getEntityHelmet
+import at.hannibal2.skyhanni.utils.compat.EntityCompat.getHelmet
+import at.hannibal2.skyhanni.utils.compat.EntityCompat.realHealth
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.itemType
@@ -43,7 +43,6 @@ import kotlin.time.DurationUnit
 
 @SkyHanniModule
 object CarnivalZombieShootout {
-
     private val config get() = SkyHanniMod.feature.event.carnival.zombieShootout
 
     private data class ShootoutLamp(var pos: LorenzVec, var time: SimpleTimeMark)
@@ -235,9 +234,10 @@ object CarnivalZombieShootout {
 
     private fun getZombies() =
         EntityUtils.getEntitiesNearby<Zombie>(50.0).mapNotNull { zombie ->
-            if (zombie.findHealthReal() <= 0) return@mapNotNull null
-            val helmet = zombie.getEntityHelmet() ?: return@mapNotNull null
+            if (zombie.realHealth <= 0) return@mapNotNull null
+            val helmet = zombie.getHelmet() ?: return@mapNotNull null
             if (helmet.isEmpty) return@mapNotNull null
+
             val type = toType(helmet) ?: run {
                 ErrorManager.logErrorStateWithData(
                     "Could not identify Zombie Shootout type",

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/RareMobWaypointShare.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/RareMobWaypointShare.kt
@@ -30,7 +30,6 @@ import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.StringUtils.cleanPlayerName
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.removeIf
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
-import at.hannibal2.skyhanni.utils.compat.deceased
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.player.RemotePlayer
@@ -115,7 +114,7 @@ object RareMobWaypointShare {
         if (!isEnabled()) return
 
         if (event.repeatSeconds(3)) {
-            rareMobsNearby.removeIf { it.value.deceased }
+            rareMobsNearby.removeIf { it.value.isRemoved }
         }
 
         _waypoints.removeIf { it.value.spawnTime.passedSince() > 75.seconds }
@@ -239,7 +238,7 @@ object RareMobWaypointShare {
             return
         }
 
-        if (rareMob.deceased) {
+        if (rareMob.isRemoved) {
             ChatUtils.chat("§cRare Mob is dead")
             return
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/jerry/frozentreasure/FrozenTreasureHighlighter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/jerry/frozentreasure/FrozenTreasureHighlighter.kt
@@ -6,11 +6,13 @@ import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.WinterApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.EntityUtils
+import at.hannibal2.skyhanni.utils.ItemUtils.cleanName
 import at.hannibal2.skyhanni.utils.ItemUtils.isSkull
 import at.hannibal2.skyhanni.utils.blockhighlight.SkyHanniBlockHighlighter
 import at.hannibal2.skyhanni.utils.blockhighlight.TimedHighlightBlock
-import at.hannibal2.skyhanni.utils.compat.EntityCompat.getInventoryItems
-import at.hannibal2.skyhanni.utils.compat.EntityCompat.getStandHelmet
+import at.hannibal2.skyhanni.utils.collection.CollectionUtils.equalsOneOf
+import at.hannibal2.skyhanni.utils.compat.EntityCompat.getEquipmentSlots
+import at.hannibal2.skyhanni.utils.compat.EntityCompat.getHelmet
 import at.hannibal2.skyhanni.utils.compat.InventoryCompat.isNotEmpty
 import at.hannibal2.skyhanni.utils.compat.InventoryCompat.orNull
 import at.hannibal2.skyhanni.utils.toLorenzVec
@@ -19,33 +21,31 @@ import net.minecraft.world.level.block.Blocks
 
 @SkyHanniModule
 object FrozenTreasureHighlighter {
+    private const val Y_OFFSET = 2
 
     private val config get() = SkyHanniMod.feature.event.winter.frozenTreasureHighlighter
 
     private val blockHighlighter = SkyHanniBlockHighlighter<TimedHighlightBlock>(
         highlightCondition = ::isEnabled,
-        blockCondition = { it.block == Blocks.ICE || it.block == Blocks.PACKED_ICE },
-        colorProvider = { config.treasureColor },
+        blockCondition = { it.block.equalsOneOf(Blocks.ICE, Blocks.PACKED_ICE) },
+        colorProvider = config::treasureColor,
     )
 
-    private fun isEnabled(): Boolean {
-        return IslandType.WINTER.isInIsland() && WinterApi.inGlacialCave() && config.enabled
-    }
-
-    private const val yOffset = 2
-
-    @HandleEvent(onlyOnIsland = IslandType.WINTER)
-    fun onTick() {
+    @HandleEvent
+    private fun onTick() {
         if (!isEnabled()) return
 
         for (armorStand in EntityUtils.getEntitiesNearby<ArmorStand>(50.0)) {
-            if (armorStand.getInventoryItems().count { it.isNotEmpty() } != 1) continue
+            if (armorStand.getEquipmentSlots().values.count { it.isNotEmpty() } != 1) continue
 
-            val standHelmet = armorStand.getStandHelmet().orNull() ?: continue
-            if (standHelmet.isSkull() && standHelmet.hoverName.string.endsWith("Head")) continue
+            val standHelmet = armorStand.getHelmet().orNull() ?: continue
+            if (standHelmet.isSkull() && standHelmet.cleanName.endsWith("Head")) continue
 
-            val treasureLocation = armorStand.blockPosition().toLorenzVec().up(yOffset)
+            val treasureLocation = armorStand.blockPosition().toLorenzVec().up(Y_OFFSET)
             blockHighlighter.addBlock(TimedHighlightBlock(treasureLocation))
         }
     }
+
+    private fun isEnabled(): Boolean =
+        config.enabled && IslandType.WINTER.isInIsland() && WinterApi.inGlacialCave()
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/ChumBucketHider.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/ChumBucketHider.kt
@@ -3,14 +3,15 @@ package at.hannibal2.skyhanni.features.fishing
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
-import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ConditionalUtils
+import at.hannibal2.skyhanni.utils.ItemUtils.cleanName
 import at.hannibal2.skyhanni.utils.PlayerUtils
+import at.hannibal2.skyhanni.utils.collection.CollectionUtils.equalsOneOf
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedSet
+import at.hannibal2.skyhanni.utils.compat.EntityCompat.getEquipmentSlots
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
-import at.hannibal2.skyhanni.utils.compat.getAllEquipment
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import net.minecraft.world.entity.Entity
 import net.minecraft.world.entity.decoration.ArmorStand
@@ -18,8 +19,8 @@ import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object ChumBucketHider {
-
     private val config get() = SkyHanniMod.feature.fishing.chumBucketHider
+
     private val titleEntity = TimeLimitedSet<Entity>(5.seconds, useWeakKeys = true)
     private val hiddenEntities = TimeLimitedCache<Entity, Boolean>(5.seconds, useWeakKeys = true)
 
@@ -65,9 +66,10 @@ object ChumBucketHider {
         }
 
         // Chum Bucket
+        // TODO check specific equipment slot + use RepoPattern
         if (config.hideBucket.get() &&
-            entity.getAllEquipment().any {
-                it != null && (it.hoverName.string == "Empty Chum Bucket" || it.hoverName.string == "Empty Chumcap Bucket")
+            entity.getEquipmentSlots().values.any {
+                it?.cleanName.equalsOneOf("Empty Chum Bucket", "Empty Chumcap Bucket")
             }
         ) {
             val entityLocation = entity.getLorenzVec()
@@ -83,7 +85,7 @@ object ChumBucketHider {
     }
 
     @HandleEvent
-    fun onConfigLoad(event: ConfigLoadEvent) {
+    fun onConfigLoad() {
         ConditionalUtils.onToggle(config.enabled, config.hideBucket, config.hideOwn) { reset() }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingApi.kt
@@ -43,7 +43,6 @@ import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.addLavas
 import at.hannibal2.skyhanni.utils.compat.addWaters
-import at.hannibal2.skyhanni.utils.compat.deceased
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
 import at.hannibal2.skyhanni.utils.compat.getCompoundOrDefault
 import at.hannibal2.skyhanni.utils.compat.getStringOrDefault
@@ -59,7 +58,6 @@ import kotlin.time.Duration.Companion.seconds
 @Suppress("MemberVisibilityCanBePrivate")
 @SkyHanniModule
 object FishingApi {
-
     enum class RodPart {
         HOOK,
         LINE,
@@ -190,7 +188,7 @@ object FishingApi {
         }
 
         val bobber = bobber ?: return
-        if (bobber.deceased) {
+        if (bobber.isRemoved) {
             if (lastReelTime.passedSince() < 0.5.seconds && lastCatchSound.passedSince() < 0.5.seconds) FishingCatchEvent.post()
             resetBobber()
             return

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureFeatures.kt
@@ -22,7 +22,7 @@ import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedSet
-import at.hannibal2.skyhanni.utils.compat.EntityCompat.findHealthReal
+import at.hannibal2.skyhanni.utils.compat.EntityCompat.realHealth
 import net.minecraft.world.entity.Entity
 import net.minecraft.world.entity.LivingEntity
 import java.awt.Color
@@ -54,7 +54,7 @@ object SeaCreatureFeatures {
         entityIds.addIfAbsent(entity.id)
         if (seaCreature.isOwn) return
 
-        if (mob.name == "Water Hydra" && entity.findHealthReal() == (entity.baseMaxHealth.toFloat() / 2)) return
+        if (mob.name == "Water Hydra" && entity.realHealth == (entity.baseMaxHealth.toFloat() / 2)) return
         if (config.alertOtherCatches && shouldNotify && SeaCreatureSettings.getConfig(mob)?.shouldNotifyForNonOwn == true) {
             val text = if (config.creatureName) "${seaCreature.displayName} NEARBY!"
             else "${seaCreature.rarity.chatColorCode}RARE SEA CREATURE!"

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/ThunderSparksHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/ThunderSparksHighlight.kt
@@ -14,7 +14,6 @@ import at.hannibal2.skyhanni.utils.EntityUtils.holdingSkullTexture
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.SkullTextureHolder
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
-import at.hannibal2.skyhanni.utils.compat.deceased
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawString
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawWaypointFilled
@@ -22,9 +21,10 @@ import net.minecraft.world.entity.decoration.ArmorStand
 
 @SkyHanniModule
 object ThunderSparksHighlight {
+    private val THUNDER_SPARK_TEXTURE by SkullTextureHolder.texture("THUNDER_SPARK")
 
     private val config get() = SkyHanniMod.feature.fishing.thunderSpark
-    private val THUNDER_SPARK_TEXTURE by SkullTextureHolder.texture("THUNDER_SPARK")
+
     private val sparks = mutableSetOf<ArmorStand>()
 
     @HandleEvent
@@ -46,7 +46,7 @@ object ThunderSparksHighlight {
         val color = config.color.toColor()
 
         for (spark in sparks) {
-            if (spark.deceased) continue
+            if (spark.isRemoved) continue
             val sparkLocation = spark.getLorenzVec()
             val block = sparkLocation.getBlockAt()
             val seeThroughBlocks = sparkLocation.distanceToPlayer() < 6 && (block in FishingApi.lavaBlocks)

--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/FireFreezeFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/FireFreezeFeatures.kt
@@ -21,7 +21,7 @@ import at.hannibal2.skyhanni.utils.ServerTimeMark
 import at.hannibal2.skyhanni.utils.SkullTextureHolder
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.removeIf
-import at.hannibal2.skyhanni.utils.compat.EntityCompat.getStandHelmet
+import at.hannibal2.skyhanni.utils.compat.EntityCompat.getHelmet
 import at.hannibal2.skyhanni.utils.compat.appendWithColor
 import at.hannibal2.skyhanni.utils.compat.componentBuilder
 import at.hannibal2.skyhanni.utils.expand
@@ -40,7 +40,6 @@ import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object FireFreezeFeatures {
-
     private val config get() = SkyHanniMod.feature.inventory.itemAbilities.fireFreeze
     private const val PARTICLE_OFFSET = 3.921568568330258E-4
 
@@ -135,7 +134,7 @@ object FireFreezeFeatures {
         if (!isInvisible) return false
 
         if (!headPose.isZero() || !bodyPose.isZero()) return false
-        val texture = getStandHelmet()?.getSkullTexture() ?: return false
+        val texture = getHelmet()?.getSkullTexture() ?: return false
         return texture == ARMORSTAND_SKULL_TEXTURE
     }
 
@@ -224,5 +223,4 @@ object FireFreezeFeatures {
     private fun timeFromPitch(pitch: Float): ServerTimeMark = ServerTimeMark.now() + (2.0 * pitch + 1).seconds
 
     private fun Rotations.isZero(): Boolean = x == 0.0f && y == 0.0f && z == 0.0f
-
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/minion/MinionFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/minion/MinionFeatures.kt
@@ -12,7 +12,6 @@ import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.data.achievements.Achievement
 import at.hannibal2.skyhanni.events.BlockClickEvent
 import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
-import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.InventoryUpdatedEvent
@@ -50,7 +49,6 @@ import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
-import at.hannibal2.skyhanni.utils.compat.EntityCompat.deceased
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
 import at.hannibal2.skyhanni.utils.getLorenzVec
@@ -66,7 +64,6 @@ import net.minecraft.world.level.block.Blocks
 
 @SkyHanniModule
 object MinionFeatures {
-
     const val MINION_FUEL_SLOT = 19
     const val MINION_PICKUP_SLOT = 53
 
@@ -442,7 +439,7 @@ object MinionFeatures {
 
         val entity = event.entity.takeIf {
             val nameMatch = it.customName?.string?.contains("❤") ?: false
-            it.hasCustomName() && !it.deceased && nameMatch
+            it.hasCustomName() && !it.isRemoved && nameMatch
         } ?: return
         val minions = minions ?: return
 
@@ -453,7 +450,7 @@ object MinionFeatures {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    fun onChestGuiRender() {
         if (!minionInventoryOpen || !config.hopperProfitDisplay) return
 
         val display = display ?: return

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/FixGhostEntities.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/FixGhostEntities.kt
@@ -7,8 +7,7 @@ import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
 import at.hannibal2.skyhanni.events.minecraft.packet.PacketReceivedEvent
 import at.hannibal2.skyhanni.features.nether.kuudra.KuudraApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.MobUtils.isDefaultValue
-import at.hannibal2.skyhanni.utils.compat.EntityCompat.getAllEquipment
+import at.hannibal2.skyhanni.utils.MobUtils.isCompletelyDefault
 import net.minecraft.network.protocol.game.ClientboundAddEntityPacket
 import net.minecraft.network.protocol.game.ClientboundRemoveEntitiesPacket
 import net.minecraft.world.entity.decoration.ArmorStand
@@ -17,12 +16,11 @@ import net.minecraft.world.entity.player.Player
 import java.util.function.IntConsumer
 
 /**
- * This feature fixes ghost entities sent by hypixel that are not properly deleted in the correct order.
- * This included Diana, Dungeon and Crimson Isle mobs and nametags.
+ * This feature fixes ghost entities sent by Hypixel that are not properly deleted in the correct
+ * order. This includes Diana, Dungeon, and Crimson Isle mobs and nametags.
  */
 @SkyHanniModule
 object FixGhostEntities {
-
     private val config get() = SkyHanniMod.feature.misc
 
     private var recentlyRemovedEntities = ArrayDeque<Int>()
@@ -30,21 +28,25 @@ object FixGhostEntities {
     private val hiddenEntityIds = mutableListOf<Int>()
 
     @HandleEvent
-    fun onWorldChange() {
+    private fun onWorldChange() {
         recentlyRemovedEntities = ArrayDeque()
         recentlySpawnedEntities = ArrayDeque()
         hiddenEntityIds.clear()
     }
 
+    @Suppress("KotlinUnreachableCode")
     @HandleEvent(onlyOnSkyblock = true)
-    fun onPacketReceive(event: PacketReceivedEvent) {
-        if (!config.fixGhostEntities) return
-        // Disable in Kuudra for now - causes players to randomly disappear in supply phase
-        // TODO: Remove once fixed
-
-        // Disabled on modern versions as the detection is not fully correct leading to incorrect hiding of entities
+    private fun onPacketReceive(event: PacketReceivedEvent) {
+        // Disabled as the detection is not fully correct on modern versions, leading to incorrect
+        // hiding of entities
         // TODO fix this
-        if (KuudraApi.inKuudra || true) return
+        return
+
+        if (!config.fixGhostEntities) return
+
+        // Disable in Kuudra for now - causes players to randomly disappear in supply phase
+        // TODO remove once fixed
+        if (KuudraApi.inKuudra) return
 
         when (val packet = event.packet) {
             is ClientboundAddEntityPacket -> {
@@ -67,10 +69,10 @@ object FixGhostEntities {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onCheckRender(event: CheckRenderEntityEvent<*>) {
+    private fun onCheckRender(event: CheckRenderEntityEvent<*>) {
         if (config.hideTemporaryArmorStands) {
             (event.entity as? ArmorStand)?.let { stand ->
-                if (stand.tickCount < 10 && stand.isDefaultValue() && stand.getAllEquipment().all { it == null }) event.cancel()
+                if (stand.tickCount < 10 && stand.isCompletelyDefault()) event.cancel()
             }
         }
         if (config.fixGhostEntities && (event.entity is Monster || event.entity is Player)) {
@@ -79,7 +81,7 @@ object FixGhostEntities {
     }
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(95, "misc.hideTemporaryArmorstands", "misc.hideTemporaryArmorStands")
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorSolver.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/trevor/TrevorSolver.kt
@@ -20,7 +20,6 @@ import net.minecraft.client.player.RemotePlayer
 import net.minecraft.world.entity.LivingEntity
 
 object TrevorSolver {
-
     private val animalHealths = setOf(100, 200, 500, 1000, 2000, 5000, 10000, 30000)
 
     var currentMob: TrevorMob? = null
@@ -35,7 +34,6 @@ object TrevorSolver {
         val playerPosition = LocationUtils.playerLocation().roundTo(2)
         val mobHeight = if (above) playerPosition.y + height else playerPosition.y - height
         if (maxHeight == 0.0) {
-
             maxHeight = mobHeight + 2.5
             minHeight = mobHeight - 2.5
         } else {
@@ -64,7 +62,6 @@ object TrevorSolver {
             val entityHealth = if (entity is LivingEntity) entity.baseMaxHealth.derpy() else 0
             currentMob = TrevorMob.findByName(name)
             if ((animalHealths.any { it == entityHealth } && currentMob != null) || isTrevor) {
-
                 val currentMob = currentMob ?: ErrorManager.skyHanniError(
                     "Found Trevor mob but current mob is null",
                     "entity" to entity,
@@ -74,7 +71,9 @@ object TrevorSolver {
                 if (foundID == entity.id) {
                     val isOasisMob = currentMob == TrevorMob.RABBIT || currentMob == TrevorMob.SHEEP
                     if (isOasisMob && mobLocation == TrapperMobArea.OASIS && !isTrevor) return
-                    val canSee = entity.canBeSeen(currentMob.renderDistance) && !entity.isInvisible && !hasBlindness
+                    val canSee = !hasBlindness &&
+                        !entity.isInvisible &&
+                        entity.canBeSeen(currentMob.renderDistance)
                     if (canSee) {
                         if (mobLocation != TrapperMobArea.FOUND) {
                             TrevorFeatures.lastTitle?.stop()

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/VanquisherWaypointShare.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/VanquisherWaypointShare.kt
@@ -11,7 +11,6 @@ import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.combat.VanquisherEvent
 import at.hannibal2.skyhanni.events.minecraft.KeyPressEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
-import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.HypixelCommands
@@ -30,15 +29,10 @@ import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.renderBeaconBeam
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import java.awt.Color
 import java.util.concurrent.ConcurrentHashMap
-import kotlin.collections.component1
-import kotlin.collections.component2
-import kotlin.collections.component3
 import kotlin.time.Duration.Companion.seconds
-
 
 @SkyHanniModule
 object VanquisherWaypointShare {
-
     private val config get() = SkyHanniMod.feature.crimsonIsle.vanquisherShare
     private val patternGroup = RepoPattern.group("vanquisher.waypoint")
 
@@ -97,14 +91,14 @@ object VanquisherWaypointShare {
         }
     }
 
-    @HandleEvent(WorldChangeEvent::class)
-    fun onWorldChange() {
+    @HandleEvent
+    private fun onWorldChange() {
         sharedWaypoints.clear()
         ownVanquisherData = null
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.CRIMSON_ISLE)
-    fun onVanquisherSpawn(event: VanquisherEvent.Spawn) {
+    @HandleEvent
+    private fun onVanquisherSpawn(event: VanquisherEvent.Spawn) {
         if (!isEnabled()) return
         if (!event.vanquisher.isOwn) return
 
@@ -127,8 +121,8 @@ object VanquisherWaypointShare {
         }
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.CRIMSON_ISLE)
-    fun onVanquisherDeath(event: VanquisherEvent.Death) {
+    @HandleEvent
+    private fun onVanquisherDeath(event: VanquisherEvent.Death) {
         if (!isEnabled()) return
         if (!event.vanquisher.isOwn) return
         if (lastShareTime.passedSince() < 2.seconds) return
@@ -141,27 +135,27 @@ object VanquisherWaypointShare {
     }
 
     @HandleEvent
-    fun onVanquisherDeSpawn(event: VanquisherEvent.DeSpawn) {
+    private fun onVanquisherDespawn(event: VanquisherEvent.Despawn) {
         if (event.vanquisher == ownVanquisherData) ownVanquisherData = null
     }
 
     @HandleEvent
-    fun onKeyPressEvent(event: KeyPressEvent) {
+    private fun onKeyPressEvent(event: KeyPressEvent) {
         if (!isEnabled()) return
         if (MinecraftCompat.screen != null) return
         if (event.keyCode == config.keybindSharing) sendSpawn()
     }
 
     @HandleEvent
-    fun onSecondPassed(event: SecondPassedEvent) {
+    private fun onSecondPassed(event: SecondPassedEvent) {
         if (!isEnabled()) return
         if (event.repeatSeconds(3)) {
             sharedWaypoints.values.removeIf { it.spawnTime.passedSince() > 60.seconds }
         }
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.CRIMSON_ISLE, receiveCancelled = true)
-    fun onReadChat(event: SkyHanniChatEvent.Allow) {
+    @HandleEvent(receiveCancelled = true)
+    private fun onReadChat(event: SkyHanniChatEvent.Allow) {
         if (!isEnabled()) return
         val message = event.cleanMessage
 
@@ -214,7 +208,7 @@ object VanquisherWaypointShare {
     }
 
     @HandleEvent
-    fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
+    private fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
         if (!isEnabled()) return
 
         val beaconColor = Color(160, 37, 191)
@@ -243,5 +237,5 @@ object VanquisherWaypointShare {
         )
     }
 
-    private fun isEnabled() = config.enabled
+    private fun isEnabled() = config.enabled && IslandType.CRIMSON_ISLE.isInIsland()
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/ashfang/AshfangHider.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/ashfang/AshfangHider.kt
@@ -8,12 +8,12 @@ import at.hannibal2.skyhanni.events.ParticleEvent
 import at.hannibal2.skyhanni.events.SkyHanniRenderEntityEvent
 import at.hannibal2.skyhanni.features.combat.damageindicator.DamageIndicatorManager
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.compat.getAllEquipment
+import at.hannibal2.skyhanni.utils.ItemUtils.cleanName
+import at.hannibal2.skyhanni.utils.compat.EntityCompat.getEquipmentSlots
 import net.minecraft.world.entity.decoration.ArmorStand
 
 @SkyHanniModule
 object AshfangHider {
-
     private val config get() = AshfangManager.config.hide
 
     @HandleEvent(priority = HandleEvent.HIGH)
@@ -34,7 +34,10 @@ object AshfangHider {
     @HandleEvent(priority = HandleEvent.HIGH, onlyOnIsland = IslandType.CRIMSON_ISLE)
     fun onCheckRender(event: CheckRenderEntityEvent<ArmorStand>) {
         if (!AshfangManager.active || !config.particles) return
-        if (event.entity.getAllEquipment().any { it?.hoverName?.string == "Glowstone" }) event.cancel()
+        // TODO check for specific equipment slot
+        if (event.entity.getEquipmentSlots().values.any { it?.cleanName == "Glowstone" }) {
+            event.cancel()
+        }
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/colosseum/TentacleWaypoint.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/colosseum/TentacleWaypoint.kt
@@ -5,14 +5,12 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.MobEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
-import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
 import at.hannibal2.skyhanni.features.rift.RiftApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.StringUtils.pluralize
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.removeIfKey
 import at.hannibal2.skyhanni.utils.compat.DamageSourceCompat
-import at.hannibal2.skyhanni.utils.compat.deceased
-import at.hannibal2.skyhanni.utils.compat.findHealthReal
+import at.hannibal2.skyhanni.utils.compat.EntityCompat.realHealth
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawWaypointFilled
@@ -23,15 +21,15 @@ import kotlin.math.ceil
 
 @SkyHanniModule
 object TentacleWaypoint {
+    private const val TENTACLE_FLOOR_Y = 68
+    private val VALID_SLIME_SIZES = 4..8
 
     private val config get() = SkyHanniMod.feature.rift.area.colosseum
+
     private val tentacleHits = mutableMapOf<LivingEntity, Int>()
 
-    private val VALID_SLIME_SIZES = 4..8
-    private const val TENTACLE_FLOOR_Y = 68
-
     @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
-    fun onEntityHealthUpdate(event: MobEvent.Spawn.Special) {
+    private fun onEntityHealthUpdate(event: MobEvent.Spawn.Special) {
         if (!isEnabled()) return
         val entity = event.mob.baseEntity as? Slime ?: return
         if (event.mob.name != "Bacte Tentacle") return
@@ -44,7 +42,7 @@ object TentacleWaypoint {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
-    fun onEntityDamage(event: MobEvent.Hurt.Special) {
+    private fun onEntityDamage(event: MobEvent.Hurt.Special) {
         if (!isEnabled()) return
         val entity = event.mob.baseEntity as? Slime ?: return
 
@@ -55,9 +53,9 @@ object TentacleWaypoint {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
-    fun onRender(event: SkyHanniRenderWorldEvent) {
+    private fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
         if (!isEnabled()) return
-        tentacleHits.removeIfKey { it.deceased || it.findHealthReal() == 0f }
+        tentacleHits.removeIfKey { it.isRemoved || it.realHealth == 0f }
 
         for ((tentacle, hits) in tentacleHits) {
             val location = tentacle.getLorenzVec()
@@ -83,7 +81,7 @@ object TentacleWaypoint {
     }
 
     @HandleEvent
-    fun onWorldSwitch(event: WorldChangeEvent) {
+    private fun onWorldChange() {
         tentacleHits.clear()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/dreadfarm/VoltHighlighter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/dreadfarm/VoltHighlighter.kt
@@ -18,7 +18,7 @@ import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkullTextureHolder
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.editCopy
-import at.hannibal2.skyhanni.utils.compat.getStandHelmet
+import at.hannibal2.skyhanni.utils.compat.EntityCompat.getHelmet
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawCylinderInWorld
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.exactLocation
@@ -31,15 +31,14 @@ import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object VoltHighlighter {
-
-    private val config get() = RiftApi.config.area.dreadfarm.voltCrux
-
+    private const val LIGHTNING_DISTANCE = 7F
+    private val CHARGE_TIME = 12.seconds
     private val VOLT_DOING_LIGHTNING by SkullTextureHolder.texture("VOLT_DOING_LIGHTNING")
     private val VOLT_FRIENDLY by SkullTextureHolder.texture("VOLT_FRIENDLY")
     private val VOLT_HOSTILE by SkullTextureHolder.texture("VOLT_HOSTILE")
 
-    private const val LIGHTNING_DISTANCE = 7F
-    private val CHARGE_TIME = 12.seconds
+    private val config get() = RiftApi.config.area.dreadfarm.voltCrux
+
     private var chargingSince = mapOf<Entity, SimpleTimeMark>()
 
     @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
@@ -107,7 +106,7 @@ object VoltHighlighter {
 
     private fun getVoltState(entity: Entity): VoltState {
         if (entity !is ArmorStand) return VoltState.NO_VOLT
-        val helmet = entity.getStandHelmet() ?: return VoltState.NO_VOLT
+        val helmet = entity.getHelmet() ?: return VoltState.NO_VOLT
         return getVoltState(helmet)
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/dreadfarm/WoodenButtonsHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/dreadfarm/WoodenButtonsHelper.kt
@@ -32,7 +32,6 @@ import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object WoodenButtonsHelper {
-
     private val config get() = RiftApi.config.enigmaSoulWaypoints
 
     private val patternGroup = RepoPattern.group("rift.area.dreadfarm.buttons")
@@ -124,9 +123,9 @@ object WoodenButtonsHelper {
             val blockState = buttonLocation.getBlockStateAt()
             if (blockState.block is ButtonBlock &&
                 blockState.getValue(ButtonBlock.POWERED) == true &&
-                buttonLocation.canBeSeen(1..3) &&
                 lastHitButton != buttonLocation &&
-                !hitButtons.contains(buttonLocation)
+                !hitButtons.contains(buttonLocation) &&
+                buttonLocation.canBeSeen(1..3)
             ) {
                 lastHitButton = buttonLocation
                 addLastHitButton()

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/livingcave/LivingCaveDefenseBlocks.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/livingcave/LivingCaveDefenseBlocks.kt
@@ -16,7 +16,6 @@ import at.hannibal2.skyhanni.utils.EntityUtils.isAtFullHealth
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceTo
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.editCopy
-import at.hannibal2.skyhanni.utils.compat.deceased
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.draw3DLine
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
@@ -28,7 +27,6 @@ import net.minecraft.core.particles.ParticleTypes
 
 @SkyHanniModule
 object LivingCaveDefenseBlocks {
-
     private val config get() = RiftApi.config.area.livingCave.defenseBlock
     private var movingBlocks = mapOf<DefenseBlock, Long>()
     private var staticBlocks = emptyList<DefenseBlock>()
@@ -38,7 +36,7 @@ object LivingCaveDefenseBlocks {
     @HandleEvent
     fun onSecondPassed(event: SecondPassedEvent) {
         if (!isEnabled()) return
-        staticBlocks = staticBlocks.editCopy { removeIf { it.entity.deceased } }
+        staticBlocks = staticBlocks.editCopy { removeIf { it.entity.isRemoved } }
     }
 
     @HandleEvent(receiveCancelled = true)

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/CraftRoomHolographicMob.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/mirrorverse/CraftRoomHolographicMob.kt
@@ -14,7 +14,7 @@ import at.hannibal2.skyhanni.utils.LocationUtils.isPlayerInside
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.filterNotClass
-import at.hannibal2.skyhanni.utils.compat.findHealthReal
+import at.hannibal2.skyhanni.utils.compat.EntityCompat.realHealth
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawString
@@ -29,7 +29,6 @@ import net.minecraft.world.phys.AABB
 // TODO fix looking at direction, slime size, helmet/skull of zombie
 @SkyHanniModule
 object CraftRoomHolographicMob {
-
     private val config get() = SkyHanniMod.feature.rift.area.mirrorverse.craftingRoom
     private val enabled get() = config.enabled && craftRoomArea.isPlayerInside()
 
@@ -83,7 +82,7 @@ object CraftRoomHolographicMob {
             append("§a$mobName ")
         }
         if (config.showHealth) {
-            append("§c${findHealthReal().roundTo(1)}♥")
+            append("§c${realHealth.roundTo(1)}♥")
         }
     }.trim().takeIf { it.isNotEmpty() }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/wyldwoods/RiftLarva.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/wyldwoods/RiftLarva.kt
@@ -2,7 +2,6 @@ package at.hannibal2.skyhanni.features.rift.area.wyldwoods
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
-import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.entity.EntityEquipmentChangeEvent
 import at.hannibal2.skyhanni.features.rift.RiftApi
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
@@ -21,16 +20,16 @@ import net.minecraft.world.entity.decoration.ArmorStand
 
 @SkyHanniModule
 object RiftLarva {
-
-    private val config get() = RiftApi.config.area.wyldWoods.larvas
-    private var hasHookInHand = false
-
     private val LARVA_SKULL_TEXTURE by SkullTextureHolder.texture("RIFT_LARVA")
 
     private val LARVA_HOOK = "LARVA_HOOK".toInternalName()
 
+    private val config get() = RiftApi.config.area.wyldWoods.larvas
+
+    private var hasHookInHand = false
+
     @HandleEvent
-    fun onSecondPassed(event: SecondPassedEvent) {
+    fun onSecondPassed() {
         if (!isEnabled()) return
 
         checkHand()

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/wyldwoods/RiftOdonata.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/wyldwoods/RiftOdonata.kt
@@ -1,7 +1,6 @@
 package at.hannibal2.skyhanni.features.rift.area.wyldwoods
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.entity.EntityEquipmentChangeEvent
 import at.hannibal2.skyhanni.features.rift.RiftApi
@@ -21,12 +20,12 @@ import net.minecraft.world.entity.decoration.ArmorStand
 
 @SkyHanniModule
 object RiftOdonata {
+    private val ODONATA_SKULL_TEXTURE by SkullTextureHolder.texture("MOB_ODONATA")
+    private val EMPTY_ODONATA_BOTTLE = "EMPTY_ODONATA_BOTTLE".toInternalName()
 
     private val config get() = RiftApi.config.area.wyldWoods.odonata
-    private var hasBottleInHand = false
 
-    private val ODONATA_SKULL_TEXTURE by SkullTextureHolder.texture("MOB_ODONATA")
-    private val emptyBottle = "EMPTY_ODONATA_BOTTLE".toInternalName()
+    private var hasBottleInHand = false
 
     @HandleEvent
     fun onSecondPassed(event: SecondPassedEvent) {
@@ -36,7 +35,7 @@ object RiftOdonata {
     }
 
     private fun checkHand() {
-        hasBottleInHand = InventoryUtils.getItemInHand()?.getInternalName() == emptyBottle
+        hasBottleInHand = InventoryUtils.getItemInHand()?.getInternalName() == EMPTY_ODONATA_BOTTLE
     }
 
     @HandleEvent
@@ -54,7 +53,7 @@ object RiftOdonata {
     // This only gets called on config change, so the performance impact is minimal
     @OptIn(AllEntitiesGetter::class)
     @HandleEvent
-    fun onConfigLoad(event: ConfigLoadEvent) {
+    fun onConfigLoad() {
         config.highlight.onToggle {
             getEntities<ArmorStand>().forEach(::tryAdd)
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerMiniBossFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerMiniBossFeatures.kt
@@ -10,14 +10,12 @@ import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.EntityUtils.canBeSeen
 import at.hannibal2.skyhanni.utils.LorenzColor
-import at.hannibal2.skyhanni.utils.compat.EntityCompat.deceased
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToCrosshair
 import net.minecraft.world.entity.Entity
 
 @SkyHanniModule
 object SlayerMiniBossFeatures {
-
     private val config get() = SlayerApi.config
     private var miniBosses = mutableSetOf<Mob>()
     private var cocoons = mutableSetOf<Entity>()
@@ -48,8 +46,8 @@ object SlayerMiniBossFeatures {
 
     @HandleEvent
     fun onSecondPassed() {
-        cocoons.removeIf { it.deceased }
-        miniBosses.removeIf { it.baseEntity.deceased }
+        cocoons.removeIf { it.isRemoved }
+        miniBosses.removeIf { it.baseEntity.isRemoved }
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/VampireSlayerFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/VampireSlayerFeatures.kt
@@ -36,8 +36,7 @@ import at.hannibal2.skyhanni.utils.ServerTimeMark
 import at.hannibal2.skyhanni.utils.SkullTextureHolder
 import at.hannibal2.skyhanni.utils.TimeUtils.ticks
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.editCopy
-import at.hannibal2.skyhanni.utils.compat.EntityCompat.deceased
-import at.hannibal2.skyhanni.utils.compat.EntityCompat.findHealthReal
+import at.hannibal2.skyhanni.utils.compat.EntityCompat.realHealth
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.draw3DLine
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawColor
@@ -59,7 +58,6 @@ import kotlin.time.Duration.Companion.milliseconds
 @OptIn(AllEntitiesGetter::class)
 @SkyHanniModule
 object VampireSlayerFeatures {
-
     private val config get() = SlayerApi.config.vampire
     private val configOwnBoss get() = config.ownBoss
     private val configOtherBoss get() = config.othersBoss
@@ -114,7 +112,7 @@ object VampireSlayerFeatures {
     @HandleEvent(SecondPassedEvent::class)
     fun onSecondPassed() {
         if (!isEnabled()) return
-        entityList.editCopy { removeIf { it.deceased } }
+        entityList.editCopy { removeIf { it.isRemoved } }
     }
 
     private fun List<String>.spawnedByCoop(stand: ArmorStand): Boolean = any {
@@ -172,7 +170,7 @@ object VampireSlayerFeatures {
             if (containUser && taggedEntityList.contains(id)) {
                 taggedEntityList.remove(id)
             }
-            val canUseSteak = findHealthReal() <= neededHealth
+            val canUseSteak = realHealth <= neededHealth
             val ownBoss = configOwnBoss.highlight && containUser && isNpc()
             val otherBoss = configOtherBoss.highlight && taggedEntityList.contains(id) && isNpc()
             val coopBoss = configCoopBoss.highlight && containCoop && isNpc()

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/blaze/BlazeSlayerDaggerHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/blaze/BlazeSlayerDaggerHelper.kt
@@ -6,7 +6,6 @@ import at.hannibal2.skyhanni.config.core.config.Position
 import at.hannibal2.skyhanni.config.core.config.gui.GuiPositionEditor
 import at.hannibal2.skyhanni.data.InteractClickType
 import at.hannibal2.skyhanni.data.SlayerApi
-import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.ItemClickEvent
 import at.hannibal2.skyhanni.events.TitleReceivedEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
@@ -18,9 +17,8 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.compat.EntityCompat.realHealth
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
-import at.hannibal2.skyhanni.utils.compat.deceased
-import at.hannibal2.skyhanni.utils.compat.findHealthReal
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
@@ -30,7 +28,6 @@ import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object BlazeSlayerDaggerHelper {
-
     private val config get() = SlayerApi.config.blazes.hellion
 
     /**
@@ -93,7 +90,7 @@ object BlazeSlayerDaggerHelper {
 
         val playerLocation = LocationUtils.playerLocation()
         return HellionShieldHelper.hellionShieldMobs
-            .filter { !it.key.deceased && it.key.getLorenzVec().distance(playerLocation) < 10 && it.key.findHealthReal() > 0 }
+            .filterKeys { !it.isRemoved && it.getLorenzVec().distance(playerLocation) < 10 && it.realHealth > 0 }
             .toSortedMap { a, b ->
                 if (a.getLorenzVec().distance(playerLocation) > b.getLorenzVec().distance(playerLocation)) 1 else 0
             }.firstNotNullOfOrNull { it.value }
@@ -140,7 +137,6 @@ object BlazeSlayerDaggerHelper {
 
             val first = dagger.shields[0]
             if (!first.active && !dagger.shields[1].active) {
-
                 val shield = readFromInventory(dagger)
                 if (shield != null) {
                     shield.active = true
@@ -242,7 +238,7 @@ object BlazeSlayerDaggerHelper {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onGuiRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
+    fun onGuiRenderOverlay() {
         if (!config.daggers) return
 
         val currentScreen = MinecraftCompat.screen

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/enderman/EndermanSlayerFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/enderman/EndermanSlayerFeatures.kt
@@ -6,7 +6,6 @@ import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.SlayerApi
 import at.hannibal2.skyhanni.data.title.TitleManager
 import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
-import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.ServerBlockChangeEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
@@ -24,8 +23,7 @@ import at.hannibal2.skyhanni.utils.SkullTextureHolder
 import at.hannibal2.skyhanni.utils.SkyHanniLogger
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.editCopy
-import at.hannibal2.skyhanni.utils.compat.EntityCompat.deceased
-import at.hannibal2.skyhanni.utils.compat.getStandHelmet
+import at.hannibal2.skyhanni.utils.compat.EntityCompat.getHelmet
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawColor
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
@@ -41,7 +39,6 @@ import kotlin.time.Duration.Companion.seconds
 // TODO replace all drawLineToEye with LineToMobHandler
 @SkyHanniModule
 object EndermanSlayerFeatures {
-
     private val config get() = SlayerApi.config.endermen
     private val beaconConfig get() = config.beacon
     private val endermenWithBeacons = mutableListOf<EnderMan>()
@@ -68,7 +65,7 @@ object EndermanSlayerFeatures {
 
         if (entity is ArmorStand) {
             if (showBeacon()) {
-                val stack = entity.getStandHelmet() ?: return
+                val stack = entity.getHelmet() ?: return
                 if (stack.hoverName.string == "Beacon" && entity.canBeSeen(viewDistance = 15.0, ignoreFrustum = true)) {
                     flyingBeacons.add(entity)
                     RenderLivingEntityHelper.setEntityColor(
@@ -84,7 +81,10 @@ object EndermanSlayerFeatures {
                 }
             }
 
-            if (config.highlightNukekebi && entity.hasSkullTexture(NUKEKUBI_SKULL_TEXTURE) && entity !in nukekubiSkulls) {
+            if (config.highlightNukekebi &&
+                entity.hasSkullTexture(NUKEKUBI_SKULL_TEXTURE) &&
+                entity !in nukekubiSkulls
+            ) {
                 nukekubiSkulls.add(entity)
                 RenderLivingEntityHelper.setEntityColor(
                     entity,
@@ -102,7 +102,7 @@ object EndermanSlayerFeatures {
     @HandleEvent(onlyOnIsland = IslandType.THE_END)
     fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
         if (beaconConfig.highlightBeacon) {
-            endermenWithBeacons.removeIf { it.deceased || !hasBeaconInHand(it) }
+            endermenWithBeacons.removeIf { it.isRemoved || !hasBeaconInHand(it) }
 
             for (location in endermenWithBeacons.map { it.getLorenzVec().add(-0.5, 0.2, -0.5) }) {
                 event.drawColor(location, beaconConfig.beaconColor, alpha = 0.5f)
@@ -116,7 +116,7 @@ object EndermanSlayerFeatures {
 
     private fun drawNukekubiSkulls(event: SkyHanniRenderWorldEvent) {
         for (skull in nukekubiSkulls) {
-            if (skull.deceased) continue
+            if (skull.isRemoved) continue
             if (config.highlightNukekebi) {
                 event.drawDynamicText(
                     skull.getLorenzVec().add(-0.5, 1.5, -0.5),
@@ -183,18 +183,18 @@ object EndermanSlayerFeatures {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.THE_END)
-    fun onSecondPassed(event: SecondPassedEvent) {
+    fun onSecondPassed() {
         nukekubiSkulls.removeAll {
-            if (it.deceased) {
+            if (it.isRemoved) {
                 RenderLivingEntityHelper.removeEntityColor(it)
             }
-            it.deceased
+            it.isRemoved
         }
         flyingBeacons.removeAll {
-            if (it.deceased) {
+            if (it.isRemoved) {
                 RenderLivingEntityHelper.removeEntityColor(it)
             }
-            it.deceased
+            it.isRemoved
         }
 
         // Removing the beacon if It's still there after 7 seconds.

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/spider/LineToSpiderSlayer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/spider/LineToSpiderSlayer.kt
@@ -37,7 +37,7 @@ object LineToSpiderSlayer {
     @HandleEvent(onlyOnSkyblock = true)
     fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
         if (!SlayerApi.isInAnyArea || !config.lineToBoss) return
-        val seenMobs = bosses.filter { it.baseEntity.canBeSeen(30) && it.isAlive }
+        val seenMobs = bosses.filter { it.isAlive && it.baseEntity.canBeSeen(30) }
         seenMobs.forEach { mob ->
             event.drawLineToCrosshair(
                 mob.baseEntity.getLorenzVec().up(),

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/spider/SpiderEggSacHighlighter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/spider/SpiderEggSacHighlighter.kt
@@ -12,14 +12,12 @@ import at.hannibal2.skyhanni.utils.ColorUtils.toColor
 import at.hannibal2.skyhanni.utils.EntityUtils.cleanName
 import at.hannibal2.skyhanni.utils.EntityUtils.getEntitiesNearby
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
-import at.hannibal2.skyhanni.utils.compat.EntityCompat.deceased
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.world.entity.decoration.ArmorStand
 
 @SkyHanniModule
 object SpiderEggSacHighlighter {
-
     private val config get() = SlayerApi.config.spider
     private val highlightedEggSacs = mutableSetOf<ArmorStand>()
 
@@ -56,7 +54,7 @@ object SpiderEggSacHighlighter {
             .toSet()
 
         highlightedEggSacs.removeAll {
-            val shouldRemove = it.deceased || it !in currentEggSacs
+            val shouldRemove = it.isRemoved || it !in currentEggSacs
             if (shouldRemove) RenderLivingEntityHelper.removeEntityColor(it)
             shouldRemove
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/summonings/SummoningMobManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/summonings/SummoningMobManager.kt
@@ -5,7 +5,6 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.data.mob.Mob
 import at.hannibal2.skyhanni.data.mob.Mob.Companion.belongsToPlayer
-import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.MobEvent
 import at.hannibal2.skyhanni.events.SkyHanniRenderEntityEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
@@ -21,9 +20,9 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
+import at.hannibal2.skyhanni.utils.compat.EntityCompat.realHealth
 import at.hannibal2.skyhanni.utils.compat.appendWithColor
 import at.hannibal2.skyhanni.utils.compat.componentBuilder
-import at.hannibal2.skyhanni.utils.compat.findHealthReal
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.container.VerticalContainerRenderable.Companion.vertical
 import at.hannibal2.skyhanni.utils.renderables.primitives.StringRenderable
@@ -34,7 +33,6 @@ import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object SummoningMobManager {
-
     private val config get() = SkyHanniMod.feature.combat.summonings
     private var mobs = mutableSetOf<Mob>()
 
@@ -126,7 +124,7 @@ object SummoningMobManager {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onGuiRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
+    fun onGuiRenderOverlay() {
         if (!config.summoningMobDisplay) return
         if (mobs.isEmpty()) return
 
@@ -134,7 +132,7 @@ object SummoningMobManager {
             add("Summoning mobs: " + mobs.size)
             mobs.forEachIndexed { index, mob ->
                 val entity = mob.baseEntity
-                val health = entity.findHealthReal()
+                val health = entity.realHealth
                 val maxHealth = entity.baseMaxHealth
                 val color = NumberUtil.percentageColor(health.toLong(), maxHealth.toLong()).getChatColor()
                 add("#${index + 1} §a${mob.name} $color${health.shortFormat()}§2/${maxHealth.shortFormat()}§c❤")

--- a/src/main/java/at/hannibal2/skyhanni/test/command/CopyNearbyEntitiesCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/command/CopyNearbyEntitiesCommand.kt
@@ -28,8 +28,8 @@ import at.hannibal2.skyhanni.utils.LocationUtils.distanceToPlayer
 import at.hannibal2.skyhanni.utils.OSUtils
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.compat.EntityCompat.getEquipmentSlots
+import at.hannibal2.skyhanni.utils.compat.EntityCompat.realHealth
 import at.hannibal2.skyhanni.utils.compat.InventoryCompat.orNull
-import at.hannibal2.skyhanni.utils.compat.findHealthReal
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
@@ -52,98 +52,101 @@ import net.minecraft.world.entity.player.Player
 
 @SkyHanniModule
 object CopyNearbyEntitiesCommand {
-
-    private var entityCounter = 0
-
     // Only runs on the command, so performance impact is minimal
+    // TODO refactor instead of suppressing
     @OptIn(AllEntitiesGetter::class)
-    private fun buildCommandResult(searchRadius: Int): List<String> = buildList {
-        val start = LocationUtils.playerLocation()
-        for (entity in EntityUtils.getAllEntities().sortedBy { it.id }) {
-            val position = entity.blockPosition()
-            val vec = position.toLorenzVec()
-            val distance = start.distance(vec)
-            val mob = MobData.entityToMob[entity]
-            if (distance >= searchRadius) continue
+    @Suppress("CyclomaticComplexMethod")
+    private fun buildCommandResult(searchRadius: Int): Pair<List<String>, Int> {
+        var count = 0
+        val list = buildList {
+            val start = LocationUtils.playerLocation()
+            for (entity in EntityUtils.getAllEntities().sortedBy { it.id }) {
+                val position = entity.blockPosition()
+                val vec = position.toLorenzVec()
+                val distance = start.distance(vec)
+                val mob = MobData.entityToMob[entity]
+                if (distance >= searchRadius) continue
 
-            val simpleName = entity.javaClass.simpleName
-            add("entity: $simpleName")
-            val displayName = entity.displayName
-            add("name: '" + entity.name.formattedTextCompatLessResets() + "'")
-            if (entity is ArmorStand) add("cleanName: '" + entity.cleanName + "'")
-            add("displayName: '${displayName.formattedTextCompat()}'")
-            add("entityId: ${entity.id}")
-            add("Category of Mob: ${getCategory(entity, mob)}")
-            add("uuid version: ${entity.uuid.version()} (${entity.uuid})")
-            add("location data:")
-            add("-  vec: $vec")
-            add("-  distance: $distance")
+                count++
+                val simpleName = entity.javaClass.simpleName
+                add("entity: $simpleName")
+                val displayName = entity.displayName
+                add("name: '" + entity.name.formattedTextCompatLessResets() + "'")
+                if (entity is ArmorStand) add("cleanName: '" + entity.cleanName + "'")
+                add("displayName: '${displayName.formattedTextCompat()}'")
+                add("entityId: ${entity.id}")
+                add("Category of Mob: ${getCategory(entity, mob)}")
+                add("uuid version: ${entity.uuid.version()} (${entity.uuid})")
+                add("location data:")
+                add("-  vec: $vec")
+                add("-  distance: $distance")
 
-            val rotationYaw = entity.yRot
-            val rotationPitch = entity.xRot
-            add("-  rotationYaw: $rotationYaw")
-            add("-  rotationPitch: $rotationPitch")
+                val rotationYaw = entity.yRot
+                val rotationPitch = entity.xRot
+                add("-  rotationYaw: $rotationYaw")
+                add("-  rotationPitch: $rotationPitch")
 
-            val firstPassenger = entity.firstPassenger
-            add("firstPassenger: $firstPassenger")
-            val ridingEntity = entity.vehicle
-            add("ridingEntity: $ridingEntity")
+                val firstPassenger = entity.firstPassenger
+                add("firstPassenger: $firstPassenger")
+                val ridingEntity = entity.vehicle
+                add("ridingEntity: $ridingEntity")
 
-            if (entity.isInvisible) {
-                add("Invisible: true")
-            }
-            if (entity.isCurrentlyGlowing) {
-                add("Glowing: true")
-            }
+                if (entity.isInvisible) {
+                    add("Invisible: true")
+                }
+                if (entity.isCurrentlyGlowing) {
+                    add("Glowing: true")
+                }
 
-            if (entity is LivingEntity) {
-                add("EntityLivingBase:")
-                val baseMaxHealth = entity.baseMaxHealth
-                val health = entity.findHealthReal().toInt()
-                add("-  baseMaxHealth: $baseMaxHealth")
-                add("-  health: $health")
-            }
+                if (entity is LivingEntity) {
+                    add("EntityLivingBase:")
+                    val baseMaxHealth = entity.baseMaxHealth
+                    val health = entity.realHealth.toInt()
+                    add("-  baseMaxHealth: $baseMaxHealth")
+                    add("-  health: $health")
+                }
 
-            if (entity is Player) {
-                val armor = entity.getArmorInventory()
-                if (armor != null) {
-                    add("armor:")
-                    for ((i, itemStack) in armor.withIndex()) {
-                        val name = itemStack?.hoverName.formattedTextCompatLeadingWhiteLessResets()
-                        add("-  at: $i: $name")
+                if (entity is Player) {
+                    val armor = entity.getArmorInventory()
+                    if (armor != null) {
+                        add("armor:")
+                        for ((i, itemStack) in armor.withIndex()) {
+                            val name = itemStack?.hoverName.formattedTextCompatLeadingWhiteLessResets()
+                            add("-  at: $i: $name")
+                        }
                     }
                 }
-            }
 
-            if (entity is Display) {
-                // separate because the when also needs to trigger
-                addDisplayEntity(entity)
-            }
+                if (entity is Display) {
+                    // separate because the when also needs to trigger
+                    addDisplayEntity(entity)
+                }
 
-            when (entity) {
-                is ArmorStand -> addArmorStand(entity)
-                is EnderMan -> addEnderman(entity)
-                is MagmaCube -> addMagmaCube(entity)
-                is ItemEntity -> addItem(entity)
-                is RemotePlayer -> addOtherPlayer(entity)
-                is Creeper -> addCreeper(entity)
-                is WitherBoss -> addWither(entity)
-                is TropicalFish -> addTropicalFish(entity)
-                is Shulker -> addShulker(entity)
-                is Panda -> addPanda(entity)
-                is Display.ItemDisplay -> addItemDisplayEntity(entity)
-                is Display.BlockDisplay -> addBlockDisplayEntity(entity)
-                is Display.TextDisplay -> addTextDisplayEntity(entity)
-                is Frog -> addFrogEntity(entity)
+                when (entity) {
+                    is ArmorStand -> addArmorStand(entity)
+                    is EnderMan -> addEnderman(entity)
+                    is MagmaCube -> addMagmaCube(entity)
+                    is ItemEntity -> addItem(entity)
+                    is RemotePlayer -> addOtherPlayer(entity)
+                    is Creeper -> addCreeper(entity)
+                    is WitherBoss -> addWither(entity)
+                    is TropicalFish -> addTropicalFish(entity)
+                    is Shulker -> addShulker(entity)
+                    is Panda -> addPanda(entity)
+                    is Display.ItemDisplay -> addItemDisplayEntity(entity)
+                    is Display.BlockDisplay -> addBlockDisplayEntity(entity)
+                    is Display.TextDisplay -> addTextDisplayEntity(entity)
+                    is Frog -> addFrogEntity(entity)
+                }
+                if (mob != null && mob.category != MobCategory.PLAYER) {
+                    add("MobInfo: ")
+                    addAll(getMobInfo(mob).map { "-  $it" })
+                }
+                add("")
+                add("")
             }
-            if (mob != null && mob.category != MobCategory.PLAYER) {
-                add("MobInfo: ")
-                addAll(getMobInfo(mob).map { "-  $it" })
-            }
-            add("")
-            add("")
-            entityCounter++
         }
+        return list to count
     }
 
     private fun MutableList<String>.addArmorStand(entity: ArmorStand) {
@@ -247,7 +250,6 @@ object CopyNearbyEntitiesCommand {
         add("-  hiddenGene: $hiddenGene")
     }
 
-
     private fun MutableList<String>.addDisplayEntity(entity: Display) {
         add("EntityDisplay:")
         val lookAngle = entity.lookAngle
@@ -333,7 +335,7 @@ object CopyNearbyEntitiesCommand {
         }
     }
 
-    fun getMobInfo(mob: Mob) = buildList<String> {
+    fun getMobInfo(mob: Mob) = buildList {
         add("Name: ${mob.name}")
         add("Category: ${mob.category}")
         add("Base Entity: ${mob.baseEntity.asString()}")
@@ -366,26 +368,25 @@ object CopyNearbyEntitiesCommand {
         event.registerBrigadier("shcopyentities") {
             description = "Copies the entities in the specified radius around the player into the clipboard"
             category = CommandCategory.DEVELOPER_DEBUG
-            argCallback("radius", BrigadierArguments.integer()) { radius ->
+            argCallback("radius", BrigadierArguments.integer(min = 1)) { radius ->
                 command(radius)
             }
             simpleCallback {
-                command()
+                command(10)
             }
         }
     }
 
-    private fun command(searchRadius: Int = 10) {
-        val resultList = buildCommandResult(searchRadius)
+    private fun command(searchRadius: Int) {
+        val (resultList, resultCount) = buildCommandResult(searchRadius)
 
-        if (entityCounter != 0) {
+        if (resultCount > 0) {
             val string = resultList.joinToString("\n")
             OSUtils.copyToClipboard(string)
-            ChatUtils.chat("$entityCounter entities copied into the clipboard!")
+            ChatUtils.chat("$resultCount entities copied into the clipboard!")
         } else {
             ChatUtils.chat("No entities found in a search radius of $searchRadius!")
         }
-        entityCounter = 0
     }
 
     private fun LivingEntity.asString() =

--- a/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/EntityUtils.kt
@@ -8,15 +8,12 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ItemUtils.getSkullTexture
 import at.hannibal2.skyhanni.utils.LocationUtils.canBeSeen
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceTo
-import at.hannibal2.skyhanni.utils.LocationUtils.distanceToIgnoreY
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.TimeUtils.ticks
-import at.hannibal2.skyhanni.utils.compat.EntityCompat.deceased
-import at.hannibal2.skyhanni.utils.compat.EntityCompat.findHealthReal
-import at.hannibal2.skyhanni.utils.compat.EntityCompat.getAllEquipment
-import at.hannibal2.skyhanni.utils.compat.EntityCompat.getEntityLevel
+import at.hannibal2.skyhanni.utils.compat.EntityCompat.getEquipmentSlots
 import at.hannibal2.skyhanni.utils.compat.EntityCompat.getHandItem
-import at.hannibal2.skyhanni.utils.compat.EntityCompat.getStandHelmet
+import at.hannibal2.skyhanni.utils.compat.EntityCompat.getHelmet
+import at.hannibal2.skyhanni.utils.compat.EntityCompat.realHealth
 import at.hannibal2.skyhanni.utils.compat.InventoryCompat.isNotEmpty
 import at.hannibal2.skyhanni.utils.compat.InventoryCompat.orNull
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
@@ -44,11 +41,11 @@ annotation class AllEntitiesGetter
 
 @SkyHanniModule
 object EntityUtils {
-
     inline val ALWAYS get(): (Entity) -> Boolean = { true }
 
     // TODO remove this relatively heavy call everywhere
-    @Deprecated("Use Mob Detection Instead")
+    @Deprecated("Use Mob Detection instead")
+    @Suppress("DEPRECATION")
     fun LivingEntity.hasNameTagWith(
         y: Int,
         contains: String,
@@ -57,25 +54,22 @@ object EntityUtils {
         debugWrongEntity: Boolean = false,
     ): Boolean = getNameTagWith(y, contains, debugRightEntity, inaccuracy, debugWrongEntity) != null
 
-    fun getPlayerEntities(): MutableList<RemotePlayer> {
-        val list = mutableListOf<RemotePlayer>()
-        for (entity in MinecraftCompat.localWorldOrNull?.players().orEmpty()) {
-            if (!entity.isNpc() && entity is RemotePlayer) {
-                list.add(entity)
-            }
-        }
-        return list
-    }
+    fun getPlayerEntities(): List<RemotePlayer> =
+        MinecraftCompat.localWorldOrNull
+            ?.players()
+            ?.filterIsInstance<RemotePlayer>()
+            ?.filterNot { it.isNpc() }
+            .orEmpty()
 
-    @Deprecated("Use Mob Detection Instead")
+    @Deprecated("Use Mob Detection instead")
     fun LivingEntity.getAllNameTagsInRadiusWith(
         contains: String,
         radius: Double = 3.0,
-    ): List<ArmorStand> = getArmorStandsInRadius(getLorenzVec().up(3), radius).filter {
-        it.name.string.contains(contains)
-    }
+    ): List<ArmorStand> =
+        getArmorStandsInRadius(getLorenzVec().up(3), radius).filter { contains in it.cleanName }
 
-    @Deprecated("Use Mob Detection Instead")
+    @Deprecated("Use Mob Detection instead")
+    @Suppress("DEPRECATION")
     fun LivingEntity.getNameTagWith(
         y: Int,
         contains: String,
@@ -84,7 +78,7 @@ object EntityUtils {
         debugWrongEntity: Boolean = false,
     ): ArmorStand? = getAllNameTagsWith(y, contains, debugRightEntity, inaccuracy, debugWrongEntity).firstOrNull()
 
-    @Deprecated("Use Mob Detection Instead")
+    @Deprecated("Use Mob Detection instead")
     fun LivingEntity.getAllNameTagsWith(
         y: Int,
         contains: String,
@@ -94,14 +88,15 @@ object EntityUtils {
     ): List<ArmorStand> {
         val center = getLorenzVec().up(y)
         return getArmorStandsInRadius(center, inaccuracy).filter {
-            val result = it.name.formattedTextCompatLessResets().contains(contains)
+            val name = it.name.formattedTextCompatLessResets()
+            val result = contains in name
             if (debugWrongEntity && !result) {
-                ChatUtils.consoleLog("wrong entity in aabb: '" + it.name.formattedTextCompatLessResets() + "'")
+                ChatUtils.consoleLog("wrong entity in aabb: '$name'")
             }
             if (debugRightEntity && result) {
-                ChatUtils.consoleLog("mob: " + center.printWithAccuracy(2))
-                ChatUtils.consoleLog("nametag: " + it.getLorenzVec().printWithAccuracy(2))
-                ChatUtils.consoleLog("accuracy: " + (it.getLorenzVec() - center).printWithAccuracy(3))
+                ChatUtils.consoleLog("mob: ${center.printWithAccuracy(2)}")
+                ChatUtils.consoleLog("nametag: ${it.getLorenzVec().printWithAccuracy(2)}")
+                ChatUtils.consoleLog("accuracy: ${(it.getLorenzVec() - center).printWithAccuracy(3)}")
             }
             result
         }
@@ -114,10 +109,11 @@ object EntityUtils {
         return getEntitiesInBoundingBox<ArmorStand>(alignedBB)
     }
 
-    @Deprecated("Old. Instead use entity detection feature instead.")
+    @Deprecated("Use entity detection feature instead")
+    @Suppress("DEPRECATION")
     fun LivingEntity.hasBossHealth(health: Int): Boolean = this.hasMaxHealth(health, true)
 
-    @Deprecated("Old. Instead use entity detection feature instead.")
+    @Deprecated("Use entity detection feature instead")
     fun LivingEntity.hasMaxHealth(health: Int, boss: Boolean = false, maxHealth: Int = baseMaxHealth): Boolean {
         val derpyMultiplier = if (ElectionApi.isDerpy) 2.0 else if (ElectionApi.isAura) 1.1 else 1.0
         if (maxHealth == (health * derpyMultiplier).toInt()) return true
@@ -134,40 +130,30 @@ object EntityUtils {
         return false
     }
 
-    internal fun Player.getSkinTexture(): String? = gameProfile.properties.entries()
-        .filter { it.key == "textures" }
-        .map { it.value }
-        .firstOrNull { it.name == "textures" }?.value
+    fun Player.getSkinTexture(): String? = gameProfile.properties.get("textures").firstOrNull()?.value
 
-    inline fun <reified T : Entity> getEntitiesNearby(radius: Double, noinline predicate: (T) -> Boolean = ALWAYS): List<T> =
-        LocationUtils.playerLocation().getEntitiesNearby<T>(radius, predicate)
+    inline fun <reified T : Entity> getEntitiesNearby(
+        radius: Double,
+        noinline predicate: (T) -> Boolean = ALWAYS,
+    ): List<T> = LocationUtils.playerLocation().getEntitiesNearby<T>(radius, predicate)
 
     // First filters for a bounding box because it's faster, and then filters based on distance
     inline fun <reified T : Entity> LorenzVec.getEntitiesNearby(
         radius: Double,
         noinline predicate: (T) -> Boolean = ALWAYS,
-    ): List<T> {
-        return getEntitiesInBox<T>(this, radius) { it.distanceTo(this) < radius && predicate(it) }
-    }
+    ): List<T> = getEntitiesInBox<T>(this, radius) { it.distanceTo(this) < radius && predicate(it) }
 
-    @AllEntitiesGetter
-    inline fun <reified T : Entity> getEntitiesNearbyIgnoreY(location: LorenzVec, radius: Double): Sequence<T> =
-        getEntities<T>().filter { it.distanceToIgnoreY(location) < radius }
-
-    fun LivingEntity.isAtFullHealth() = baseMaxHealth == findHealthReal().toInt()
+    fun LivingEntity.isAtFullHealth() = baseMaxHealth == realHealth.toInt()
 
     @Deprecated("Use specific methods instead, such as wearingSkullTexture or holdingSkullTexture")
-    fun ArmorStand.hasSkullTexture(skin: String?): Boolean {
-        skin ?: return false
-        val inventory = this.getAllEquipment()
-        return inventory.any { it != null && it.getSkullTexture() == skin }
-    }
+    fun LivingEntity.hasSkullTexture(skin: String?): Boolean =
+        skin != null && getEquipmentSlots().values.any { it?.getSkullTexture() == skin }
 
-    fun ArmorStand.getWornSkullTexture(): String? = getStandHelmet()?.getSkullTexture()
-    fun ArmorStand.wearingSkullTexture(skin: String?) = skin != null && getWornSkullTexture() == skin
-    fun ArmorStand.holdingSkullTexture(skin: String?) = skin != null && getHandItem()?.getSkullTexture() == skin
+    fun LivingEntity.getWornSkullTexture(): String? = getHelmet()?.getSkullTexture()
+    fun LivingEntity.wearingSkullTexture(skin: String?) = skin != null && getWornSkullTexture() == skin
+    fun LivingEntity.holdingSkullTexture(skin: String?) = skin != null && getHandItem()?.getSkullTexture() == skin
 
-    internal fun Player.isNpc() = !isRealPlayer()
+    fun Player.isNpc() = !isRealPlayer()
 
     fun LivingEntity.getArmorInventory(): Array<SafeItemStack?>? {
         if (this !is Player) return null
@@ -181,25 +167,32 @@ object EntityUtils {
 
     fun EnderMan.getBlockInHand(): BlockState? = carriedBlock
 
-    @AllEntitiesGetter
+    @OptIn(AllEntitiesGetter::class)
     inline fun <reified R : Entity> getEntities(): Sequence<R> = getAllEntities().filterIsInstance<R>()
 
-    inline fun <reified E : Entity> getEntitiesInBox(pos: LorenzVec, radius: Double, noinline predicate: (E) -> Boolean = ALWAYS): List<E> {
-        return getEntitiesInBoundingBox(pos.boundingCenter(radius), predicate)
-    }
+    inline fun <reified E : Entity> getEntitiesInBox(
+        pos: LorenzVec,
+        radius: Double,
+        noinline predicate: (E) -> Boolean = ALWAYS,
+    ): List<E> = getEntitiesInBoundingBox(pos.boundingCenter(radius), predicate)
 
-    // More efficient than filtering by type, and then for distance, as Minecraft already first filters the chunks that contain the aabb,
-    // and then filters both for entity type and with the predicate for entities inside those chunks.
-    inline fun <reified E : Entity> getEntitiesInBoundingBox(aabb: AABB, noinline predicate: (E) -> Boolean = ALWAYS): List<E> {
-        val world = MinecraftCompat.localWorldOrNull ?: return emptyList()
-        return world.getEntitiesOfClass(E::class.java, aabb, predicate)
-    }
+    /**
+     * More efficient than filtering by type, and then for distance, as Minecraft already first
+     * filters the chunks that contain the [aabb], and then filters both for entity type and with
+     * the predicate for entities inside those chunks.
+     */
+    inline fun <reified E : Entity> getEntitiesInBoundingBox(
+        aabb: AABB,
+        noinline predicate: (E) -> Boolean = ALWAYS,
+    ): List<E> = MinecraftCompat.localWorldOrNull?.getEntitiesOfClass(
+        E::class.java, aabb, predicate,
+    ).orEmpty()
 
-    @AllEntitiesGetter
+    @OptIn(AllEntitiesGetter::class)
     fun getAllEntities(): Sequence<Entity> = MinecraftCompat.localWorldOrNull?.entitiesForRendering()?.let {
         if (Minecraft.getInstance().isSameThread) it
-        // TODO: while I am here, I want to point out that copying the entity list does not constitute proper synchronization,
-        //  but *does* make crashes because of it rarer.
+        // TODO: while I am here, I want to point out that copying the entity list does not
+        //  constitute proper synchronization, but *does* make crashes because of it rarer.
         else it.toMutableList()
     }?.asSequence().orEmpty()
 
@@ -217,24 +210,22 @@ object EntityUtils {
     }
 
     fun Entity.canBeSeen(viewDistance: Number = 150.0, vecYOffset: Double = 0.5, ignoreFrustum: Boolean = false): Boolean {
-        if (deceased) return false
+        if (isRemoved) return false
         // TODO add cache that only updates e.g. 10 times a second
         if (!ignoreFrustum && !FrustumUtils.isVisible(boundingBox)) return false
         return getLorenzVec().up(vecYOffset).canBeSeen(viewDistance)
     }
 
-    fun getEntityByID(entityId: Int): Entity? = MinecraftCompat.localPlayerOrNull?.getEntityLevel()?.getEntity(entityId)
+    fun getEntityByID(entityId: Int): Entity? = MinecraftCompat.localWorldOrNull?.getEntity(entityId)
 
-    fun LivingEntity.isCorrupted() = baseMaxHealth == findHealthReal().toInt().derpy() * 3 || isRunicAndCorrupt()
-    fun LivingEntity.isRunic() = baseMaxHealth == findHealthReal().toInt().derpy() * 4 || isRunicAndCorrupt()
-    fun LivingEntity.isRunicAndCorrupt() = baseMaxHealth == findHealthReal().toInt().derpy() * 3 * 4
+    fun LivingEntity.isCorrupted() = baseMaxHealth == realHealth.toInt().derpy() * 3 || isRunicAndCorrupt()
+    fun LivingEntity.isRunic() = baseMaxHealth == realHealth.toInt().derpy() * 4 || isRunicAndCorrupt()
+    fun LivingEntity.isRunicAndCorrupt() = baseMaxHealth == realHealth.toInt().derpy() * 3 * 4
 
-    val Entity.cleanName
-        get() = this.name.string.removeColor()
+    val Entity.cleanName: String get() = name.string.removeColor()
 
     // TODO use derpy() on every use case
-    val LivingEntity.baseMaxHealth: Int
-        get() = this.getAttributeBaseValue(Attributes.MAX_HEALTH).toInt()
+    val LivingEntity.baseMaxHealth: Int get() = getAttributeBaseValue(Attributes.MAX_HEALTH).toInt()
 
     inline val Entity.spawnTime: ServerTimeMark get() = ServerTimeMark.now() - tickCount.ticks
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/MobUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/MobUtils.kt
@@ -7,7 +7,7 @@ import at.hannibal2.skyhanni.utils.EntityUtils.cleanName
 import at.hannibal2.skyhanni.utils.EntityUtils.getEntitiesNearby
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceTo
 import at.hannibal2.skyhanni.utils.LocationUtils.rayIntersects
-import at.hannibal2.skyhanni.utils.compat.EntityCompat.getInventoryItems
+import at.hannibal2.skyhanni.utils.compat.EntityCompat.hasEquipment
 import at.hannibal2.skyhanni.utils.compat.InventoryCompat.isNotEmpty
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
 import net.minecraft.client.resources.language.I18n
@@ -18,7 +18,6 @@ import net.minecraft.world.entity.player.Player
 
 @SkyHanniModule
 object MobUtils {
-
     private val defaultArmorStandName get() = I18n.get("entity.minecraft.armor_stand")
 
     // The corresponding ArmorStand for a mob has always the ID + 1 (with some exceptions)
@@ -39,9 +38,7 @@ object MobUtils {
 
     fun ArmorStand?.takeNonDefault() = this?.takeIf { !it.isDefaultValue() }
 
-    fun ArmorStand.hasEmptyInventory() = getInventoryItems().none { it.isNotEmpty() }
-
-    fun ArmorStand.isCompletelyDefault() = isDefaultValue() && hasEmptyInventory()
+    fun ArmorStand.isCompletelyDefault() = isDefaultValue() && !hasEquipment()
 
     class Ownership(val ownerName: String) {
         val ownerPlayer = MobData.players.firstOrNull { it.name == ownerName }
@@ -93,5 +90,4 @@ object MobUtils {
     val LivingEntity.mob: Mob? get() = MobData.entityToMob[this]
 
     val Entity.mob: Mob? get() = (this as? LivingEntity)?.mob
-
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/EntityCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/EntityCompat.kt
@@ -2,106 +2,28 @@ package at.hannibal2.skyhanni.utils.compat
 
 import at.hannibal2.skyhanni.utils.EntityUtils.baseMaxHealth
 import at.hannibal2.skyhanni.utils.SafeItemStack
+import at.hannibal2.skyhanni.utils.compat.InventoryCompat.isNotEmpty
 import at.hannibal2.skyhanni.utils.compat.InventoryCompat.orNull
-import net.minecraft.world.entity.Entity
 import net.minecraft.world.entity.EquipmentSlot
 import net.minecraft.world.entity.LivingEntity
-import net.minecraft.world.entity.Mob
-import net.minecraft.world.entity.decoration.ArmorStand
-import net.minecraft.world.level.Level
 
-// TODO replace all function calls outside the clas with the equivalents inside the class, then remove the function.
 /**
- * This is a compatibility layer that helps with multiple minecraft versions and mixins.
+ * This is a compatibility layer that helps with multiple Minecraft versions and mixins.
  * This class should be used in utils/data/api classes and not in feature classes.
  */
 object EntityCompat {
-
-    fun ArmorStand.getStandHelmet(): SafeItemStack? =
-        this.getItemBySlot(EquipmentSlot.HEAD)
-
-    fun Mob.getEntityHelmet(): SafeItemStack? =
-        this.getItemBySlot(EquipmentSlot.HEAD)
-
-    fun LivingEntity.getAllEquipment() =
-        this.equipment.items.values.toTypedArray()
-
-    fun ArmorStand.getHandItem(): SafeItemStack? =
-        this.getItemBySlot(EquipmentSlot.MAINHAND)
-
-    fun ArmorStand.getInventoryItems(): Array<SafeItemStack> =
-        arrayOf(
-            getItemBySlot(EquipmentSlot.MAINHAND),
-            getItemBySlot(EquipmentSlot.FEET),
-            getItemBySlot(EquipmentSlot.LEGS),
-            getItemBySlot(EquipmentSlot.CHEST),
-            getItemBySlot(EquipmentSlot.HEAD),
-            getItemBySlot(EquipmentSlot.OFFHAND),
-        )
-
-    fun ArmorStand.getEquipmentSlots(): Map<EquipmentSlot, SafeItemStack?> =
+    fun LivingEntity.getEquipmentSlots(): Map<EquipmentSlot, SafeItemStack?> =
         EquipmentSlot.entries.associateWith { getItemBySlot(it).orNull() }
 
-    fun Entity.getEntityLevel(): Level =
-        this.level()
+    fun LivingEntity.hasEquipment(): Boolean =
+        getEquipmentSlots().values.any { it.isNotEmpty() }
 
-    val Entity.deceased: Boolean
-        get() = this.isRemoved
+    fun LivingEntity.getHelmet(): SafeItemStack? =
+        getItemBySlot(EquipmentSlot.HEAD).orNull()
 
-    fun LivingEntity.findHealthReal(): Float {
-        val entityHealth = health
-        if (entityHealth == 1024f) {
-            return baseMaxHealth.toFloat()
-        }
-        return entityHealth
-    }
+    fun LivingEntity.getHandItem(): SafeItemStack? =
+        getItemBySlot(EquipmentSlot.MAINHAND).orNull()
 
-}
-
-@Deprecated("use EntityCompat directly")
-fun ArmorStand.getStandHelmet(): SafeItemStack? =
-    this.getItemBySlot(EquipmentSlot.HEAD)
-
-@Deprecated("use EntityCompat directly")
-fun Mob.getEntityHelmet(): SafeItemStack? =
-    this.getItemBySlot(EquipmentSlot.HEAD)
-
-@Deprecated("use EntityCompat directly")
-fun LivingEntity.getAllEquipment() =
-    this.equipment.items.values.toTypedArray()
-
-@Deprecated("use EntityCompat directly")
-fun ArmorStand.getHandItem(): SafeItemStack? =
-    this.getItemBySlot(EquipmentSlot.MAINHAND)
-
-@Deprecated("use EntityCompat directly")
-fun ArmorStand.getInventoryItems(): Array<SafeItemStack> =
-    arrayOf(
-        getItemBySlot(EquipmentSlot.MAINHAND),
-        getItemBySlot(EquipmentSlot.FEET),
-        getItemBySlot(EquipmentSlot.LEGS),
-        getItemBySlot(EquipmentSlot.CHEST),
-        getItemBySlot(EquipmentSlot.HEAD),
-        getItemBySlot(EquipmentSlot.OFFHAND),
-    )
-
-@Deprecated("use EntityCompat directly")
-fun ArmorStand.getEquipmentSlots(): Map<EquipmentSlot, SafeItemStack?> =
-    EquipmentSlot.entries.associateWith { getItemBySlot(it).orNull() }
-
-@Deprecated("use EntityCompat directly")
-fun Entity.getEntityLevel(): Level =
-    this.level()
-
-@Deprecated("use EntityCompat directly")
-val Entity.deceased: Boolean
-    get() = this.isRemoved
-
-@Deprecated("use EntityCompat directly")
-fun LivingEntity.findHealthReal(): Float {
-    val entityHealth = health
-    if (entityHealth == 1024f) {
-        return baseMaxHealth.toFloat()
-    }
-    return entityHealth
+    val LivingEntity.realHealth: Float
+        get() = health.takeUnless { it == 1024f } ?: baseMaxHealth.toFloat()
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
@@ -16,7 +16,6 @@ import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.createResourceLocation
-import at.hannibal2.skyhanni.utils.compat.deceased
 import at.hannibal2.skyhanni.utils.compat.position
 import at.hannibal2.skyhanni.utils.compat.rotation
 import at.hannibal2.skyhanni.utils.expand
@@ -971,7 +970,7 @@ object WorldRenderUtils {
     }
 
     fun SkyHanniRenderWorldEvent.exactBoundingBox(entity: Entity): AABB {
-        if (entity.deceased) return entity.boundingBox
+        if (entity.isRemoved) return entity.boundingBox
         val offset = exactLocation(entity) - entity.getLorenzVec()
         return entity.boundingBox.move(offset.x, offset.y, offset.z)
     }


### PR DESCRIPTION
## What
Various improvements and cleanup to entity-related features.

## Changelog Technical Details
+ Split mob name and category display into a new Mob Display debug option. - Luna
+ Fixed Show Invisible option not working and restricted it to development environment only to prevent it from being used to cheat. - Luna
+ Fixed /shcopyentities showing the wrong amount of copied entities. - Luna
+ Fixed Vanquisher Waypoint Share keybind attempting to activate outside the Crimson Isle. - Luna
    * This is not really user-facing, as it returned early anyway and only logged a debug message.
+ Cleaned up EntityCompat methods and made them work universally on all LivingEntities. - Luna