### PR TITLE
Improvement: Added an Ironman Option to Profit Trackers

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/experimentationtable/ExperimentsProfitTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/experimentationtable/ExperimentsProfitTrackerConfig.kt
@@ -10,6 +10,7 @@ import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDraggableList
 import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+import io.github.notenoughupdates.moulconfig.observer.Property
 
 class ExperimentsProfitTrackerConfig {
     @Expose
@@ -22,6 +23,11 @@ class ExperimentsProfitTrackerConfig {
     @ConfigOption(name = "Hide Messages", desc = "Change the messages to be hidden after completing Add-on/Main experiments.")
     @ConfigEditorDraggableList
     val hideMessages: MutableList<ExperimentationTableApi.ExperimentationMessages> = mutableListOf()
+
+    @Expose
+    @ConfigOption(name = "Ironman Profits", desc = "Removes the cost of Experience Bottles from Profit.")
+    @ConfigEditorBoolean
+    var ironmanProfitCalc: Property<Boolean> = Property.of(true)
 
     @Expose
     @ConfigOption(name = "Track Time Spent", desc = "Track time spent doing addons and experiments.")
@@ -41,7 +47,7 @@ class ExperimentsProfitTrackerConfig {
     @Expose
     @ConfigOption(
         name = "Tracker Settings",
-        desc = ""
+        desc = "",
     )
     @Accordion
     val perTrackerConfig: IndividualItemTrackerConfig = IndividualItemTrackerConfig()

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/experimentationtable/ExperimentsProfitTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/experimentationtable/ExperimentsProfitTrackerConfig.kt
@@ -8,6 +8,7 @@ import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.Accordion
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDraggableList
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDropdown
 import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 import io.github.notenoughupdates.moulconfig.observer.Property
@@ -25,9 +26,16 @@ class ExperimentsProfitTrackerConfig {
     val hideMessages: MutableList<ExperimentationTableApi.ExperimentationMessages> = mutableListOf()
 
     @Expose
-    @ConfigOption(name = "Ironman Profits", desc = "Removes the cost of Experience Bottles from Profit.")
-    @ConfigEditorBoolean
-    var ironmanProfitCalc: Property<Boolean> = Property.of(true)
+    @ConfigOption(name = "Ironman Profits", desc = "Select which profiles should use the Ironman price calculation option. §eRemoves the cost of Experience Bottles from the Profit.")
+    @ConfigEditorDropdown
+    val ironmanProfitType: Property<IronmanProfitType> = Property.of(IronmanProfitType.NONE)
+
+    enum class IronmanProfitType(private val displayName: String) {
+        NONE("None"),
+        ONLY_IRONMAN("Only Ironman"),
+        ALL_PROFILES("All Profiles");
+        override fun toString(): String = displayName
+    }
 
     @Expose
     @ConfigOption(name = "Track Time Spent", desc = "Track time spent doing addons and experiments.")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/experimentationtable/ExperimentsProfitTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/experimentationtable/ExperimentsProfitTrackerConfig.kt
@@ -28,7 +28,7 @@ class ExperimentsProfitTrackerConfig {
     @Expose
     @ConfigOption(name = "Ironman Profits", desc = "Select which profiles should use the Ironman price calculation option. §eRemoves the cost of Experience Bottles from the Profit.")
     @ConfigEditorDropdown
-    val ironmanProfitType: Property<IronmanProfitType> = Property.of(IronmanProfitType.NONE)
+    val ironmanProfitType: Property<IronmanProfitType> = Property.of(IronmanProfitType.ONLY_IRONMAN)
 
     enum class IronmanProfitType(private val displayName: String) {
         NONE("None"),

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/experimentationtable/ExperimentsProfitTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/experimentationtable/ExperimentsProfitTrackerConfig.kt
@@ -31,9 +31,9 @@ class ExperimentsProfitTrackerConfig {
     val ironmanProfitType: Property<IronmanProfitType> = Property.of(IronmanProfitType.ONLY_IRONMAN)
 
     enum class IronmanProfitType(private val displayName: String) {
-        NONE("None"),
-        ONLY_IRONMAN("Only Ironman"),
-        ALL_PROFILES("All Profiles");
+        NONE("§cNone"),
+        ONLY_IRONMAN("§7Only Ironman"),
+        ALL_PROFILES("§2All Profiles");
         override fun toString(): String = displayName
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/ExcavatorProfitTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/ExcavatorProfitTrackerConfig.kt
@@ -34,7 +34,7 @@ class ExcavatorProfitTrackerConfig {
     @Expose
     @ConfigOption(name = "Ironman Profits", desc = "Select which profiles should use the Ironman price calculation option. §eRemoves the cost of Scrap from the Profit.")
     @ConfigEditorDropdown
-    val ironmanProfitType: Property<IronmanProfitType> = Property.of(IronmanProfitType.NONE)
+    val ironmanProfitType: Property<IronmanProfitType> = Property.of(IronmanProfitType.ONLY_IRONMAN)
 
     enum class IronmanProfitType(private val displayName: String) {
         NONE("None"),

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/ExcavatorProfitTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/ExcavatorProfitTrackerConfig.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.config.features.misc.tracker.individual.IndividualI
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.Accordion
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDropdown
 import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 import io.github.notenoughupdates.moulconfig.observer.Property
@@ -31,9 +32,16 @@ class ExcavatorProfitTrackerConfig {
     var showFossilDust: Boolean = true
 
     @Expose
-    @ConfigOption(name = "Ironman Profits", desc = "Removes the cost of Scrap from Profit.")
-    @ConfigEditorBoolean
-    var ironmanProfitCalc: Property<Boolean> = Property.of(true)
+    @ConfigOption(name = "Ironman Profits", desc = "Select which profiles should use the Ironman price calculation option. §eRemoves the cost of Scrap from the Profit.")
+    @ConfigEditorDropdown
+    val ironmanProfitType: Property<IronmanProfitType> = Property.of(IronmanProfitType.NONE)
+
+    enum class IronmanProfitType(private val displayName: String) {
+        NONE("None"),
+        ONLY_IRONMAN("Only Ironman"),
+        ALL_PROFILES("All Profiles");
+        override fun toString(): String = displayName
+    }
 
     @Expose
     @ConfigOption(

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/ExcavatorProfitTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/ExcavatorProfitTrackerConfig.kt
@@ -37,9 +37,9 @@ class ExcavatorProfitTrackerConfig {
     val ironmanProfitType: Property<IronmanProfitType> = Property.of(IronmanProfitType.ONLY_IRONMAN)
 
     enum class IronmanProfitType(private val displayName: String) {
-        NONE("None"),
-        ONLY_IRONMAN("Only Ironman"),
-        ALL_PROFILES("All Profiles");
+        NONE("§cNone"),
+        ONLY_IRONMAN("§7Only Ironman"),
+        ALL_PROFILES("§2All Profiles");
         override fun toString(): String = displayName
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/ExcavatorProfitTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/ExcavatorProfitTrackerConfig.kt
@@ -8,6 +8,7 @@ import io.github.notenoughupdates.moulconfig.annotations.Accordion
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+import io.github.notenoughupdates.moulconfig.observer.Property
 
 class ExcavatorProfitTrackerConfig {
     @Expose
@@ -28,6 +29,11 @@ class ExcavatorProfitTrackerConfig {
     @ConfigOption(name = "Track Fossil Dust", desc = "Track Fossil Dust and use it for profit calculation.")
     @ConfigEditorBoolean
     var showFossilDust: Boolean = true
+
+    @Expose
+    @ConfigOption(name = "Ironman Profits", desc = "Removes the cost of Scrap from Profit.")
+    @ConfigEditorBoolean
+    var ironmanProfitCalc: Property<Boolean> = Property.of(true)
 
     @Expose
     @ConfigOption(

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/FossilExcavatorConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/FossilExcavatorConfig.kt
@@ -41,7 +41,7 @@ class FossilExcavatorConfig {
     @Expose
     @ConfigOption(name = "Ironman Profits", desc = "Select which profiles should use the Ironman price calculation option. §eRemoves the cost of Experience Bottles from the Profit.")
     @ConfigEditorDropdown
-    val ironmanProfitType: Property<IronmanProfitType> = Property.of(IronmanProfitType.NONE)
+    val ironmanProfitType: Property<IronmanProfitType> = Property.of(IronmanProfitType.ONLY_IRONMAN)
 
     enum class IronmanProfitType(private val displayName: String) {
         NONE("None"),

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/FossilExcavatorConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/FossilExcavatorConfig.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.config.FeatureToggle
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.Accordion
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDropdown
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 import io.github.notenoughupdates.moulconfig.observer.Property
 
@@ -38,10 +39,16 @@ class FossilExcavatorConfig {
     var profitPerExcavation: Boolean = false
 
     @Expose
-    @ConfigOption(name = "Ironman Profits", desc = "Removes the cost of Scrap from Profit.")
-    @ConfigEditorBoolean
-    @FeatureToggle
-    var ironmanProfitCalc: Property<Boolean> = Property.of(true)
+    @ConfigOption(name = "Ironman Profits", desc = "Select which profiles should use the Ironman price calculation option. §eRemoves the cost of Experience Bottles from the Profit.")
+    @ConfigEditorDropdown
+    val ironmanProfitType: Property<IronmanProfitType> = Property.of(IronmanProfitType.NONE)
+
+    enum class IronmanProfitType(private val displayName: String) {
+        NONE("None"),
+        ONLY_IRONMAN("Only Ironman"),
+        ALL_PROFILES("All Profiles");
+        override fun toString(): String = displayName
+    }
 
     @Expose
     @ConfigOption(name = "Glacite Powder Stack", desc = "Show Glacite Powder as stack size in the Fossil Excavator.")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/FossilExcavatorConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/FossilExcavatorConfig.kt
@@ -5,6 +5,7 @@ import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.Accordion
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+import io.github.notenoughupdates.moulconfig.observer.Property
 
 class FossilExcavatorConfig {
     @Expose
@@ -35,6 +36,12 @@ class FossilExcavatorConfig {
     @ConfigEditorBoolean
     @FeatureToggle
     var profitPerExcavation: Boolean = false
+
+    @Expose
+    @ConfigOption(name = "Ironman Profits", desc = "Removes the cost of Scrap from Profit.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var ironmanProfitCalc: Property<Boolean> = Property.of(true)
 
     @Expose
     @ConfigOption(name = "Glacite Powder Stack", desc = "Show Glacite Powder as stack size in the Fossil Excavator.")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/FossilExcavatorConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/glacite/FossilExcavatorConfig.kt
@@ -44,9 +44,9 @@ class FossilExcavatorConfig {
     val ironmanProfitType: Property<IronmanProfitType> = Property.of(IronmanProfitType.ONLY_IRONMAN)
 
     enum class IronmanProfitType(private val displayName: String) {
-        NONE("None"),
-        ONLY_IRONMAN("Only Ironman"),
-        ALL_PROFILES("All Profiles");
+        NONE("§cNone"),
+        ONLY_IRONMAN("§7Only Ironman"),
+        ALL_PROFILES("§2All Profiles");
         override fun toString(): String = displayName
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/nucleus/CrystalNucleusTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/nucleus/CrystalNucleusTrackerConfig.kt
@@ -60,9 +60,9 @@ class CrystalNucleusTrackerConfig {
     val ironmanProfitType: Property<IronmanProfitType> = Property.of(IronmanProfitType.ONLY_IRONMAN)
 
     enum class IronmanProfitType(private val displayName: String) {
-        NONE("None"),
-        ONLY_IRONMAN("Only Ironman"),
-        ALL_PROFILES("All Profiles");
+        NONE("§cNone"),
+        ONLY_IRONMAN("§7Only Ironman"),
+        ALL_PROFILES("§2All Profiles");
         override fun toString(): String = displayName
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/nucleus/CrystalNucleusTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/nucleus/CrystalNucleusTrackerConfig.kt
@@ -57,7 +57,7 @@ class CrystalNucleusTrackerConfig {
     @Expose
     @ConfigOption(name = "Ironman Profits", desc = "Select which profiles should use the Ironman price calculation option. §eRemoves the cost of Jungle Keys & Automaton Parts from the Profit.")
     @ConfigEditorDropdown
-    val ironmanProfitType: Property<IronmanProfitType> = Property.of(IronmanProfitType.NONE)
+    val ironmanProfitType: Property<IronmanProfitType> = Property.of(IronmanProfitType.ONLY_IRONMAN)
 
     enum class IronmanProfitType(private val displayName: String) {
         NONE("None"),

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/nucleus/CrystalNucleusTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/nucleus/CrystalNucleusTrackerConfig.kt
@@ -55,6 +55,11 @@ class CrystalNucleusTrackerConfig {
     }
 
     @Expose
+    @ConfigOption(name = "Ironman Profits", desc = "Removes the cost of Jungle Keys & Automaton Parts from Profit.")
+    @ConfigEditorBoolean
+    var ironmanProfitCalc: Property<Boolean> = Property.of(true)
+
+    @Expose
     @ConfigOption(
         name = "Tracker Settings",
         desc = ""

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/nucleus/CrystalNucleusTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/nucleus/CrystalNucleusTrackerConfig.kt
@@ -53,15 +53,9 @@ class CrystalNucleusTrackerConfig {
 
         override fun toString(): String = displayName
     }
-    /*
-    @Expose
-    @ConfigOption(name = "Ironman Profits", desc = "Removes the cost of Jungle Keys & Automaton Parts from Profit.")
-    @ConfigEditorBoolean
-    var ironmanProfitCalc: Property<Boolean> = Property.of(true)*/
 
-    //Alternate Version of the Selector
     @Expose
-    @ConfigOption(name = "Ironman Profits", desc = "Select which profiles should use the Ironman price calculation option.")
+    @ConfigOption(name = "Ironman Profits", desc = "Select which profiles should use the Ironman price calculation option. §eRemoves the cost of Jungle Keys & Automaton Parts from the Profit.")
     @ConfigEditorDropdown
     val ironmanProfitType: Property<IronmanProfitType> = Property.of(IronmanProfitType.NONE)
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/nucleus/CrystalNucleusTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/nucleus/CrystalNucleusTrackerConfig.kt
@@ -53,11 +53,24 @@ class CrystalNucleusTrackerConfig {
 
         override fun toString(): String = displayName
     }
-
+    /*
     @Expose
     @ConfigOption(name = "Ironman Profits", desc = "Removes the cost of Jungle Keys & Automaton Parts from Profit.")
     @ConfigEditorBoolean
-    var ironmanProfitCalc: Property<Boolean> = Property.of(true)
+    var ironmanProfitCalc: Property<Boolean> = Property.of(true)*/
+
+    //Alternate Version of the Selector
+    @Expose
+    @ConfigOption(name = "Ironman Profits", desc = "Select which profiles should use the Ironman price calculation option.")
+    @ConfigEditorDropdown
+    val ironmanProfitType: Property<IronmanProfitType> = Property.of(IronmanProfitType.NONE)
+
+    enum class IronmanProfitType(private val displayName: String) {
+        NONE("None"),
+        ONLY_IRONMAN("Only Ironman"),
+        ALL_PROFILES("All Profiles");
+        override fun toString(): String = displayName
+    }
 
     @Expose
     @ConfigOption(

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsProfitTracker.kt
@@ -9,6 +9,7 @@ import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ItemAddManager
+import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.ItemAddEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
@@ -17,6 +18,7 @@ import at.hannibal2.skyhanni.events.experiments.TableTaskCompletedEvent
 import at.hannibal2.skyhanni.events.experiments.TableXPBottleUsedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.ConditionalUtils.onToggle
 import at.hannibal2.skyhanni.utils.InventoryDetector
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemPriceSource
@@ -188,6 +190,11 @@ object ExperimentsProfitTracker {
         return npcPrice.coerceAtLeast(price).toInt()
     }
 
+    @HandleEvent
+    fun onConfigLoad(event: ConfigLoadEvent) {
+        config.ironmanProfitCalc.onToggle(tracker::update)
+    }
+
     private fun drawDisplay(data: Data): List<Searchable> = buildList {
         addSearchString("§e§lExperiments Profit Tracker")
         val startCost = when (SkyHanniMod.feature.misc.tracker.priceSource) {
@@ -204,16 +211,28 @@ object ExperimentsProfitTracker {
 
         val startCostFormat = startCost.absoluteValue
         val bitCostFormat = data.bitCost
-        add(
-            Renderable.hoverTips(
-                "§eTotal Cost: §c-${startCostFormat.shortFormat()}§e/§b-${bitCostFormat.shortFormat()}",
-                listOf(
-                    "§7You paid §c${startCostFormat.addSeparators()} §7coins and",
-                    "§b${bitCostFormat.addSeparators()} §7bits for starting",
-                    "§7experiments.",
-                ),
-            ).toSearchable(),
-        )
+        if (config.ironmanProfitCalc.get()) {
+            add(
+                Renderable.hoverTips(
+                    "§eTotal Cost: §b${bitCostFormat.shortFormat()}",
+                    listOf(
+                        "§7You paid §b${bitCostFormat.addSeparators()} §7bits",
+                        "§7for starting experiments.",
+                    ),
+                ).toSearchable(),
+            )
+        } else {
+            add(
+                Renderable.hoverTips(
+                    "§eTotal Cost: §c${startCostFormat.shortFormat()}§e/§b${bitCostFormat.shortFormat()}",
+                    listOf(
+                        "§7You paid §c${startCostFormat.addSeparators()} §7coins and",
+                        "§b${bitCostFormat.addSeparators()} §7bits for starting",
+                        "§7experiments.",
+                    ),
+                ).toSearchable(),
+            )
+        }
         val duration = data.getTotalUptime()
         addAll(tracker.addTotalProfit(profit, data.experimentsDone, "experiment", duration, "Experiments"))
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsProfitTracker.kt
@@ -7,6 +7,7 @@ import at.hannibal2.skyhanni.api.ExperimentationTableApi.experimentRenewPattern
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
+import at.hannibal2.skyhanni.config.features.inventory.experimentationtable.ExperimentsProfitTrackerConfig.IronmanProfitType
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ItemAddManager
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
@@ -32,6 +33,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.pluralize
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut
@@ -192,7 +194,7 @@ object ExperimentsProfitTracker {
 
     @HandleEvent
     fun onConfigLoad(event: ConfigLoadEvent) {
-        config.ironmanProfitCalc.onToggle(tracker::update)
+        config.ironmanProfitType.onToggle(tracker::update)
     }
 
     private fun drawDisplay(data: Data): List<Searchable> = buildList {
@@ -211,7 +213,7 @@ object ExperimentsProfitTracker {
 
         val startCostFormat = startCost.absoluteValue
         val bitCostFormat = data.bitCost
-        if (config.ironmanProfitCalc.get()) {
+        if (config.ironmanProfitType.get() == IronmanProfitType.NONE || (config.ironmanProfitType.get() == IronmanProfitType.ONLY_IRONMAN && !SkyBlockUtils.isIronmanProfile)) {
             add(
                 Renderable.hoverTips(
                     "§eTotal Cost: §b${bitCostFormat.shortFormat()}",

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusProfitPer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusProfitPer.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.api.event.HandleEvent.Companion.HIGH
 import at.hannibal2.skyhanni.config.features.mining.nucleus.CrystalNucleusTrackerConfig
+import at.hannibal2.skyhanni.config.features.mining.nucleus.CrystalNucleusTrackerConfig.IronmanProfitType
 import at.hannibal2.skyhanni.events.mining.CrystalNucleusLootEvent
 import at.hannibal2.skyhanni.features.mining.crystalhollows.CrystalNucleusApi.JUNGLE_KEY_ITEM
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -46,16 +47,16 @@ object CrystalNucleusProfitPer {
 
         val jungleKeyCost = JUNGLE_KEY_ITEM.getPrice()
         val partsCost = CrystalNucleusApi.getPrecursorRunPrice { it.getPrice() }
-        if (config.ironmanProfitType.get() == CrystalNucleusTrackerConfig.IronmanProfitType.NONE ||
-                (config.ironmanProfitType.get() == CrystalNucleusTrackerConfig.IronmanProfitType.ONLY_IRONMAN && !SkyBlockUtils.isIronmanProfile)) {
+        if (config.ironmanProfitType.get() == IronmanProfitType.NONE ||
+                (config.ironmanProfitType.get() == IronmanProfitType.ONLY_IRONMAN && !SkyBlockUtils.isIronmanProfile)) {
             totalProfit -= (jungleKeyCost + partsCost)
         }
 
         val profitPrefix = if (totalProfit < 0) "§c" else "§6"
         val totalMessage = "Profit for Crystal Nucleus Run§e: $profitPrefix${totalProfit.shortFormat()}"
 
-        if (config.ironmanProfitType.get() == CrystalNucleusTrackerConfig.IronmanProfitType.NONE ||
-                (config.ironmanProfitType.get() == CrystalNucleusTrackerConfig.IronmanProfitType.ONLY_IRONMAN && !SkyBlockUtils.isIronmanProfile)) {
+        if (config.ironmanProfitType.get() == IronmanProfitType.NONE ||
+                (config.ironmanProfitType.get() == IronmanProfitType.ONLY_IRONMAN && !SkyBlockUtils.isIronmanProfile)) {
             hover.add("")
             hover.add("§cUsed §5Jungle Key§7: §c-${jungleKeyCost.shortFormat()}")
             hover.add("§cUsed §9Robot Parts§7: §c-${partsCost.shortFormat()}")

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusProfitPer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusProfitPer.kt
@@ -44,14 +44,18 @@ object CrystalNucleusProfitPer {
 
         val jungleKeyCost = JUNGLE_KEY_ITEM.getPrice()
         val partsCost = CrystalNucleusApi.getPrecursorRunPrice { it.getPrice() }
-        totalProfit -= (jungleKeyCost + partsCost)
+        if (!config.ironmanProfitCalc.get()) {
+            totalProfit -= (jungleKeyCost + partsCost)
+        }
 
         val profitPrefix = if (totalProfit < 0) "§c" else "§6"
         val totalMessage = "Profit for Crystal Nucleus Run§e: $profitPrefix${totalProfit.shortFormat()}"
 
-        hover.add("")
-        hover.add("§cUsed §5Jungle Key§7: §c-${jungleKeyCost.shortFormat()}")
-        hover.add("§cUsed §9Robot Parts§7: §c-${partsCost.shortFormat()}")
+        if (!config.ironmanProfitCalc.get()) {
+            hover.add("")
+            hover.add("§cUsed §5Jungle Key§7: §c-${jungleKeyCost.shortFormat()}")
+            hover.add("§cUsed §9Robot Parts§7: §c-${partsCost.shortFormat()}")
+        }
         hover.add("")
         hover.add("§e$totalMessage")
 

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusProfitPer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusProfitPer.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.mining.crystalhollows
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.api.event.HandleEvent.Companion.HIGH
+import at.hannibal2.skyhanni.config.features.mining.nucleus.CrystalNucleusTrackerConfig
 import at.hannibal2.skyhanni.events.mining.CrystalNucleusLootEvent
 import at.hannibal2.skyhanni.features.mining.crystalhollows.CrystalNucleusApi.JUNGLE_KEY_ITEM
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -10,6 +11,7 @@ import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPrice
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPriceName
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
+import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sortedDesc
 
@@ -44,14 +46,16 @@ object CrystalNucleusProfitPer {
 
         val jungleKeyCost = JUNGLE_KEY_ITEM.getPrice()
         val partsCost = CrystalNucleusApi.getPrecursorRunPrice { it.getPrice() }
-        if (!config.ironmanProfitCalc.get()) {
+        if (config.ironmanProfitType.get() == CrystalNucleusTrackerConfig.IronmanProfitType.NONE ||
+                (config.ironmanProfitType.get() == CrystalNucleusTrackerConfig.IronmanProfitType.ONLY_IRONMAN && !SkyBlockUtils.isIronmanProfile)) {
             totalProfit -= (jungleKeyCost + partsCost)
         }
 
         val profitPrefix = if (totalProfit < 0) "§c" else "§6"
         val totalMessage = "Profit for Crystal Nucleus Run§e: $profitPrefix${totalProfit.shortFormat()}"
 
-        if (!config.ironmanProfitCalc.get()) {
+        if (config.ironmanProfitType.get() == CrystalNucleusTrackerConfig.IronmanProfitType.NONE ||
+                (config.ironmanProfitType.get() == CrystalNucleusTrackerConfig.IronmanProfitType.ONLY_IRONMAN && !SkyBlockUtils.isIronmanProfile)) {
             hover.add("")
             hover.add("§cUsed §5Jungle Key§7: §c-${jungleKeyCost.shortFormat()}")
             hover.add("§cUsed §9Robot Parts§7: §c-${partsCost.shortFormat()}")

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusTracker.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.api.event.HandleEvent.Companion.HIGH
 import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
+import at.hannibal2.skyhanni.config.features.mining.nucleus.CrystalNucleusTrackerConfig
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ItemAddManager
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
@@ -18,6 +19,7 @@ import at.hannibal2.skyhanni.features.mining.crystalhollows.CrystalNucleusApi.EP
 import at.hannibal2.skyhanni.features.mining.crystalhollows.CrystalNucleusApi.JUNGLE_KEY_ITEM
 import at.hannibal2.skyhanni.features.mining.crystalhollows.CrystalNucleusApi.LEGENDARY_BAL_ITEM
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ConditionalUtils.onToggle
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.formatPercentage
@@ -37,6 +39,7 @@ import at.hannibal2.skyhanni.utils.tracker.ItemTrackerData
 import at.hannibal2.skyhanni.utils.tracker.SessionUptime
 import at.hannibal2.skyhanni.utils.tracker.SkyHanniItemTracker
 import com.google.gson.annotations.Expose
+import kotlin.toString
 
 @SkyHanniModule
 object CrystalNucleusTracker {
@@ -126,6 +129,7 @@ object CrystalNucleusTracker {
     @HandleEvent
     fun onConfigLoad(event: ConfigLoadEvent) {
         config.professorUsage.onToggle(tracker::update)
+        config.ironmanProfitType.onToggle(tracker::update)
     }
 
     private fun drawDisplay(data: Data): List<Searchable> = buildList {
@@ -135,7 +139,9 @@ object CrystalNucleusTracker {
         if (runsCompleted > 0) {
             var profit = tracker.drawItems(data, { true }, this)
             val jungleKeyCost: Double = tracker.getPricePer(JUNGLE_KEY_ITEM) * runsCompleted
-            if (!config.ironmanProfitCalc.get()) {
+            if (config.ironmanProfitType.get() == CrystalNucleusTrackerConfig.IronmanProfitType.NONE ||
+                (config.ironmanProfitType.get() == CrystalNucleusTrackerConfig.IronmanProfitType.ONLY_IRONMAN && !SkyBlockUtils.isIronmanProfile)) {
+
                 profit -= jungleKeyCost
                 val jungleKeyCostFormat = jungleKeyCost.shortFormat()
                 add(
@@ -161,7 +167,8 @@ object CrystalNucleusTracker {
             else rawConfigString
             val usageTotal = if (usesApparatus) runsCompleted else runsCompleted * 6
 
-            if (!config.ironmanProfitCalc.get()) {
+            if (config.ironmanProfitType.get() == CrystalNucleusTrackerConfig.IronmanProfitType.NONE ||
+                (config.ironmanProfitType.get() == CrystalNucleusTrackerConfig.IronmanProfitType.ONLY_IRONMAN && !SkyBlockUtils.isIronmanProfile)) {
                 profit -= totalSapphireCost
                 val totalSapphireCostFormat = totalSapphireCost.shortFormat()
                 add(

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusTracker.kt
@@ -135,17 +135,19 @@ object CrystalNucleusTracker {
         if (runsCompleted > 0) {
             var profit = tracker.drawItems(data, { true }, this)
             val jungleKeyCost: Double = tracker.getPricePer(JUNGLE_KEY_ITEM) * runsCompleted
-            profit -= jungleKeyCost
-            val jungleKeyCostFormat = jungleKeyCost.shortFormat()
-            add(
-                Renderable.hoverTips(
-                    " §7${runsCompleted}x §5Jungle Key§7: §c-$jungleKeyCostFormat",
-                    tips = listOf(
-                        "§7You lost §c$jungleKeyCostFormat §7of total profit",
-                        "§7due to §5Jungle Keys§7.",
-                    ),
-                ).toSearchable("Jungle Key"),
-            )
+            if (!config.ironmanProfitCalc.get()) {
+                profit -= jungleKeyCost
+                val jungleKeyCostFormat = jungleKeyCost.shortFormat()
+                add(
+                    Renderable.hoverTips(
+                        " §7${runsCompleted}x §5Jungle Key§7: §c-$jungleKeyCostFormat",
+                        tips = listOf(
+                            "§7You lost §c$jungleKeyCostFormat §7of total profit",
+                            "§7due to §5Jungle Keys§7.",
+                        ),
+                    ).toSearchable("Jungle Key"),
+                )
+            }
 
             val usesApparatus = CrystalNucleusApi.usesApparatus()
             val partsCost = CrystalNucleusApi.getPrecursorRunPrice { tracker.getPricePer(it) }
@@ -159,17 +161,19 @@ object CrystalNucleusTracker {
             else rawConfigString
             val usageTotal = if (usesApparatus) runsCompleted else runsCompleted * 6
 
-            profit -= totalSapphireCost
-            val totalSapphireCostFormat = totalSapphireCost.shortFormat()
-            add(
-                Renderable.hoverTips(
-                    " §7${usageTotal}x $usageString§7: §c-$totalSapphireCostFormat",
-                    tips = listOf(
-                        "§7You lost §c$totalSapphireCostFormat §7of total profit",
-                        "§7due to $usageString§7.",
-                    ),
-                ).toSearchable(usageString.removeColor()),
-            )
+            if (!config.ironmanProfitCalc.get()) {
+                profit -= totalSapphireCost
+                val totalSapphireCostFormat = totalSapphireCost.shortFormat()
+                add(
+                    Renderable.hoverTips(
+                        " §7${usageTotal}x $usageString§7: §c-$totalSapphireCostFormat",
+                        tips = listOf(
+                            "§7You lost §c$totalSapphireCostFormat §7of total profit",
+                            "§7due to $usageString§7.",
+                        ),
+                    ).toSearchable(usageString.removeColor()),
+                )
+            }
 
             add(
                 Renderable.hoverTips(

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalNucleusTracker.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.api.event.HandleEvent.Companion.HIGH
 import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.config.features.mining.nucleus.CrystalNucleusTrackerConfig
+import at.hannibal2.skyhanni.config.features.mining.nucleus.CrystalNucleusTrackerConfig.IronmanProfitType
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ItemAddManager
 import at.hannibal2.skyhanni.events.ConfigLoadEvent
@@ -139,8 +140,8 @@ object CrystalNucleusTracker {
         if (runsCompleted > 0) {
             var profit = tracker.drawItems(data, { true }, this)
             val jungleKeyCost: Double = tracker.getPricePer(JUNGLE_KEY_ITEM) * runsCompleted
-            if (config.ironmanProfitType.get() == CrystalNucleusTrackerConfig.IronmanProfitType.NONE ||
-                (config.ironmanProfitType.get() == CrystalNucleusTrackerConfig.IronmanProfitType.ONLY_IRONMAN && !SkyBlockUtils.isIronmanProfile)) {
+            if (config.ironmanProfitType.get() == IronmanProfitType.NONE ||
+                (config.ironmanProfitType.get() == IronmanProfitType.ONLY_IRONMAN && !SkyBlockUtils.isIronmanProfile)) {
 
                 profit -= jungleKeyCost
                 val jungleKeyCostFormat = jungleKeyCost.shortFormat()
@@ -167,8 +168,8 @@ object CrystalNucleusTracker {
             else rawConfigString
             val usageTotal = if (usesApparatus) runsCompleted else runsCompleted * 6
 
-            if (config.ironmanProfitType.get() == CrystalNucleusTrackerConfig.IronmanProfitType.NONE ||
-                (config.ironmanProfitType.get() == CrystalNucleusTrackerConfig.IronmanProfitType.ONLY_IRONMAN && !SkyBlockUtils.isIronmanProfile)) {
+            if (config.ironmanProfitType.get() == IronmanProfitType.NONE ||
+                (config.ironmanProfitType.get() == IronmanProfitType.ONLY_IRONMAN && !SkyBlockUtils.isIronmanProfile)) {
                 profit -= totalSapphireCost
                 val totalSapphireCostFormat = totalSapphireCost.shortFormat()
                 add(

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ExcavatorProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ExcavatorProfitTracker.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
+import at.hannibal2.skyhanni.config.features.mining.glacite.ExcavatorProfitTrackerConfig.IronmanProfitType
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ItemAddManager
 import at.hannibal2.skyhanni.events.IslandChangeEvent
@@ -71,7 +72,8 @@ object ExcavatorProfitTracker {
                 listOf("§7You excavated §e${timesExcavated.addSeparators()} §7times."),
             ).toSearchable(),
         )
-        if (!config.ironmanProfitCalc.get()) {
+        if (config.ironmanProfitType.get() == IronmanProfitType.NONE ||
+            (config.ironmanProfitType.get() == IronmanProfitType.ONLY_IRONMAN && !SkyBlockUtils.isIronmanProfile)) {
             profit = addScrap(timesExcavated, profit)
         }
         if (config.showFossilDust) {

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ExcavatorProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ExcavatorProfitTracker.kt
@@ -71,8 +71,9 @@ object ExcavatorProfitTracker {
                 listOf("§7You excavated §e${timesExcavated.addSeparators()} §7times."),
             ).toSearchable(),
         )
-
-        profit = addScrap(timesExcavated, profit)
+        if (!config.ironmanProfitCalc.get()) {
+            profit = addScrap(timesExcavated, profit)
+        }
         if (config.showFossilDust) {
             profit = addFossilDust(data.fossilDustGained, profit)
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ProfitPerExcavation.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ProfitPerExcavation.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.features.mining.fossilexcavator
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.features.mining.glacite.FossilExcavatorConfig.IronmanProfitType
 import at.hannibal2.skyhanni.events.mining.FossilExcavationEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
@@ -10,6 +11,7 @@ import at.hannibal2.skyhanni.utils.ItemUtils.repoItemName
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
+import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sortedDesc
 
 @SkyHanniModule
@@ -40,7 +42,8 @@ object ProfitPerExcavation {
         val scrapPrice = scrapItem.getPrice()
         map["${scrapItem.repoItemName}: §c-${scrapPrice.shortFormat()}"] = -scrapPrice
 
-        if (!config.ironmanProfitCalc.get()) {
+        if (config.ironmanProfitType.get() == IronmanProfitType.NONE ||
+            (config.ironmanProfitType.get() == IronmanProfitType.ONLY_IRONMAN && !SkyBlockUtils.isIronmanProfile)) {
             totalProfit -= scrapPrice
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ProfitPerExcavation.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ProfitPerExcavation.kt
@@ -39,7 +39,10 @@ object ProfitPerExcavation {
 
         val scrapPrice = scrapItem.getPrice()
         map["${scrapItem.repoItemName}: §c-${scrapPrice.shortFormat()}"] = -scrapPrice
-        totalProfit -= scrapPrice
+
+        if (!config.ironmanProfitCalc.get()) {
+            totalProfit -= scrapPrice
+        }
 
         val hover = map.sortedDesc().keys.toMutableList()
         val profitPrefix = if (totalProfit < 0) "§c" else "§6"


### PR DESCRIPTION
<!-- remove all unused parts 

The title of your PR should be descriptive and concise. It should be in the format of `Type: Description`. For example, `Feature: Add new command` or `Fix: Bug in command`. If there are multiple types of changes these can be separated by a plus. For example, `Feature + Fix: Add new command and fix bug in command`.
Commonly used labels are Improvement, Backend, Feature and Fix.

## PR Reviews

When your PR is marked as ready for review, some of our maintainers will look through your code to make sure everything is good to go. In order to do this, they may request some changes you will need to do, **or fix smaller stuff (like merge conflicts) for you**. If a maintainer has reviewed your PR, make sure to **pull any of their changes** into your local project before doing more work on your code. Having maintainers fix small stuff for you helps us speed up the process of merging your PR, so if some of your systems warrant further care, be sure to let us know (preferably with a code comment).

Make sure to only mark your PR as "Ready to review" when it is. If you still want to do major changes, you can keep a draft PR open until then.

-->

## What
Added a toggle in the settings for the Crystal Nucleus, Fossil Excavator and Enchanting Table.
Changing the way Profits are being calculated. Reopen from old PR #3918.

Crystal Nucleus Tracker:
- Removed the inclusion of the Jungle Key & Automaton Parts from the Total Profit

<details>
<summary>Images</summary>

![Screenshot 2025-05-01 153750](https://github.com/user-attachments/assets/c47ea6c0-2eaf-4d2f-ae58-31bf0673defe)
![Screenshot 2025-05-01 153821](https://github.com/user-attachments/assets/9e53a7dc-0689-450b-9e2b-60b643b3521d)

</details>

Fossil Excavator:
- Removed the inclusion of Scrap from the Total Profit

<details>
<summary>Images</summary>

![Screenshot 2025-05-01 154138](https://github.com/user-attachments/assets/0021e7b2-7047-44b1-823b-ab2210357523)
![Screenshot 2025-05-01 154349](https://github.com/user-attachments/assets/e8bf3b28-7109-4dac-b846-97b5885c82b4)


</details>

Enchanting Table:
- Removed the starting cost from the Total Profit

<details>
<summary>Images</summary>

![Screenshot 2025-05-01 153902](https://github.com/user-attachments/assets/f7b798f6-4cf1-4630-8e9d-e48d09064ae7)
![Screenshot 2025-05-01 154016](https://github.com/user-attachments/assets/8ab3368b-19ce-4fd3-95ed-37f2099827a0)

</details>

## Changelog Improvements
+ Different Profit Calculations for Ironman. - Mayhan


