### PR TITLE
Fix: Fishing tracker 

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/tracker/FishingProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/tracker/FishingProfitTracker.kt
@@ -195,6 +195,7 @@ object FishingProfitTracker {
 
     private var slot9Item: NeuInternalName? = null
 
+    @HandleEvent
     fun onInventoryUpdate(event: OwnInventoryItemUpdateEvent) {
         if (event.slot == 44) {
             slot9Item = event.itemStack.getInternalNameOrNull()

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/tracker/FishingProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/tracker/FishingProfitTracker.kt
@@ -7,6 +7,7 @@ import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.data.ItemAddManager
 import at.hannibal2.skyhanni.data.jsonobjects.repo.FishingProfitItemsJson
 import at.hannibal2.skyhanni.events.ItemAddEvent
+import at.hannibal2.skyhanni.events.OwnInventoryItemUpdateEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.fishing.FishingBobberCastEvent
@@ -19,6 +20,7 @@ import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.ItemCategory
+import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
@@ -191,9 +193,18 @@ object FishingProfitTracker {
         }
     }
 
+    private var slot9Item: NeuInternalName? = null
+
+    fun onInventoryUpdate(event: OwnInventoryItemUpdateEvent) {
+        if (event.slot == 44) {
+            slot9Item = event.itemStack.getInternalNameOrNull()
+        }
+    }
+
     @HandleEvent
     fun onItemAdd(event: ItemAddEvent) {
         if (!isEnabled()) return
+        if (event.internalName == slot9Item) return
 
         if (event.source == ItemAddManager.Source.COMMAND) {
             if (!config.enabled) return


### PR DESCRIPTION

## What
Fishing tracker now ignores hotbar slot 9 so the baits don't get added to profit
bandage fix, optimal would be ignoring hotbar slot 9 globally


## Changelog Fixes
+ Fixed the Fishing Profit Tracker detecting the baits in hotbar slot 9. - Rain