### PR TITLE
Improvement: Use Hypixel Items API for Minion XP

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/other/SkyblockItemsDataJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/other/SkyblockItemsDataJson.kt
@@ -12,4 +12,9 @@ data class SkyblockItemData(
     @Expose @SerializedName("npc_sell_price") val npcPrice: Double?,
     @Expose @SerializedName("motes_sell_price") val motesPrice: Double?,
     @Expose @SerializedName("stats") val stats: Map<String, Int>?,
+    @Expose val experience: Map<String, SkyblockItemExperience>?,
+)
+
+data class SkyblockItemExperience(
+    @Expose @SerializedName("MINION_STORAGE") val minionStorage: Double?,
 )

--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/MinionXPJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/MinionXPJson.kt
@@ -1,8 +1,0 @@
-package at.hannibal2.skyhanni.data.jsonobjects.repo
-
-import com.google.gson.annotations.Expose
-import com.google.gson.annotations.SerializedName
-
-data class MinionXPJson(
-    @Expose @SerializedName("minion_xp") val minionXP: Map<String, Map<String, Double>>,
-)

--- a/src/main/java/at/hannibal2/skyhanni/events/MinionOpenEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/MinionOpenEvent.kt
@@ -1,9 +1,15 @@
 package at.hannibal2.skyhanni.events
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.SafeItemStack
 
+@PrimaryFunction("onMinionOpen")
 class MinionOpenEvent(val inventoryName: String, val inventoryItems: Map<Int, SafeItemStack>) : SkyHanniEvent()
+
+@PrimaryFunction("onMinionClose")
 class MinionCloseEvent : SkyHanniEvent()
+
+@PrimaryFunction("onMinionStorageOpen")
 class MinionStorageOpenEvent(val position: LorenzVec?, val inventoryItems: Map<Int, SafeItemStack>) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarApi.kt
