### PR TITLE
Fix: Don't suppress discontinued version notification if extraInfo is missing

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
@@ -296,7 +296,7 @@ object UpdateManager {
         if (hasWarned) return
 
         if (PlatformUtils.MC_VERSION in discontinuedVersions) {
-            val extraInfo = discontinuedVersions[PlatformUtils.MC_VERSION]?.extraInfo ?: return
+            val extraInfo = discontinuedVersions[PlatformUtils.MC_VERSION]?.extraInfo.orEmpty()
 
             val notification = SkyHanniNotification(
                 listOf(


### PR DESCRIPTION
## What
UpdateManager was skipping sending the discontinued version notification if `extraInfo` was missing, even though there is already a perfectly functional notification that can be sent even without `extraInfo`.

If necessary, I can add a field to disable the notification, but this subtle behavior is not a good way to go about it.

## Changelog Fixes
+ Fixed discontinued Minecraft version notification not being sent in some cases. - Luna

