### PR TITLE
Backend: Remove deprecated eventTypes parameter from HandleEvent

### DIFF
--- a/detekt/baseline-main.xml
+++ b/detekt/baseline-main.xml
@@ -1110,14 +1110,6 @@
     <ID>PrivateEventListener:ExperimentationSuperpairApi.kt:ExperimentationSuperpairApi$@HandleEvent fun onTableTaskStarted</ID>
     <ID>PrivateEventListener:ExperimentationSuperpairApi.kt:ExperimentationSuperpairApi$@HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND) fun onInventoryUpdated</ID>
     <ID>PrivateEventListener:ExperimentationSuperpairApi.kt:ExperimentationSuperpairApi$@HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND) fun onSlotClick</ID>
-    <ID>PrivateEventListener:ExperimentationTableApi.kt:ExperimentationTableApi$@HandleEvent fun onRepoReload</ID>
-    <ID>PrivateEventListener:ExperimentationTableApi.kt:ExperimentationTableApi$@HandleEvent( onlyOnIsland = IslandType.PRIVATE_ISLAND, eventTypes = [WorldChangeEvent::class, ItemAddInInventoryEvent::class], ) fun refreshBottlesInInventory</ID>
-    <ID>PrivateEventListener:ExperimentationTableApi.kt:ExperimentationTableApi$@HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND) fun onChat</ID>
-    <ID>PrivateEventListener:ExperimentationTableApi.kt:ExperimentationTableApi$@HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND) fun onClick</ID>
-    <ID>PrivateEventListener:ExperimentationTableApi.kt:ExperimentationTableApi$@HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND) fun onInventoryClose</ID>
-    <ID>PrivateEventListener:ExperimentationTableApi.kt:ExperimentationTableApi$@HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND) fun onInventoryFullyOpened</ID>
-    <ID>PrivateEventListener:ExperimentationTableApi.kt:ExperimentationTableApi$@HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND) fun onSlotClick</ID>
-    <ID>PrivateEventListener:ExperimentationTableApi.kt:ExperimentationTableApi$@HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND, priority = HandleEvent.HIGH) fun onInventoryUpdated</ID>
     <ID>PrivateEventListener:ExperimentationXPOverlay.kt:ExperimentationXPOverlay$@HandleEvent fun onConfigFix</ID>
     <ID>PrivateEventListener:ExperimentationXPOverlay.kt:ExperimentationXPOverlay$@HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND) fun onRenderItemOverlayPost</ID>
     <ID>PrivateEventListener:ExperimentsAddonsHelper.kt:ExperimentsAddonsHelper$@HandleEvent fun onConfigFix</ID>
@@ -1737,11 +1729,6 @@
     <ID>PrivateEventListener:HoppityEventSummary.kt:HoppityEventSummary$@HandleEvent fun onProfileJoin</ID>
     <ID>PrivateEventListener:HoppityEventSummary.kt:HoppityEventSummary$@HandleEvent fun onRabbitFound</ID>
     <ID>PrivateEventListener:HoppityEventSummary.kt:HoppityEventSummary$@HandleEvent(onlyOnSkyblock = true) fun onSecondPassed</ID>
-    <ID>PrivateEventListener:HoppityLiveDisplay.kt:HoppityLiveDisplay$@HandleEvent fun onConfigLoad</ID>
-    <ID>PrivateEventListener:HoppityLiveDisplay.kt:HoppityLiveDisplay$@HandleEvent(onlyOnSkyblock = true) fun onGuiRenderTop</ID>
-    <ID>PrivateEventListener:HoppityLiveDisplay.kt:HoppityLiveDisplay$@HandleEvent(onlyOnSkyblock = true) fun onKeyPress</ID>
-    <ID>PrivateEventListener:HoppityLiveDisplay.kt:HoppityLiveDisplay$@HandleEvent(onlyOnSkyblock = true) fun onSecondPassed</ID>
-    <ID>PrivateEventListener:HoppityLiveDisplay.kt:HoppityLiveDisplay$@HandleEvent(onlyOnSkyblock = true, eventTypes = [InventoryCloseEvent::class, InventoryFullyOpenedEvent::class]) fun reCheckInventoryState</ID>
     <ID>PrivateEventListener:HoppityMuteEggSounds.kt:HoppityMuteEggSounds$@HandleEvent fun onPlaySound</ID>
     <ID>PrivateEventListener:HoppityNpc.kt:HoppityNpc$@HandleEvent fun onBackgroundDrawn</ID>
     <ID>PrivateEventListener:HoppityNpc.kt:HoppityNpc$@HandleEvent fun onInventoryClose</ID>