@@ -38,7 +38,6 @@ import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.equalsIgnoreColor
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
-import at.hannibal2.skyhanni.utils.api.ApiUtils
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.client.gui.screens.inventory.ContainerScreen
@@ -50,9 +49,6 @@ object BazaarApi {
 
     private val storage get() = ProfileStorageData.playerSpecific?.bazaar
 
-    private var loadedNpcPriceData = false
-
-    val holder = HypixelItemApi()
     var inBazaarInventory = false
     private var currentSearchedItem = ""
 
@@ -233,15 +229,6 @@ object BazaarApi {
         if (sellInstantly.hoverName.formattedTextCompatLeadingWhiteLessResets() != "§6Sell Instantly") return
         taxPattern.firstMatcher(sellInstantly.getLore()) {
             taxRate = group("tax").formatDouble()
-        }
-    }
-
-    @HandleEvent
-    private fun onTick() {
-        if (ApiUtils.isHypixelItemsDisabled()) return
-        if (!loadedNpcPriceData) {
-            loadedNpcPriceData = true
-            holder.start()
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/HypixelItemApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/HypixelItemApi.kt
@@ -1,80 +1,144 @@
 package at.hannibal2.skyhanni.features.inventory.bazaar
 
-import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.SkyHanniMod.launch
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigManager
 import at.hannibal2.skyhanni.data.jsonobjects.other.SkyblockItemsDataJson
 import at.hannibal2.skyhanni.data.jsonobjects.repo.neu.NeuGeorgeJson
+import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.NeuRepositoryReloadEvent
 import at.hannibal2.skyhanni.features.rift.RiftApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ItemUtils
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuItems
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.api.ApiStaticGetPath
 import at.hannibal2.skyhanni.utils.api.ApiUtils
+import at.hannibal2.skyhanni.utils.coroutines.CoroutineSettings
 import at.hannibal2.skyhanni.utils.json.fromJson
+import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
-class HypixelItemApi {
-    @SkyHanniModule
-    companion object {
-        // prices = george prices + npc prices
-        private var prices = mapOf<NeuInternalName, Double>()
-        private var npcPrices = mapOf<NeuInternalName, Double>()
-        private var georgePrices = mapOf<NeuInternalName, Double>()
-        private var minionStorageXP = mapOf<NeuInternalName, Map<String, Double>>()
-
-        fun getNpcPrice(internalName: NeuInternalName) = prices[internalName]
-
-        fun getMinionStorageXP(internalName: NeuInternalName): Map<String, Double>? =
-            minionStorageXP[internalName]
-
-        @HandleEvent
-        private fun onNeuRepoReload(event: NeuRepositoryReloadEvent) {
-            val constant = event.getConstant<NeuGeorgeJson>("george")
-            georgePrices = constant.prices ?: return
-            prices = georgePrices + npcPrices
-        }
-
-        internal fun processItemData(itemsData: SkyblockItemsDataJson) {
-            val npcPrices = mutableMapOf<NeuInternalName, Double>()
-            val motesPrice = mutableMapOf<NeuInternalName, Double>()
-            val allStats = mutableMapOf<NeuInternalName, Map<String, Int>>()
-            val minionStorageXP = mutableMapOf<NeuInternalName, Map<String, Double>>()
-            for (item in itemsData.items) {
-                val neuItemId = NeuItems.transHypixelNameToInternalName(item.id ?: continue)
-                item.npcPrice?.let { npcPrices[neuItemId] = it }
-                item.motesPrice?.let { motesPrice[neuItemId] = it }
-                item.stats?.let { stats -> allStats[neuItemId] = stats }
-                item.experience?.mapNotNull { (skill, experience) ->
-                    experience.minionStorage?.let { skill to it }
-                }?.toMap()?.takeIf { it.isNotEmpty() }?.let { minionStorageXP[neuItemId] = it }
-            }
-            ItemUtils.updateBaseStats(allStats)
-            RiftApi.motesPrice = motesPrice
-            HypixelItemApi.npcPrices = npcPrices
-            HypixelItemApi.minionStorageXP = minionStorageXP
-            prices = georgePrices + npcPrices
-        }
-    }
-
+@SkyHanniModule
+object HypixelItemApi {
     private val hypixelItemStatic = ApiStaticGetPath(
         "https://api.hypixel.net/v2/resources/skyblock/items",
         "Hypixel SkyBlock Items",
     )
 
-    private suspend fun loadItemData() {
-        val (_, apiResponseData) = ApiUtils.getJsonResponse(hypixelItemStatic).assertSuccessWithData() ?: return
-        val itemsData = ConfigManager.gson.fromJson<SkyblockItemsDataJson>(apiResponseData)
-        processItemData(itemsData)
-    }
+    private const val HIDDEN_FAILED_ATTEMPTS = 3
 
-    fun start() {
-        SkyHanniMod.launchIOCoroutine("hypixel item api fetch", timeout = 1.minutes) {
-            loadItemData()
+    private val itemFetchCoroutine = CoroutineSettings("hypixel item api fetch", timeout = 1.minutes)
+
+    // prices = george prices + npc prices
+    private var prices = mapOf<NeuInternalName, Double>()
+    private var npcPrices = mapOf<NeuInternalName, Double>()
+    private var georgePrices = mapOf<NeuInternalName, Double>()
+    private var minionStorageXP = mapOf<NeuInternalName, Map<String, Double>>()
+
+    private val isFetching = AtomicBoolean(false)
+    private var lastSuccessfulFetch = SimpleTimeMark.farPast()
+    private var nextFetchTime = SimpleTimeMark.farPast()
+    private var failedAttempts = 0
+
+    fun getNpcPrice(internalName: NeuInternalName) = prices[internalName]
+
+    fun getMinionStorageXP(internalName: NeuInternalName): Map<String, Double>? =
+        minionStorageXP[internalName]
+
+    @HandleEvent
+    private fun onDebugDataCollect(event: DebugDataCollectEvent) {
+        event.title("Hypixel Items Data Fetcher from API")
+
+        val data = listOf(
+            "failedAttempts: $failedAttempts",
+            "nextFetchTime: ${nextFetchTime.timeUntil()}",
+            "lastSuccessfulFetch: ${lastSuccessfulFetch.passedSince()}",
+        )
+
+        if (failedAttempts == 0) {
+            event.addIrrelevant(data)
+        } else {
+            event.addData(data)
         }
-
-        // TODO use SecondPassedEvent
     }
+
+    @HandleEvent
+    private fun onNeuRepoReload(event: NeuRepositoryReloadEvent) {
+        val constant = event.getConstant<NeuGeorgeJson>("george")
+        georgePrices = constant.prices ?: return
+        prices = georgePrices + npcPrices
+    }
+
+    @HandleEvent
+    private fun onSecondPassed() {
+        if (!canFetch()) return
+        itemFetchCoroutine.launch { fetchAndProcessItemData() }
+    }
+
+    private suspend fun fetchAndProcessItemData() {
+        if (!isFetching.compareAndSet(expectedValue = false, newValue = true)) return
+
+        nextFetchTime = SimpleTimeMark.now() + 1.hours
+        try {
+            val (_, jsonResponse) = ApiUtils.getJsonResponse(hypixelItemStatic).assertSuccessWithData()
+                ?: return onError(Exception("Failed to fetch item data from Hypixel API"))
+            val itemsData = ConfigManager.gson.fromJson<SkyblockItemsDataJson>(jsonResponse)
+            processItemData(itemsData)
+            failedAttempts = 0
+            lastSuccessfulFetch = SimpleTimeMark.now()
+        } catch (e: Exception) {
+            onError(e)
+        } finally {
+            isFetching.store(false)
+        }
+    }
+
+    internal fun processItemData(itemsData: SkyblockItemsDataJson) {
+        val npcPrices = mutableMapOf<NeuInternalName, Double>()
+        val motesPrice = mutableMapOf<NeuInternalName, Double>()
+        val allStats = mutableMapOf<NeuInternalName, Map<String, Int>>()
+        val minionStorageXP = mutableMapOf<NeuInternalName, Map<String, Double>>()
+        for (item in itemsData.items) {
+            val neuItemId = NeuItems.transHypixelNameToInternalName(item.id ?: continue)
+            item.npcPrice?.let { npcPrices[neuItemId] = it }
+            item.motesPrice?.let { motesPrice[neuItemId] = it }
+            item.stats?.let { stats -> allStats[neuItemId] = stats }
+            item.experience?.mapNotNull { (skill, experience) ->
+                experience.minionStorage?.let { skill to it }
+            }?.toMap()?.takeIf { it.isNotEmpty() }?.let { minionStorageXP[neuItemId] = it }
+        }
+        ItemUtils.updateBaseStats(allStats)
+        RiftApi.motesPrice = motesPrice
+        this.npcPrices = npcPrices
+        this.minionStorageXP = minionStorageXP
+        prices = georgePrices + npcPrices
+    }
+
+    private fun onError(e: Exception) {
+        val userMessage = "Failed fetching item data from hypixel"
+        failedAttempts++
+        if (failedAttempts <= HIDDEN_FAILED_ATTEMPTS) {
+            nextFetchTime = SimpleTimeMark.now() + 15.seconds
+            ChatUtils.debug("$userMessage. (errorMessage=${e.message}, failedAttempts=$failedAttempts)")
+            e.printStackTrace()
+        } else {
+            nextFetchTime = SimpleTimeMark.now() + 15.minutes
+            ErrorManager.logErrorWithData(
+                e,
+                userMessage,
+                "failedAttempts" to failedAttempts,
+            )
+        }
+    }
+
+    private fun canFetch() = !ApiUtils.isHypixelItemsDisabled() &&
+        SkyBlockUtils.onHypixel &&
+        nextFetchTime.isInPast()
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/HypixelItemApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/HypixelItemApi.kt
@@ -17,21 +17,44 @@ import at.hannibal2.skyhanni.utils.json.fromJson
 import kotlin.time.Duration.Companion.minutes
 
 class HypixelItemApi {
-
     @SkyHanniModule
     companion object {
-
         // prices = george prices + npc prices
         private var prices = mapOf<NeuInternalName, Double>()
         private var npcPrices = mapOf<NeuInternalName, Double>()
         private var georgePrices = mapOf<NeuInternalName, Double>()
+        private var minionStorageXP = mapOf<NeuInternalName, Map<String, Double>>()
 
         fun getNpcPrice(internalName: NeuInternalName) = prices[internalName]
 
+        fun getMinionStorageXP(internalName: NeuInternalName): Map<String, Double>? =
+            minionStorageXP[internalName]
+
         @HandleEvent
-        fun onNeuRepoReload(event: NeuRepositoryReloadEvent) {
+        private fun onNeuRepoReload(event: NeuRepositoryReloadEvent) {
             val constant = event.getConstant<NeuGeorgeJson>("george")
             georgePrices = constant.prices ?: return
+            prices = georgePrices + npcPrices
+        }
+
+        internal fun processItemData(itemsData: SkyblockItemsDataJson) {
+            val npcPrices = mutableMapOf<NeuInternalName, Double>()
+            val motesPrice = mutableMapOf<NeuInternalName, Double>()
+            val allStats = mutableMapOf<NeuInternalName, Map<String, Int>>()
+            val minionStorageXP = mutableMapOf<NeuInternalName, Map<String, Double>>()
+            for (item in itemsData.items) {
+                val neuItemId = NeuItems.transHypixelNameToInternalName(item.id ?: continue)
+                item.npcPrice?.let { npcPrices[neuItemId] = it }
+                item.motesPrice?.let { motesPrice[neuItemId] = it }
+                item.stats?.let { stats -> allStats[neuItemId] = stats }
+                item.experience?.mapNotNull { (skill, experience) ->
+                    experience.minionStorage?.let { skill to it }
+                }?.toMap()?.takeIf { it.isNotEmpty() }?.let { minionStorageXP[neuItemId] = it }
+            }
+            ItemUtils.updateBaseStats(allStats)
+            RiftApi.motesPrice = motesPrice
+            HypixelItemApi.npcPrices = npcPrices
+            HypixelItemApi.minionStorageXP = minionStorageXP
             prices = georgePrices + npcPrices
         }
     }
@@ -44,28 +67,14 @@ class HypixelItemApi {
     private suspend fun loadItemData() {
         val (_, apiResponseData) = ApiUtils.getJsonResponse(hypixelItemStatic).assertSuccessWithData() ?: return
         val itemsData = ConfigManager.gson.fromJson<SkyblockItemsDataJson>(apiResponseData)
-
-        val npcPrices = mutableMapOf<NeuInternalName, Double>()
-        val motesPrice = mutableMapOf<NeuInternalName, Double>()
-        val allStats = mutableMapOf<NeuInternalName, Map<String, Int>>()
-        for (item in itemsData.items) {
-            val neuItemId = NeuItems.transHypixelNameToInternalName(item.id ?: continue)
-            item.npcPrice?.let { npcPrices[neuItemId] = it }
-            item.motesPrice?.let { motesPrice[neuItemId] = it }
-            item.stats?.let { stats -> allStats[neuItemId] = stats }
-        }
-        ItemUtils.updateBaseStats(allStats)
-        RiftApi.motesPrice = motesPrice
-        HypixelItemApi.npcPrices = npcPrices
+        processItemData(itemsData)
     }
 
     fun start() {
         SkyHanniMod.launchIOCoroutine("hypixel item api fetch", timeout = 1.minutes) {
             loadItemData()
-            prices = georgePrices + npcPrices
         }
 
         // TODO use SecondPassedEvent
     }
-
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/minion/MinionXP.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/minion/MinionXP.kt
@@ -3,21 +3,16 @@ package at.hannibal2.skyhanni.features.minion
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.Perk
-import at.hannibal2.skyhanni.data.jsonobjects.repo.MinionXPJson
-import at.hannibal2.skyhanni.events.IslandChangeEvent
-import at.hannibal2.skyhanni.events.MinionCloseEvent
 import at.hannibal2.skyhanni.events.MinionOpenEvent
 import at.hannibal2.skyhanni.events.MinionStorageOpenEvent
-import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.events.minecraft.ToolTipTextEvent
 import at.hannibal2.skyhanni.events.minecraft.add
+import at.hannibal2.skyhanni.features.inventory.bazaar.HypixelItemApi
 import at.hannibal2.skyhanni.features.skillprogress.SkillType
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LorenzVec
-import at.hannibal2.skyhanni.utils.NeuInternalName
-import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.PrimitiveItemStack
 import at.hannibal2.skyhanni.utils.SafeItemStack
@@ -31,17 +26,14 @@ import java.util.EnumMap
 
 @SkyHanniModule
 object MinionXP {
-
     private val config get() = SkyHanniMod.feature.misc.minions
 
-    private val xpItemMap: MutableMap<PrimitiveItemStack, String> = mutableMapOf()
+    private val xpItemMap: MutableMap<PrimitiveItemStack, List<String>> = mutableMapOf()
     private val collectItemXPList: MutableList<String> = mutableListOf()
 
     private var collectItem: Item? = null
 
     private val minionStorages = mutableListOf<MinionStorage>()
-
-    private var xpInfoMap: Map<NeuInternalName, XPInfo> = hashMapOf()
 
     data class XPInfo(val type: SkillType, val amount: Double)
 
@@ -53,7 +45,7 @@ object MinionXP {
         PrimitiveItemStack(itemStack.getInternalName(), itemStack.count)
 
     @HandleEvent
-    fun onMinionOpen(event: MinionOpenEvent) {
+    private fun onMinionOpen(event: MinionOpenEvent) {
         if (!config.xpDisplay) return
 
         collectItem = event.inventoryItems[48]?.itemType
@@ -105,22 +97,29 @@ object MinionXP {
             .map { toPrimitiveItemStack(it) }
         for (item in list) {
             val name = item.internalName
-            val xp = xpInfoMap[name] ?: continue
+            val minionStorageXP = HypixelItemApi.getMinionStorageXP(name) ?: continue
+            val multiplier = if (Perk.MOAR_SKILLZ.isActive) 1.5 else 1.0
+            val xpInfo = calculateXPInfo(minionStorageXP, item.amount, multiplier)
 
-            // TODO add wisdom and temporary skill exp (Events) to calculation
-            val baseXP = xp.amount * item.amount
-            val xpAmount = if (Perk.MOAR_SKILLZ.isActive) {
-                baseXP * 1.5
-            } else baseXP
-
-            xpItemMap[item] = collectMessage(xp.type, xpAmount)
-            xpTotal.compute(xp.type) { _, currentAmount -> (currentAmount ?: 0.0) + xpAmount }
+            xpItemMap[item] = xpInfo.map { collectMessage(it.type, it.amount) }
+            for (xp in xpInfo) {
+                xpTotal.compute(xp.type) { _, currentAmount -> (currentAmount ?: 0.0) + xp.amount }
+            }
         }
         return xpTotal
     }
 
+    // TODO add wisdom and temporary skill exp (Events) to calculation
+    internal fun calculateXPInfo(
+        minionStorageXP: Map<String, Double>,
+        itemAmount: Int,
+        multiplier: Double,
+    ): List<XPInfo> = minionStorageXP.mapNotNull { (skillName, amount) ->
+        SkillType.getByNameOrNull(skillName)?.let { XPInfo(it, amount * itemAmount * multiplier) }
+    }
+
     @HandleEvent
-    fun onMinionStorageOpen(event: MinionStorageOpenEvent) {
+    private fun onMinionStorageOpen(event: MinionStorageOpenEvent) {
         if (!config.xpDisplay) return
 
         val xpTotal = handleItems(event.inventoryItems, false)
@@ -147,7 +146,7 @@ object MinionXP {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onToolTip(event: ToolTipTextEvent) {
+    private fun onToolTip(event: ToolTipTextEvent) {
         if (!config.xpDisplay) return
         when {
             MinionFeatures.minionInventoryOpen -> {
@@ -167,29 +166,22 @@ object MinionXP {
     }
 
     private fun addXPInfoToTooltip(event: ToolTipTextEvent) {
-        xpItemMap[toPrimitiveItemStack(event.itemStack)]?.let {
+        xpItemMap[toPrimitiveItemStack(event.itemStack)]?.takeIf { it.isNotEmpty() }?.let { messages ->
             event.toolTip.add("")
-            event.toolTip.add(it)
+            messages.forEach(event.toolTip::add)
         }
     }
 
     @HandleEvent
-    fun onIslandChange(event: IslandChangeEvent) {
+    private fun onWorldChange() {
         minionStorages.clear()
         xpItemMap.clear()
         collectItemXPList.clear()
     }
 
     @HandleEvent
-    fun onMinionClose(event: MinionCloseEvent) {
+    private fun onMinionClose() {
         xpItemMap.clear()
         collectItemXPList.clear()
-    }
-
-    @HandleEvent
-    fun onRepoReload(event: RepositoryReloadEvent) {
-        xpInfoMap = event.getConstant<MinionXPJson>("MinionXP").minionXP.mapNotNull { xpType ->
-            xpType.value.mapNotNull { it.key.toInternalName() to XPInfo(SkillType.getByName(xpType.key), it.value) }
-        }.flatten().toMap()
     }
 }

--- a/src/test/java/at/hannibal2/skyhanni/test/features/minion/HypixelItemApiTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/features/minion/HypixelItemApiTest.kt
@@ -1,0 +1,108 @@
+package at.hannibal2.skyhanni.test.features.minion
+
+import at.hannibal2.skyhanni.config.ConfigManager
+import at.hannibal2.skyhanni.data.jsonobjects.other.SkyblockItemsDataJson
+import at.hannibal2.skyhanni.features.inventory.bazaar.HypixelItemApi
+import at.hannibal2.skyhanni.features.minion.MinionXP
+import at.hannibal2.skyhanni.features.skillprogress.SkillType
+import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
+import at.hannibal2.skyhanni.utils.json.fromJson
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class HypixelItemApiTest {
+    @Test
+    fun `extracts minion storage xp from Hypixel item data`() {
+        val itemsData = ConfigManager.gson.fromJson<SkyblockItemsDataJson>(ITEMS_RESPONSE)
+        HypixelItemApi.processItemData(itemsData)
+
+        assertEquals(
+            mapOf("fishing" to 20480.0),
+            HypixelItemApi.getMinionStorageXP("CONDENSED_WATER_LILY".toInternalName()),
+        )
+        assertNull(HypixelItemApi.getMinionStorageXP("NO_EXPERIENCE".toInternalName()))
+        assertNull(HypixelItemApi.getMinionStorageXP("NO_MINION_STORAGE".toInternalName()))
+        assertEquals(
+            mapOf("farming" to 2.0, "mining" to 3.0),
+            HypixelItemApi.getMinionStorageXP("MULTI_SKILL".toInternalName()),
+        )
+        assertEquals(
+            mapOf("mystery" to 4.0),
+            HypixelItemApi.getMinionStorageXP("UNKNOWN_SKILL".toInternalName()),
+        )
+    }
+
+    @Test
+    fun `calculates every known skill and ignores unknown skills`() {
+        assertEquals(
+            listOf(
+                MinionXP.XPInfo(SkillType.FARMING, 6.0),
+                MinionXP.XPInfo(SkillType.MINING, 9.0),
+            ),
+            MinionXP.calculateXPInfo(
+                mapOf("farming" to 2.0, "mining" to 3.0, "mystery" to 4.0),
+                itemAmount = 2,
+                multiplier = 1.5,
+            ),
+        )
+    }
+
+    companion object {
+        private val ITEMS_RESPONSE = """
+            {
+              "items": [
+                {
+                  "material": "PAPER",
+                  "item_model": "hypixel_skyblock:item/collections/lily_pad/condensed_lily_pad",
+                  "name": "Condensed Lily Pad",
+                  "tier": "RARE",
+                  "npc_sell_price": 256000,
+                  "description": "%%gray%%A truly massive amount of Lily Pads mashed into a large ball.",
+                  "components": [
+                    {
+                      "type": "RECIPE_INGREDIENT"
+                    }
+                  ],
+                  "experience": {
+                    "fishing": {
+                      "MINION_STORAGE": 20480.0
+                    }
+                  },
+                  "id": "CONDENSED_WATER_LILY"
+                },
+                {
+                  "id": "NO_EXPERIENCE"
+                },
+                {
+                  "experience": {
+                    "fishing": {
+                      "OTHER_SOURCE": 10.0
+                    }
+                  },
+                  "id": "NO_MINION_STORAGE"
+                },
+                {
+                  "experience": {
+                    "farming": {
+                      "MINION_STORAGE": 2.0
+                    },
+                    "mining": {
+                      "MINION_STORAGE": 3.0
+                    }
+                  },
+                  "id": "MULTI_SKILL"
+                },
+                {
+                  "experience": {
+                    "mystery": {
+                      "MINION_STORAGE": 4.0
+                    }
+                  },
+                  "id": "UNKNOWN_SKILL"
+                }
+              ]
+            }
+        """.trimIndent()
+    }
+}


### PR DESCRIPTION
## What
Hypixel recently added how much XP each item grants when collected from a minion to their API. This PR changes our feature to use the Hypixel API directly rather than the `MinionXP` SkyHanni-REPO constant.

## Changelog Improvements
+ Improved Minion XP Display to show the XP for newly added items right away. - Luna