### PR TITLE
Improvement: Use materials in sacks for MinionCraftHelper

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/bingo/MinionCraftHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/bingo/MinionCraftHelper.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.features.bingo
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
+import at.hannibal2.skyhanni.data.SackApi
 import at.hannibal2.skyhanni.data.title.TitleManager
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
@@ -81,7 +82,7 @@ object MinionCraftHelper {
         }
 
         if (event.repeatSeconds(2)) {
-            hasItemsForMinion = loadFromInventory(mainInventory).first.isNotEmpty()
+            hasItemsForMinion = loadFromInventoryAndSacks(mainInventory).first.isNotEmpty()
         }
 
         if (!hasMinionInInventory && !hasItemsForMinion) {
@@ -91,7 +92,7 @@ object MinionCraftHelper {
 
         if (!event.isMod(3)) return
 
-        val (minions, otherItems) = loadFromInventory(mainInventory)
+        val (minions, otherItems) = loadFromInventoryAndSacks(mainInventory)
 
         display = drawDisplay(minions, otherItems)
     }
@@ -111,7 +112,7 @@ object MinionCraftHelper {
         return newDisplay
     }
 
-    private fun loadFromInventory(
+    private fun loadFromInventoryAndSacks(
         mainInventory: List<SafeItemStack>,
     ): Pair<MutableMap<String, NeuInternalName>, MutableMap<NeuInternalName, Int>> {
         init()
@@ -141,6 +142,18 @@ object MinionCraftHelper {
                 val (itemId, multiplier) = NeuItems.getPrimitiveMultiplier(rawId)
                 val old = otherItems.getOrDefault(itemId, 0)
                 otherItems[itemId] = old + item.count * multiplier
+            }
+        }
+
+        for ((internalName, item) in SackApi.sackData) {
+            if (!allIngredients.contains(internalName)) continue
+            if (!isAllowed(allMinions, internalName)) continue
+
+            val (itemId, multiplier) = NeuItems.getPrimitiveMultiplier(internalName)
+            val old = otherItems.getOrDefault(itemId, 0)
+            val newAmount = old + item.amount * multiplier
+            if (newAmount > 0) {
+                otherItems[itemId] = newAmount
             }
         }
 


### PR DESCRIPTION
# What
With the new beginner sacks available right as the start of bingo, players using them will deceive the current logic of MinionCraftHelper.

This commit makes uses of the current SackApi to get the required items from it.

Unfortunately, if the player is using a sack, the currently amount of materials the player has will be delayed by a significant amount of time, instead of being instantly without the sack.

## Changelog Improvements
+ MinionCraftHelper now also uses materials in sacks. - cornago