### PR TITLE
Backend: Make ComponentMatcher naming consistent with regular Matcher

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/pet/PetStorageApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/pet/PetStorageApi.kt
@@ -58,7 +58,6 @@ import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object PetStorageApi {
-
     private val config get() = SkyHanniMod.feature.misc.pets
     private val petStorage get() = ProfileStorageData.petProfiles
     private const val PET_MENU_CURRENT_PET_SLOT = 4
@@ -68,7 +67,7 @@ object PetStorageApi {
     private var jsonNeedsSave: Boolean = false
     private var lastSaved: SimpleTimeMark = SimpleTimeMark.farPast()
     private var lastExactPetMenuClick: SimpleTimeMark = SimpleTimeMark.farPast()
-    private var petWidgetState: PetWidgetState = PetWidgetState.NOT_READY
+    private var petWidgetState = PetWidgetState.NOT_READY
 
     private val mainMenuInventory = InventoryDetector(
         checkInventoryName = {
@@ -87,7 +86,7 @@ object PetStorageApi {
             "§cInaccurate! Enable /tab → Pet Widget"
         }
 
-        showMissingOverflowXpWarning && petWidgetState == PetWidgetState.MAXED_WITHOUT_OVERFLOW_XP -> {
+        showMissingOverflowXpWarning && petWidgetState == MAXED_WITHOUT_OVERFLOW_XP -> {
             "§cInaccurate! Enable /tab → Pet Widget → Show Overflow Pet XP"
         }
 
@@ -121,26 +120,26 @@ object PetStorageApi {
         getPetSkinColorTagOrNull()?.replace(" ", "")
 
     private fun ComponentMatcher.getPetSkinColorTagOrNull(): String? =
-        component("skin")?.formattedTextForItemLookup()
-            ?: component("altskin")?.formattedTextForItemLookup()
+        componentOrNull("skin")?.formattedTextForItemLookup()
+            ?: componentOrNull("altskin")?.formattedTextForItemLookup()
 
     private fun ComponentMatcher.petNameAndRarityOrNull(): Pair<String, LorenzRarity>? {
-        val petSpan = groupOrThrow("pet")
+        val petSpan = group("pet")
         val petName = petSpan.getText().trim()
         val rarity = petSpan.sampleStyleAtStart().toLorenzRarityOrNull() ?: return null
         return petName to rarity
     }
 
     private fun Style.toLorenzRarityOrNull(): LorenzRarity? = when (color?.name) {
-        "dark_red" -> LorenzRarity.ULTIMATE
-        "red" -> LorenzRarity.SPECIAL
-        "aqua" -> LorenzRarity.DIVINE
-        "light_purple" -> LorenzRarity.MYTHIC
-        "gold" -> LorenzRarity.LEGENDARY
-        "dark_purple" -> LorenzRarity.EPIC
-        "blue" -> LorenzRarity.RARE
-        "green" -> LorenzRarity.UNCOMMON
-        "white" -> LorenzRarity.COMMON
+        "dark_red" -> ULTIMATE
+        "red" -> SPECIAL
+        "aqua" -> DIVINE
+        "light_purple" -> MYTHIC
+        "gold" -> LEGENDARY
+        "dark_purple" -> EPIC
+        "blue" -> RARE
+        "green" -> UNCOMMON
+        "white" -> COMMON
         else -> null
     }
 
@@ -216,7 +215,7 @@ object PetStorageApi {
         PetStoragePatterns.petMenuPetStackNamePattern.matchStyledMatcher(hoverName) {
             val petInfo = getPetInfo()
             val level = matcher.group("level").formatInt()
-            val petSpan = groupOrThrow("pet")
+            val petSpan = group("pet")
             val petName = petSpan.getText().trim()
             val itemInternalName = getInternalNameOrNull()?.takeIf { PetUtils.getPetRarity(it) != null }
             val petInternalName = itemInternalName ?: run {
@@ -254,7 +253,7 @@ object PetStorageApi {
     private fun SafeItemStack.isCurrentPetStack() = getLore().any { it.contains("Click to despawn") }
 
     @HandleEvent
-    fun onSecondPassed() {
+    private fun onSecondPassed() {
         if (!jsonNeedsSave || lastSaved.passedSince() < 30.seconds) return
         SkyHanniMod.configManager.saveConfig(ConfigFileType.PETS, "saving-data")
         jsonNeedsSave = false
@@ -262,11 +261,11 @@ object PetStorageApi {
     }
 
     @HandleEvent(onlyOnSkyblock = true, priority = HandleEvent.HIGHEST)
-    fun onWidgetUpdate(event: WidgetUpdateEvent) {
-        if (!event.isWidget(TabWidget.PET)) return
+    private fun onWidgetUpdate(event: WidgetUpdateEvent) {
+        if (!event.isWidget(PET)) return
         if (event.isClear()) {
             if (SkyBlockUtils.lastWorldSwitch.passedSince() < WIDGET_LOAD_GRACE) return
-            petWidgetState = PetWidgetState.NOT_READY
+            petWidgetState = NOT_READY
             return
         }
         var foundUsableWidgetPet = false
@@ -275,7 +274,7 @@ object PetStorageApi {
             foundUsableWidgetPet = foundUsableWidgetPet || lineWasUsable
         }
         if (!foundUsableWidgetPet) {
-            petWidgetState = PetWidgetState.NOT_READY
+            petWidgetState = NOT_READY
         }
     }
 
@@ -324,7 +323,7 @@ object PetStorageApi {
             previousExp = previousExp,
             appliedExp = exactPetExp,
         )
-        CurrentPetApi.assertFoundCurrentData(currentPetData, CurrentPetApi.PetDataAssertionSource.TAB)
+        CurrentPetApi.assertFoundCurrentData(currentPetData, source = TAB)
         updatePetWidgetState(maxedWithoutOverflowXp, exactPetExp)
         jsonNeedsSave = true
         return maxedWithoutOverflowXp || exactPetExp != null
@@ -394,9 +393,9 @@ object PetStorageApi {
     }
 
     @HandleEvent(priority = HandleEvent.HIGHEST)
-    fun onChat(event: SkyHanniChatEvent.Allow) {
+    private fun onChat(event: SkyHanniChatEvent.Allow) {
         PetStoragePatterns.petItemHeldMessagePattern.matchStyledMatcher(event.chatComponent) {
-            val petHeldItemName = componentOrThrow("item").formattedTextForItemLookup()
+            val petHeldItemName = component("item").formattedTextForItemLookup()
             val petHeldItem = resolveAppliedPetItemOrNull(petHeldItemName) ?: return
             updateCurrentPetHeldItem(petHeldItem)
         }
@@ -418,7 +417,7 @@ object PetStorageApi {
             val hoverInfoComponents = event.chatComponent.hoverTextComponents()
             val hoverInfo = hoverInfoComponents.toColorlessText()
             val petHeldItemName = hoverInfoComponents.firstStyledMatcher(PetStoragePatterns.autoPetHoverHeldItemPattern) {
-                componentOrThrow("item").formattedTextForItemLookup()
+                component("item").formattedTextForItemLookup()
             }?.trim()
             val petHeldItem = petHeldItemName?.let(PetUtils::resolvePetItemOrNull)
 
@@ -444,7 +443,7 @@ object PetStorageApi {
             }
 
             val previousPet = CurrentPetApi.currentPet
-            CurrentPetApi.assertFoundCurrentData(resolvedPet, CurrentPetApi.PetDataAssertionSource.AUTOPET)
+            CurrentPetApi.assertFoundCurrentData(resolvedPet, source = AUTOPET)
             PetXpEstimateApi.recordAutopetSwap(resolvedPet, previousPet, hoverInfo.autopetTriggerOrNull())
             jsonNeedsSave = true
         }
@@ -465,7 +464,7 @@ object PetStorageApi {
         if (currentPet.heldItemInternalName == heldItem) return
         currentPet.heldItemInternalName = heldItem
         if (currentPet.uuid != null) petStorage?.pets?.addOrReplace(currentPet)
-        CurrentPetApi.assertFoundCurrentData(currentPet, CurrentPetApi.PetDataAssertionSource.CHAT)
+        CurrentPetApi.assertFoundCurrentData(currentPet, source = CHAT)
         markDirty()
     }
 
@@ -507,7 +506,7 @@ object PetStorageApi {
     }
 
     @HandleEvent(onlyOnSkyblock = true, priority = HandleEvent.HIGHEST)
-    fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
+    private fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
         if (!inMainPetMenuName()) return
         if (!event.slotId.isPetStackLocation()) return
         val clickedItem = event.slot?.item.orNull() ?: event.item.orNull() ?: return
@@ -530,7 +529,7 @@ object PetStorageApi {
                     CurrentPetApi.clearCurrentPet()
                 } else {
                     if (clickedPetUuid != null) petStorage?.pets?.addOrReplace(clickedPetData)
-                    CurrentPetApi.assertFoundCurrentData(clickedPetData, CurrentPetApi.PetDataAssertionSource.MENU)
+                    CurrentPetApi.assertFoundCurrentData(clickedPetData, source = MENU)
                 }
             }
 
@@ -540,7 +539,7 @@ object PetStorageApi {
     }
 
     @HandleEvent(onlyOnSkyblock = true, priority = HandleEvent.HIGHEST)
-    fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
+    private fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
         event.readSelectedPetData()
         event.readEquipmentPetData()
         PetStorageExpShare.readInventory(event.inventoryName, event.inventoryItems)
@@ -583,7 +582,7 @@ object PetStorageApi {
 
         petStorage.pets.addOrReplace(data)
 
-        CurrentPetApi.assertFoundCurrentData(data, CurrentPetApi.PetDataAssertionSource.MENU)
+        CurrentPetApi.assertFoundCurrentData(data, source = MENU)
         jsonNeedsSave = true
     }
 
@@ -631,7 +630,7 @@ object PetStorageApi {
             previousExp = previousExp,
             appliedExp = exactPetExp,
         )
-        CurrentPetApi.assertFoundCurrentData(currentPetData, CurrentPetApi.PetDataAssertionSource.MENU)
+        CurrentPetApi.assertFoundCurrentData(currentPetData, source = MENU)
         jsonNeedsSave = true
         return true
     }
@@ -700,7 +699,7 @@ object PetStorageApi {
             previousExp = previousExp,
             appliedExp = currentPetData.exp,
         )
-        CurrentPetApi.assertFoundCurrentData(currentPetData, CurrentPetApi.PetDataAssertionSource.MENU)
+        CurrentPetApi.assertFoundCurrentData(currentPetData, source = MENU)
         jsonNeedsSave = true
         return true
     }

--- a/src/main/java/at/hannibal2/skyhanni/data/BestiaryApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/BestiaryApi.kt
@@ -373,8 +373,8 @@ object BestiaryApi {
 
     private fun getMobVariant(stack: SafeItemStack): BestiaryMobVariant? {
         val (name, levelOrTier) = mobVariantPattern.matchStyledMatcher(stack.hoverName.intoSpan()) {
-            val name = group("name")?.intoComponent() ?: return@matchStyledMatcher null
-            val levelOrTier = group("level")?.getText()?.formatInt() ?: return@matchStyledMatcher null
+            val name = groupOrNull("name")?.intoComponent() ?: return@matchStyledMatcher null
+            val levelOrTier = groupOrNull("level")?.getText()?.formatInt() ?: return@matchStyledMatcher null
             name to levelOrTier
         } ?: return null
 
@@ -384,7 +384,7 @@ object BestiaryApi {
     private fun parseStackName(component: Component): Pair<Component, String>? {
         var level = "0"
         val name = mobLevelPattern.matchStyledMatcher(component) {
-            level = group("level")?.getText() ?: "0"
+            level = groupOrNull("level")?.getText() ?: "0"
             group("name")
         }?.intoComponent() ?: return null
         return name to level

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerChatManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerChatManager.kt
@@ -28,7 +28,6 @@ import net.minecraft.network.chat.Component
  */
 @SkyHanniModule
 object PlayerChatManager {
-
     private val patternGroup = RepoPattern.group("data.chat.player")
 
     /**
@@ -124,40 +123,40 @@ object PlayerChatManager {
     )
 
     @HandleEvent
-    fun onChat(event: SkyHanniChatEvent.Allow) {
+    private fun onChat(event: SkyHanniChatEvent.Allow) {
         val chatComponent = event.chatComponent.intoSpan().stripHypixelMessage()
         coopPattern.matchStyledMatcher(chatComponent) {
-            val author = groupOrThrow("author")
-            val message = groupOrThrow("message")
+            val author = group("author")
+            val message = group("message")
             CoopChatEvent.Allow(author, message, event.chatComponent).postChat(event)
             return
         }
         partyPattern.matchStyledMatcher(chatComponent) {
-            PartyChatEvent.Allow(groupOrThrow("author"), groupOrThrow("message"), event.chatComponent)
+            PartyChatEvent.Allow(group("author"), group("message"), event.chatComponent)
                 .postChat(event)
             return
         }
         guildPattern.matchStyledMatcher(chatComponent) {
             GuildChatEvent.Allow(
-                groupOrThrow("author"),
-                groupOrThrow("message"),
-                group("guildRank"),
+                group("author"),
+                group("message"),
+                groupOrNull("guildRank"),
                 event.chatComponent,
             ).postChat(event)
             return
         }
         privateMessagePattern.matchStyledMatcher(chatComponent) {
-            val direction = Direction.fromString(groupOrThrow("direction").getText())
-            val author = groupOrThrow("author")
-            val message = groupOrThrow("message")
+            val direction = Direction.fromString(group("direction").getText())
+            val author = group("author")
+            val message = group("message")
             PrivateMessageChatEvent.Allow(direction, author, message, event.chatComponent).postChat(event)
             return
         }
         itemShowPattern.matchStyledMatcher(chatComponent) {
-            val level = group("level")
-            val author = groupOrThrow("author")
-            val action = groupOrThrow("action")
-            val itemName = groupOrThrow("itemName")
+            val level = groupOrNull("level")
+            val author = group("author")
+            val action = group("action")
+            val itemName = group("itemName")
 
             PlayerShowItemChatEvent.Allow(
                 level,
@@ -177,40 +176,40 @@ object PlayerChatManager {
     }
 
     @HandleEvent
-    fun onChat(event: SkyHanniChatEvent.Modify) {
+    private fun onChat(event: SkyHanniChatEvent.Modify) {
         val chatComponent = event.chatComponent.intoSpan().stripHypixelMessage()
         coopPattern.matchStyledMatcher(chatComponent) {
-            val author = groupOrThrow("author")
-            val message = groupOrThrow("message")
+            val author = group("author")
+            val message = group("message")
             CoopChatEvent.Modify(author, message, event.chatComponent).postChat(event)
             return
         }
         partyPattern.matchStyledMatcher(chatComponent) {
-            PartyChatEvent.Modify(groupOrThrow("author"), groupOrThrow("message"), event.chatComponent)
+            PartyChatEvent.Modify(group("author"), group("message"), event.chatComponent)
                 .postChat(event)
             return
         }
         guildPattern.matchStyledMatcher(chatComponent) {
             GuildChatEvent.Modify(
-                groupOrThrow("author"),
-                groupOrThrow("message"),
-                group("guildRank"),
+                group("author"),
+                group("message"),
+                groupOrNull("guildRank"),
                 event.chatComponent,
             ).postChat(event)
             return
         }
         privateMessagePattern.matchStyledMatcher(chatComponent) {
-            val direction = Direction.fromString(groupOrThrow("direction").getText())
-            val author = groupOrThrow("author")
-            val message = groupOrThrow("message")
+            val direction = Direction.fromString(group("direction").getText())
+            val author = group("author")
+            val message = group("message")
             PrivateMessageChatEvent.Modify(direction, author, message, event.chatComponent).postChat(event)
             return
         }
         itemShowPattern.matchStyledMatcher(chatComponent) {
-            val level = group("level")
-            val author = groupOrThrow("author")
-            val action = groupOrThrow("action")
-            val itemName = groupOrThrow("itemName")
+            val level = groupOrNull("level")
+            val author = group("author")
+            val action = group("action")
+            val itemName = group("itemName")
 
             PlayerShowItemChatEvent.Modify(
                 level,
@@ -230,13 +229,13 @@ object PlayerChatManager {
     }
 
     private fun ComponentMatcher.isGlobalChat(event: SkyHanniChatEvent.Allow): Boolean {
-        var author = groupOrThrow("author")
-        val chatColor = groupOrThrow("chatColor")
+        var author = group("author")
+        val chatColor = group("chatColor")
         if (chatColor.length == 0 && !author.getText().removeColor().endsWith(PlayerUtils.getName())) {
             // The last format string is always present, unless this is the players own message
             return false
         }
-        val message = groupOrThrow("message").removePrefix("§f")
+        val message = group("message").removePrefix("§f")
         if (author.getText().contains("[NPC]")) {
             NpcChatEvent.Allow(author, message, event.chatComponent).postChat(event)
             return true
@@ -246,21 +245,21 @@ object PlayerChatManager {
         var privateIslandGuest: ComponentSpan? = null
         if (IslandTypeTag.PRIVATE_ISLAND.isInIsland()) {
             privateIslandGuestPattern.matchStyledMatcher(author) {
-                privateIslandGuest = groupOrThrow("guest")
-                val prefix = groupOrThrow("prefix")
-                val suffix = groupOrThrow("suffix")
+                privateIslandGuest = group("guest")
+                val prefix = group("prefix")
+                val suffix = group("suffix")
                 author = prefix + suffix
             }
             privateIslandRankPattern.matchStyledMatcher(author) {
-                privateIslandRank = groupOrThrow("privateIslandRank")
-                val prefix = groupOrThrow("prefix")
-                val suffix = groupOrThrow("suffix")
+                privateIslandRank = group("privateIslandRank")
+                val prefix = group("prefix")
+                val suffix = group("suffix")
                 author = prefix + suffix
             }
         }
 
         PlayerAllChatEvent.Allow(
-            levelComponent = group("level"),
+            levelComponent = groupOrNull("level"),
             privateIslandRank = privateIslandRank,
             privateIslandGuest = privateIslandGuest,
             chatColor = chatColor.getText(),
@@ -272,13 +271,13 @@ object PlayerChatManager {
     }
 
     private fun ComponentMatcher.isGlobalChat(event: SkyHanniChatEvent.Modify): Boolean {
-        var author = groupOrThrow("author")
-        val chatColor = groupOrThrow("chatColor")
+        var author = group("author")
+        val chatColor = group("chatColor")
         if (chatColor.length == 0 && !author.getText().removeColor().endsWith(PlayerUtils.getName())) {
             // The last format string is always present, unless this is the players own message
             return false
         }
-        val message = groupOrThrow("message").removePrefix("§f")
+        val message = group("message").removePrefix("§f")
         if (author.getText().contains("[NPC]")) {
             NpcChatEvent.Modify(author, message, event.chatComponent).postChat(event)
             return true
@@ -288,21 +287,21 @@ object PlayerChatManager {
         var privateIslandGuest: ComponentSpan? = null
         if (IslandTypeTag.PRIVATE_ISLAND.isInIsland()) {
             privateIslandGuestPattern.matchStyledMatcher(author) {
-                privateIslandGuest = groupOrThrow("guest")
-                val prefix = groupOrThrow("prefix")
-                val suffix = groupOrThrow("suffix")
+                privateIslandGuest = group("guest")
+                val prefix = group("prefix")
+                val suffix = group("suffix")
                 author = prefix + suffix
             }
             privateIslandRankPattern.matchStyledMatcher(author) {
-                privateIslandRank = groupOrThrow("privateIslandRank")
-                val prefix = groupOrThrow("prefix")
-                val suffix = groupOrThrow("suffix")
+                privateIslandRank = group("privateIslandRank")
+                val prefix = group("prefix")
+                val suffix = group("suffix")
                 author = prefix + suffix
             }
         }
 
         PlayerAllChatEvent.Modify(
-            levelComponent = group("level"),
+            levelComponent = groupOrNull("level"),
             privateIslandRank = privateIslandRank,
             privateIslandGuest = privateIslandGuest,
             chatColor = chatColor.getText(),

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerNameFormatter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerNameFormatter.kt
@@ -3,7 +3,7 @@ package at.hannibal2.skyhanni.data.hypixel.chat
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
-import at.hannibal2.skyhanni.config.features.chat.PlayerMessagesConfig
+import at.hannibal2.skyhanni.config.features.chat.PlayerMessagesConfig.MessagePart
 import at.hannibal2.skyhanni.data.hypixel.chat.event.CoopChatEvent
 import at.hannibal2.skyhanni.data.hypixel.chat.event.GuildChatEvent
 import at.hannibal2.skyhanni.data.hypixel.chat.event.PartyChatEvent
@@ -20,7 +20,6 @@ import at.hannibal2.skyhanni.utils.ColorUtils.getFirstColorCode
 import at.hannibal2.skyhanni.utils.ComponentMatcherUtils.intoSpan
 import at.hannibal2.skyhanni.utils.ComponentMatcherUtils.matchStyledMatcher
 import at.hannibal2.skyhanni.utils.ComponentSpan
-import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.StringUtils.applyFormattingFrom
@@ -62,7 +61,7 @@ object PlayerNameFormatter {
     )
 
     @HandleEvent
-    fun onPlayerAllChat(event: PlayerAllChatEvent.Modify) {
+    private fun onPlayerAllChat(event: PlayerAllChatEvent.Modify) {
         if (!isEnabled()) return
         val levelColor = event.levelColor
         val levelComponent = event.levelComponent
@@ -86,7 +85,7 @@ object PlayerNameFormatter {
         all.append(": ")
         all.append(chatColor.asComponent())
         all.append(
-            if (config.sameChatColor) message.intoComponent().changeColor(LorenzColor.WHITE)
+            if (config.sameChatColor) message.intoComponent().changeColor(WHITE)
             else message.intoComponent(),
         )
         val component = StringUtils.replaceIfNeeded(event.chatComponent, all) ?: return
@@ -94,7 +93,7 @@ object PlayerNameFormatter {
     }
 
     @HandleEvent
-    fun onCoopChat(event: CoopChatEvent.Modify) {
+    private fun onCoopChat(event: CoopChatEvent.Modify) {
         if (!isEnabled()) return
         val component = StringUtils.replaceIfNeeded(
             event.chatComponent,
@@ -108,7 +107,7 @@ object PlayerNameFormatter {
     }
 
     @HandleEvent
-    fun onGuildChat(event: GuildChatEvent.Modify) {
+    private fun onGuildChat(event: GuildChatEvent.Modify) {
         if (!isEnabled()) return
         val component = StringUtils.replaceIfNeeded(
             event.chatComponent,
@@ -122,7 +121,7 @@ object PlayerNameFormatter {
     }
 
     @HandleEvent
-    fun onPartyChat(event: PartyChatEvent.Modify) {
+    private fun onPartyChat(event: PartyChatEvent.Modify) {
         if (!isEnabled()) return
         val component = StringUtils.replaceIfNeeded(
             event.chatComponent,
@@ -136,7 +135,7 @@ object PlayerNameFormatter {
     }
 
     @HandleEvent
-    fun onPrivateChat(event: PrivateMessageChatEvent.Modify) {
+    private fun onPrivateChat(event: PrivateMessageChatEvent.Modify) {
         if (!isEnabled()) return
         val component = StringUtils.replaceIfNeeded(
             event.chatComponent,
@@ -145,7 +144,7 @@ object PlayerNameFormatter {
                 append(nameFormat(event.authorComponent))
                 append("§f: ")
                 append(
-                    if (config.sameChatColor) event.messageComponent.intoComponent().changeColor(LorenzColor.WHITE)
+                    if (config.sameChatColor) event.messageComponent.intoComponent().changeColor(WHITE)
                     else event.messageComponent.intoComponent(),
                 )
             },
@@ -154,7 +153,7 @@ object PlayerNameFormatter {
     }
 
     @HandleEvent
-    fun onPlayerShowItemChat(event: PlayerShowItemChatEvent.Modify) {
+    private fun onPlayerShowItemChat(event: PlayerShowItemChatEvent.Modify) {
         if (!isEnabled()) return
         val component = StringUtils.replaceIfNeeded(
             event.chatComponent,
@@ -168,7 +167,7 @@ object PlayerNameFormatter {
                 )
 
                 append(" ")
-                append(event.action.intoComponent().changeColor(LorenzColor.GRAY))
+                append(event.action.intoComponent().changeColor(GRAY))
 
                 append(" ")
                 append(event.item.intoComponent())
@@ -189,8 +188,8 @@ object PlayerNameFormatter {
 
         var emblemFormat: Component? = null
         emblemPattern.matchStyledMatcher(author) {
-            emblemFormat = componentOrThrow("emblem")
-            cleanAuthor = groupOrThrow("author").stripHypixelMessage()
+            emblemFormat = component("emblem")
+            cleanAuthor = group("author").stripHypixelMessage()
         }
 
         val name = formatAuthor(cleanAuthor, levelColor)
@@ -207,16 +206,17 @@ object PlayerNameFormatter {
             listOf(faction, ironman, bingo)
         } ?: listOf(null, null, null)
 
-        val map = mutableMapOf<PlayerMessagesConfig.MessagePart, Component?>()
-        map[PlayerMessagesConfig.MessagePart.SKYBLOCK_LEVEL] = levelFormat
-        map[PlayerMessagesConfig.MessagePart.EMBLEM] = emblemFormat
-        map[PlayerMessagesConfig.MessagePart.PLAYER_NAME] = name.intoComponent()
-        map[PlayerMessagesConfig.MessagePart.CRIMSON_FACTION] = faction
-        map[PlayerMessagesConfig.MessagePart.MODE_IRONMAN] = ironman
-        map[PlayerMessagesConfig.MessagePart.BINGO_LEVEL] = bingo
-        map[PlayerMessagesConfig.MessagePart.GUILD_RANK] = guildRankFormat
-        map[PlayerMessagesConfig.MessagePart.PRIVATE_ISLAND_RANK] = privateIslandRankFormat
-        map[PlayerMessagesConfig.MessagePart.PRIVATE_ISLAND_GUEST] = privateIslandGuestFormat
+        val map = mapOf(
+            MessagePart.SKYBLOCK_LEVEL to levelFormat,
+            MessagePart.EMBLEM to emblemFormat,
+            MessagePart.PLAYER_NAME to name.intoComponent(),
+            MessagePart.CRIMSON_FACTION to faction,
+            MessagePart.MODE_IRONMAN to ironman,
+            MessagePart.BINGO_LEVEL to bingo,
+            MessagePart.GUILD_RANK to guildRankFormat,
+            MessagePart.PRIVATE_ISLAND_RANK to privateIslandRankFormat,
+            MessagePart.PRIVATE_ISLAND_GUEST to privateIslandGuestFormat,
+        )
 
         val components = config.partsOrder.mapNotNull { map[it] }
         components.find { it.unformattedTextCompat().endsWith(" ") }?.let {
@@ -292,7 +292,7 @@ object PlayerNameFormatter {
     fun isEnabled() = SkyBlockUtils.inSkyBlock && config.enable
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.transform(41, "chat.PlayerMessagesConfig.partsOrder") { element ->
             val newList = JsonArray()
             for (entry in element.asJsonArray) {

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/TreeProgressDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/TreeProgressDisplay.kt
@@ -26,7 +26,6 @@ import net.minecraft.world.entity.decoration.ArmorStand
 
 @SkyHanniModule
 object TreeProgressDisplay {
-
     private val config get() = SkyHanniMod.feature.foraging.trees.progress
 
     private data class TreeProgressDisplay(
@@ -97,8 +96,8 @@ object TreeProgressDisplay {
     }
 
     private fun ComponentMatcher.formatCompact(): Component {
-        val treeType = componentOrThrow("treeType")
-        val percent = groupOrThrow("percent")
+        val treeType = component("treeType")
+        val percent = group("percent")
         val percentStyle = percent.sampleStyleAtStart()
 
         return componentBuilder {

--- a/src/main/java/at/hannibal2/skyhanni/utils/ComponentMatcherUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ComponentMatcherUtils.kt
@@ -21,7 +21,6 @@ import java.util.regex.Matcher
 import java.util.regex.Pattern
 
 object ComponentMatcherUtils {
-
     /**
      * Convert an [IChatComponent] into a [ComponentSpan], which allows taking substrings of the given component,
      * while preserving chat style.
@@ -95,14 +94,14 @@ class ComponentMatcher internal constructor(
     /**
      * Return a span equivalent to the entire match found by [matches] or [find]
      */
-    fun group(): ComponentSpan {
+    fun groupOrNull(): ComponentSpan {
         return this.span.slice(matcher.start(), matcher.end())
     }
 
     /**
      * Return a span equivalent to the group with the given index found by [matches] or [find]
      */
-    fun group(index: Int): ComponentSpan? {
+    fun groupOrNull(index: Int): ComponentSpan? {
         val start = matcher.start(index)
         if (start < 0) return null
         return this.span.slice(start, matcher.end(index))
@@ -111,7 +110,7 @@ class ComponentMatcher internal constructor(
     /**
      * Return a span equivalent to the group with the given name found by [matches] or [find]
      */
-    fun group(name: String): ComponentSpan? {
+    fun groupOrNull(name: String): ComponentSpan? {
         val start = try {
             matcher.start(name)
         } catch (_: IllegalArgumentException) {
@@ -124,24 +123,24 @@ class ComponentMatcher internal constructor(
     /**
      * Return a span equivalent to the group with the given name found by [matches] or [find]
      */
-    fun component(name: String): Component? {
-        return group(name)?.intoComponent()
+    fun componentOrNull(name: String): Component? {
+        return groupOrNull(name)?.intoComponent()
     }
 
     /**
      * Return a span equivalent to the group with the given name found by [matches] or [find].
      * Returns not nullable object, or throws an error.
      */
-    fun groupOrThrow(name: String): ComponentSpan {
-        return group(name) ?: error("group '$name' not found in ComponentSpan!")
+    fun group(name: String): ComponentSpan {
+        return groupOrNull(name) ?: error("group '$name' not found in ComponentSpan!")
     }
 
     /**
      * Return a IChatComponent equivalent to the group with the given name found by [matches] or [find].
      * Returns not nullable object, or throws an error.
      */
-    fun componentOrThrow(name: String): Component {
-        return groupOrThrow(name).intoComponent()
+    fun component(name: String): Component {
+        return group(name).intoComponent()
     }
 }
 
@@ -323,5 +322,4 @@ class ComponentSpan internal constructor(
             return ComponentSpan("".asComponent(), "", 0, 0)
         }
     }
-
 }

--- a/src/test/java/at/hannibal2/skyhanni/test/ComponentSpanTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/ComponentSpanTest.kt
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test
 import java.util.regex.Pattern
 
 class ComponentSpanTest {
-
     private val redColor = TextColor.fromLegacyFormat(ChatFormatting.RED)!!.value
 
     @Test
@@ -59,21 +58,21 @@ class ComponentSpanTest {
             append("12345")
         }
         Pattern.compile("[0-9]*(?<middle>[a-z]+)[0-9]*").matchStyledMatcher(component) {
-            assertEquals(redColor, groupOrThrow("middle").sampleStyleAtStart().getColor()?.value)
+            assertEquals(redColor, group("middle").sampleStyleAtStart().getColor()?.value)
         }
         val middlePartExtracted =
             Pattern.compile("[0-9]*(?<middle>[0-9][a-z]+[0-9])[0-9]*").matchStyledMatcher(component) {
-                assertEquals(3, groupOrThrow("middle").sampleComponents().size)
+                assertEquals(3, group("middle").sampleComponents().size)
                 assertEquals(
                     redColor,
-                    groupOrThrow("middle").sampleStyles().find {
+                    group("middle").sampleStyles().find {
                         it.getColor() != null
                     }?.getColor()?.value
                 )
-                groupOrThrow("middle")
+                group("middle")
             }!!
         Pattern.compile("(?<whole>c)").findStyledMatcher(middlePartExtracted) {
-            assertEquals(redColor, groupOrThrow("whole").sampleStyleAtStart().getColor()?.value)
+            assertEquals(redColor, group("whole").sampleStyleAtStart().getColor()?.value)
         }
     }
 
@@ -83,8 +82,7 @@ class ComponentSpanTest {
             append("Selected pet: Rift Ferret")
         }
         Pattern.compile("Selected pet: (?<pet>[\\w ]+)(?<skin> ✦)?").matchStyledMatcher(component) {
-            assertNull(component("skin") ?: component("altskin"))
+            assertNull(componentOrNull("skin") ?: componentOrNull("altskin"))
         }
     }
-
 }


### PR DESCRIPTION
## What
Regular `Matcher` uses `group/groupOrNull`. `ComponentMatcher` was using `groupOrThrow/group` and `componentOrThrow/component`. This PR makes it consistent with `Matcher`.

## Changelog Technical Details
+ Made ComponentMatcher methods consistent with Matcher. - Luna
  * Changes: component → componentOrNull, componentOrThrow → component, group → groupOrNull, groupOrThrow → group.