@@ -2514,10 +2501,6 @@
     <ID>PrivateEventListener:QuiverDisplay.kt:QuiverDisplay$@HandleEvent fun onGuiRenderOverlay</ID>
     <ID>PrivateEventListener:QuiverDisplay.kt:QuiverDisplay$@HandleEvent fun onProfileJoin</ID>
     <ID>PrivateEventListener:QuiverDisplay.kt:QuiverDisplay$@HandleEvent fun onQuiverUpdate</ID>
-    <ID>PrivateEventListener:QuiverWarning.kt:QuiverWarning$@HandleEvent fun onConfigFix</ID>
-    <ID>PrivateEventListener:QuiverWarning.kt:QuiverWarning$@HandleEvent fun onQuiverUpdate</ID>
-    <ID>PrivateEventListener:QuiverWarning.kt:QuiverWarning$@HandleEvent fun onWorldChange</ID>
-    <ID>PrivateEventListener:QuiverWarning.kt:QuiverWarning$@HandleEvent(eventTypes = [DungeonCompleteEvent::class, KuudraCompleteEvent::class]) fun onInstanceComplete</ID>
     <ID>PrivateEventListener:RareCropTracker.kt:RareCropTracker$@HandleEvent fun onChat</ID>
     <ID>PrivateEventListener:RareCropTracker.kt:RareCropTracker$@HandleEvent fun onCommandRegistration</ID>
     <ID>PrivateEventListener:RareCropTracker.kt:RareCropTracker$@HandleEvent fun onConfigFix</ID>

--- a/src/main/java/at/hannibal2/skyhanni/api/ExperimentationTableApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/ExperimentationTableApi.kt
@@ -12,15 +12,14 @@ import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.InventoryOpenEvent
 import at.hannibal2.skyhanni.events.InventoryUpdatedEvent
+import at.hannibal2.skyhanni.events.IslandJoinEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.events.WorldClickEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
-import at.hannibal2.skyhanni.events.entity.ItemAddInInventoryEvent
 import at.hannibal2.skyhanni.events.experiments.TableRareUncoverEvent
 import at.hannibal2.skyhanni.events.experiments.TableTaskCompletedEvent
 import at.hannibal2.skyhanni.events.experiments.TableTaskStartedEvent
 import at.hannibal2.skyhanni.events.experiments.TableXPBottleUsedEvent
-import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
@@ -55,7 +54,6 @@ typealias TaskType = ExperimentationTableApi.ExperimentationTaskType
 
 @SkyHanniModule
 object ExperimentationTableApi {
-
     private const val ADDONS_OVER_DATA_SLOT = 11
     private const val SUPERPAIRS_OVER_DATA_SLOT = 13
 
@@ -338,14 +336,14 @@ object ExperimentationTableApi {
     private fun ExperimentationMessages.isSelected() = config.experimentsProfitTracker.hideMessages.contains(this)
 
     @HandleEvent
-    fun onRepoReload(event: RepositoryReloadEvent) {
+    private fun onRepoReload(event: RepositoryReloadEvent) {
         val experiments = event.getConstant<ExperimentsJson>("ExperimentationTable")
         miscRepoRewards = experiments.miscRewards
         ultraRareMiscItems = experiments.ultraRareRewards.orEmpty()
     }
 
     @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND)
-    fun onInventoryClose() {
+    private fun onInventoryClose() {
         if (currentExpOverHash != 0) {
             lastExpOverHash = currentExpOverHash
             currentExpOverHash = 0
@@ -364,19 +362,24 @@ object ExperimentationTableApi {
         }
     }
 
-    @HandleEvent(
-        onlyOnIsland = IslandType.PRIVATE_ISLAND,
-        eventTypes = [WorldChangeEvent::class, ItemAddInInventoryEvent::class],
-    )
-    fun refreshBottlesInInventory() {
+    private fun refreshBottlesInInventory() {
         currentBottlesInInventory = getBottlesInOwnInventory().takeIf {
             it != currentBottlesInInventory
         } ?: return
         ChatUtils.debug("Updated bottles in inventory: $currentBottlesInInventory")
     }
 
+    @HandleEvent
+    private fun onIslandJoin(event: IslandJoinEvent) {
+        if (event.island != IslandType.PRIVATE_ISLAND) return
+        refreshBottlesInInventory()
+    }
+
+    @HandleEvent
+    private fun onItemAddInInventory() = refreshBottlesInInventory()
+
     @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND)
-    fun onChat(event: SkyHanniChatEvent.Allow) {
+    private fun onChat(event: SkyHanniChatEvent.Allow) {
         if (claimMessagePattern.matches(event.message) && ExperimentationMessages.DONE.isSelected()) {
             event.blockedReason = "CLAIM_MESSAGE"
             return
@@ -432,7 +435,7 @@ object ExperimentationTableApi {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND)
-    fun onClick(event: WorldClickEvent) {
+    private fun onClick(event: WorldClickEvent) {
         if (!inDistanceToTable(15.0)) return
         if (event.clickType != InteractClickType.RIGHT_CLICK) return
 
@@ -446,7 +449,7 @@ object ExperimentationTableApi {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND, priority = HandleEvent.HIGH)
-    fun onInventoryUpdated(event: InventoryUpdatedEvent) {
+    private fun onInventoryUpdated(event: InventoryUpdatedEvent) {
         if (!inTable) return
         event.tryUpdateCurrentActivity()
         event.tryFireRareBookUncovered()
@@ -455,7 +458,7 @@ object ExperimentationTableApi {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND)
-    fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
+    private fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
         if (!inTable || event.item == null || event.slot == null) return
         event.tryResetQueuedEvent()
     }
@@ -466,7 +469,7 @@ object ExperimentationTableApi {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND)
-    fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
+    private fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
         if (!inTable) return
         updateTablePosition()
         event.tryProcessExperimentOver()

--- a/src/main/java/at/hannibal2/skyhanni/api/event/HandleEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/event/HandleEvent.kt
@@ -10,17 +10,9 @@ import kotlin.reflect.KClass
 annotation class HandleEvent(
     /**
      * For cases where the event properties are themselves not needed, and solely a listener for an event fire suffices.
-     * To specify multiple events, use [eventTypes] instead.
      */
     @Deprecated("Use Primary Function Name, or explicit type parameter instead.")
     val eventType: KClass<out SkyHanniEvent> = SkyHanniEvent::class,
-
-    /**
-     * For cases where multiple events are listened to, and properties are unnecessary.
-     * To specify only one event, use [eventType] instead.
-     */
-    @Deprecated("Use Primary Function Name, or explicit type parameter instead.")
-    val eventTypes: Array<KClass<out SkyHanniEvent>> = [],
 
     /**
      * If the event should only be received while on SkyBlock.

--- a/src/main/java/at/hannibal2/skyhanni/api/event/SkyHanniEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/event/SkyHanniEvents.kt
@@ -18,7 +18,6 @@ import java.util.concurrent.atomic.AtomicInteger
 
 @SkyHanniModule
 object SkyHanniEvents {
-
     private val listeners: MutableMap<Class<out SkyHanniEvent>, EventListeners> = mutableMapOf()
     private val handlers: MutableMap<Class<out SkyHanniEvent>, EventHandler<out SkyHanniEvent>> = mutableMapOf()
     private var disabledHandlers = emptySet<String>()
@@ -46,11 +45,9 @@ object SkyHanniEvents {
     fun isDisabledInvoker(invoker: String): Boolean = invoker in disabledHandlerInvokers
 
     private fun registerMethod(method: Method, instance: Any) {
-        val (options, eventTypes) = getEventData(method) ?: return
-        eventTypes.forEach { eventType ->
-            listeners.getOrPut(eventType) { EventListeners(eventType) }
-                .addListener(method, instance, options)
-        }
+        val (options, eventType) = getEventData(method) ?: return
+        listeners.getOrPut(eventType) { EventListeners(eventType) }
+            .addListener(method, instance, options)
     }
 
     @JvmStatic
@@ -62,28 +59,24 @@ object SkyHanniEvents {
     private fun handleZeroParameterMethod(
         method: Method,
         options: HandleEvent,
-    ): Pair<HandleEvent, List<Class<out SkyHanniEvent>>>? {
+    ): Pair<HandleEvent, Class<out SkyHanniEvent>>? {
         val primaryFunctionEventType = eventPrimaryFunctionNames[method.name]
-        if (primaryFunctionEventType != null) return options to listOf(primaryFunctionEventType)
+        if (primaryFunctionEventType != null) return options to primaryFunctionEventType
 
-        if (options.eventType != SkyHanniEvent::class) return options to listOf(options.eventType.java)
+        if (options.eventType != SkyHanniEvent::class) return options to options.eventType.java
 
-        if (options.eventTypes.isEmpty()) {
-            ErrorManager.crashInDevEnv(
-                "Function ${method.fullyQualifiedName} must have an event parameter, a primary " +
-                    "function name, or an explicit event specification because it is annotated " +
-                    "with @HandleEvent",
-            )
-            return null
-        }
-
-        return options to options.eventTypes.map { it.java }
+        ErrorManager.crashInDevEnv(
+            "Function ${method.fullyQualifiedName} must have an event parameter, a primary " +
+                "function name, or an explicit event specification because it is annotated " +
+                "with @HandleEvent",
+        )
+        return null
     }
 
     private fun handleSingleParameterMethod(
         method: Method,
         options: HandleEvent,
-    ): Pair<HandleEvent, List<Class<out SkyHanniEvent>>>? {
+    ): Pair<HandleEvent, Class<out SkyHanniEvent>>? {
         val eventType = method.parameterTypes.first()
 
         if (!SkyHanniEvent::class.java.isAssignableFrom(eventType)) {
@@ -95,10 +88,10 @@ object SkyHanniEvents {
         }
 
         @Suppress("UNCHECKED_CAST")
-        return options to listOf(eventType as Class<out SkyHanniEvent>)
+        return options to (eventType as Class<out SkyHanniEvent>)
     }
 
-    private fun getEventData(method: Method): Pair<HandleEvent, List<Class<out SkyHanniEvent>>>? {
+    private fun getEventData(method: Method): Pair<HandleEvent, Class<out SkyHanniEvent>>? {
         val options = method.getAnnotation(HandleEvent::class.java) ?: return null
         if (!method.declaringClass.isAnnotationPresent(SkyHanniModule::class.java)) {
             ErrorManager.crashInDevEnv(
@@ -123,11 +116,9 @@ object SkyHanniEvents {
     }
 
     private fun unregisterMethod(method: Method) {
-        val (_, eventTypes) = getEventData(method) ?: return
-        eventTypes.forEach { event ->
-            unregisterHandler(event)
-            listeners.values.forEach { it.removeListener(method) }
-        }
+        val (_, eventType) = getEventData(method) ?: return
+        unregisterHandler(eventType)
+        listeners.values.forEach { it.removeListener(method) }
     }
 
     private fun unregisterHandler(clazz: Class<out SkyHanniEvent>) {
@@ -178,7 +169,6 @@ object SkyHanniEvents {
         markEventCacheDirty(DirtyReason.REPO_RELOAD)
     }
 
-
     private fun Set<DisabledEventVersionedJson>.activeNames(
         version: ModVersion,
         mcVersion: String,
@@ -198,7 +188,6 @@ object SkyHanniEvents {
 
             for (second in seconds) {
                 if (event.repeatSeconds(second)) {
-
                     for (handler in list) {
                         val log = handler.invokeLog
                         val current = log.invokeCount
@@ -221,7 +210,6 @@ object SkyHanniEvents {
     class EventInvokeData(var oldValue: Long, var diff: Long)
 
     class EventInvokeLog {
-
         var invokeCount: Long = 0L
 
         var overTimeLog = mutableMapOf<Int, EventInvokeData>()

--- a/src/main/java/at/hannibal2/skyhanni/events/dungeon/DungeonCompleteEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/dungeon/DungeonCompleteEvent.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.events.dungeon
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 
 /**
  * Fired when a dungeon run is completed.
@@ -10,4 +11,5 @@ import at.hannibal2.skyhanni.api.event.SkyHanniEvent
  *
  * [floor] holds the current dungeon floor identifier (e.g., "F7", "M7", "E").
  */
+@PrimaryFunction("onDungeonComplete")
 class DungeonCompleteEvent(val floor: String) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/entity/ItemAddInInventoryEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/entity/ItemAddInInventoryEvent.kt
@@ -1,6 +1,8 @@
 package at.hannibal2.skyhanni.events.entity
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 import at.hannibal2.skyhanni.utils.NeuInternalName
 
+@PrimaryFunction("onItemAddInInventory")
 class ItemAddInInventoryEvent(val internalName: NeuInternalName, val amount: Int) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/kuudra/KuudraCompleteEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/kuudra/KuudraCompleteEvent.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.events.kuudra
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 
 /**
  * Fired when a Kuudra boss is defeated.
@@ -9,4 +10,5 @@ import at.hannibal2.skyhanni.api.event.SkyHanniEvent
  *
  * [kuudraTier] holds the tier of the completed run (1 = basic, 2 = hot, 3 = burning, 4 = fiery, 5 = infernal).
  */
+@PrimaryFunction("onKuudraComplete")
 class KuudraCompleteEvent(val kuudraTier: Int) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/summary/HoppityLiveDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/summary/HoppityLiveDisplay.kt
@@ -8,8 +8,6 @@ import at.hannibal2.skyhanni.config.features.event.hoppity.summary.HoppityLiveDi
 import at.hannibal2.skyhanni.config.features.event.hoppity.summary.HoppityLiveDisplayConfig.HoppityLiveDisplayInventoryType
 import at.hannibal2.skyhanni.config.storage.ProfileSpecificStorage.HoppityEventStats
 import at.hannibal2.skyhanni.data.ProfileStorageData
-import at.hannibal2.skyhanni.events.InventoryCloseEvent
-import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.minecraft.KeyPressEvent
 import at.hannibal2.skyhanni.features.event.hoppity.HoppityApi
 import at.hannibal2.skyhanni.features.event.hoppity.HoppityApi.getEventEndMark
@@ -61,7 +59,6 @@ private typealias DTType = HoppityLiveDisplayConfig.HoppityDateTimeDisplayType
 
 @SkyHanniModule
 object HoppityLiveDisplay {
-
     /**
      * REGEX-TEST: Hoppity's Collection
      * REGEX-TEST: (1/2) Hoppity's Collection
@@ -101,8 +98,7 @@ object HoppityLiveDisplay {
     private var displayCardRenderables: List<Renderable> = emptyList()
     private var lastToggleMark: SimpleTimeMark = SimpleTimeMark.farPast()
 
-    @HandleEvent(onlyOnSkyblock = true, eventTypes = [InventoryCloseEvent::class, InventoryFullyOpenedEvent::class])
-    fun reCheckInventoryState() {
+    private fun reCheckInventoryState() {
         if (isInInventory() != lastKnownInInvState) {
             lastKnownInInvState = !lastKnownInInvState
             lastKnownStatHash = 0
@@ -110,14 +106,20 @@ object HoppityLiveDisplay {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onSecondPassed() {
+    private fun onInventoryClose() = reCheckInventoryState()
+
+    @HandleEvent(onlyOnSkyblock = true)
+    private fun onInventoryFullyOpened() = reCheckInventoryState()
+
+    @HandleEvent(onlyOnSkyblock = true)
+    private fun onSecondPassed() {
         reCheckInventoryState()
         if (!currentTimerActive) return
         lastKnownStatHash = 0
     }
 
     @HandleEvent
-    fun onConfigLoad() {
+    private fun onConfigLoad() {
         eventConfig.eventSummary.statDisplayList.afterChange {
             lastKnownStatHash = 0
         }
@@ -127,7 +129,7 @@ object HoppityLiveDisplay {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onKeyPress(event: KeyPressEvent) {
+    private fun onKeyPress(event: KeyPressEvent) {
         reCheckInventoryState()
         if (!config.enabled) return
         if (config.toggleKeybind == GLFW.GLFW_KEY_UNKNOWN || config.toggleKeybind != event.keyCode) return
@@ -142,7 +144,7 @@ object HoppityLiveDisplay {
     private var inventoryOpen = false
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onGuiRenderTop() {
+    private fun onGuiRenderTop() {
         if (!liveDisplayEnabled()) return
 
         val stats = getYearStats(HoppityEventSummary.statYear) ?: return

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/quiver/QuiverWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/quiver/QuiverWarning.kt
@@ -8,8 +8,6 @@ import at.hannibal2.skyhanni.data.QuiverApi
 import at.hannibal2.skyhanni.data.QuiverApi.amount
 import at.hannibal2.skyhanni.data.title.TitleManager
 import at.hannibal2.skyhanni.events.QuiverUpdateEvent
-import at.hannibal2.skyhanni.events.dungeon.DungeonCompleteEvent
-import at.hannibal2.skyhanni.events.kuudra.KuudraCompleteEvent
 import at.hannibal2.skyhanni.features.dungeon.DungeonApi
 import at.hannibal2.skyhanni.features.nether.kuudra.KuudraApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -25,14 +23,12 @@ import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object QuiverWarning {
-
     private val config get() = SkyHanniMod.feature.combat.quiverConfig
 
     private var lastLowQuiverReminder = SimpleTimeMark.farPast()
     private val arrowsInInstance = mutableSetOf<ArrowType>()
 
-    @HandleEvent(eventTypes = [DungeonCompleteEvent::class, KuudraCompleteEvent::class])
-    fun onInstanceComplete() {
+    private fun onInstanceComplete() {
         val arrows = arrowsInInstance.filterTo(mutableSetOf()) { it.amount <= config.lowQuiverAmount }
         arrowsInInstance.clear()
 
@@ -42,6 +38,12 @@ object QuiverWarning {
             }
         }
     }
+
+    @HandleEvent
+    private fun onDungeonComplete() = onInstanceComplete()
+
+    @HandleEvent
+    private fun onKuudraComplete() = onInstanceComplete()
 
     private fun instanceAlert(arrows: Set<ArrowType>) {
         val arrowsText = arrows.map { arrowType ->
@@ -61,7 +63,7 @@ object QuiverWarning {
     }
 
     @HandleEvent
-    fun onQuiverUpdate(event: QuiverUpdateEvent) {
+    private fun onQuiverUpdate(event: QuiverUpdateEvent) {
         val amount = event.currentAmount
         val arrow = event.currentArrow ?: return
         if (arrow == QuiverApi.NONE_ARROW_TYPE) return
@@ -75,12 +77,12 @@ object QuiverWarning {
     }
 
     @HandleEvent
-    fun onWorldChange() = arrowsInInstance.clear()
+    private fun onWorldChange() = arrowsInInstance.clear()
 
     private fun inInstance() = DungeonApi.inDungeon() || KuudraApi.inKuudra
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(35, "inventory.quiverAlert", "combat.quiverConfig.lowQuiverNotification")
     }
 }


### PR DESCRIPTION
## What
Removes the deprecated `eventTypes` parameter from `@HandleEvent` and replaces existing usages with individual event handlers. This is just some early low-hanging fruit cleanup since it is a very small diff to review compared to removing `eventType`.

## Changelog Technical Details
+ Removed deprecated eventTypes parameter from HandleEvent. - Luna