### PR TITLE
Feature: Bingo Active Effects Display

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/bingo/BingoConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/bingo/BingoConfig.kt
@@ -48,6 +48,20 @@ class BingoConfig {
     @ConfigLink(owner = BingoConfig::class, field = "minionCraftHelperEnabled")
     val minionCraftHelperPos: Position = Position(10, 10)
 
+    @Expose
+    @ConfigOption(
+        name = "Active Effects Display",
+        desc = "Show your total active effects and when they expire, so you know when your god " +
+            "splash runs out. Only shows on a Bingo profile."
+    )
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var activeEffectsDisplay: Boolean = true
+
+    @Expose
+    @ConfigLink(owner = BingoConfig::class, field = "activeEffectsDisplay")
+    val activeEffectsPosition: Position = Position(-200, 10)
+
     @ConfigOption(name = "Bingo Boop Party", desc = "Bingo Boop Party has been moved to Misc. Click here to jump straight to it.")
     @ConfigEditorButton(buttonText = "Go")
     val boopPartyJumpButton = Runnable { SkyHanniMod.feature.misc.boopParty::boopPartyBingo.jumpToEditor() }

--- a/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
@@ -304,7 +304,7 @@ object EffectApi {
     private fun readActiveEffectTimes(lines: List<Component>): List<Duration> {
         val times = mutableListOf<Duration>()
         tabEffectPattern.matchAllComponents(lines) {
-            TimeUtils.getDurationOrNull(group("time"))?.let { times.add(it) }
+            TimeUtils.getDurationOrNull(group("time"))?.let { time -> times.add(time) }
         }
         return times
     }

--- a/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/EffectApi.kt
@@ -149,6 +149,15 @@ object EffectApi {
     )
 
     /**
+     * REGEX-TEST: You have 28 active effects. Use "/effects" to see them!
+     * REGEX-TEST: You have 10 non-god effects.
+     */
+    private val activeEffectsCountPattern by patternGroup.pattern(
+        "footer.active-effects-count",
+        "You have (?<count>\\d+) (?:active|non-god) effects?.*",
+    )
+
+    /**
      * REGEX-TEST: Active Effects
      */
     private val activeEffectsFooterPattern by patternGroup.pattern(
@@ -171,6 +180,17 @@ object EffectApi {
 
     private val profileStorage get() = ProfileStorageData.profileSpecific
     internal var totalEffectsCount = 0
+
+    /**
+     * Total active effects currently shown in the tab footer (either the "active" or "non-god"
+     * wording). Unlike [totalEffectsCount] this counts every effect, not just non-god ones.
+     */
+    var totalActiveEffects = 0
+        private set
+
+    /** The soonest-expiring active effect's remaining time, as shown in the tab footer, or null. */
+    var soonestActiveEffectRemaining: Duration? = null
+        private set
 
     // Todo: Add support for poison candy I, and add support for splash / other formats
     @HandleEvent(onlyOnSkyblock = true)
@@ -209,6 +229,17 @@ object EffectApi {
 
     @HandleEvent(onlyOnSkyblock = true)
     private fun onTabListFooterUpdate(event: TablistFooterUpdateEvent) {
+        // Only scan within the "Active Effects" section so unrelated footer lines can't be misread
+        // as effects. Empty when there is no such section, which resets the values to "none".
+        val effectSection = activeEffectsSection(event.footer)
+        val effectTimes = readActiveEffectTimes(effectSection)
+        soonestActiveEffectRemaining = effectTimes.minOrNull()
+        // The count line only appears when the footer truncates the effect list; with few effects
+        // it lists them all inline, so fall back to the number of effects actually shown.
+        totalActiveEffects = activeEffectsCountPattern.firstComponentMatcher(effectSection) {
+            group("count").toIntOrNull()
+        } ?: effectTimes.size
+
         if (!activeEffectsFooterPattern.anyMatchesComponent(event.footer)) return
         event.footer.readNonGodPotEffects()
 
@@ -251,6 +282,31 @@ object EffectApi {
             }
             else -> {}
         }
+    }
+
+    /** The footer's "Active Effects" section: the title line through the next blank line. */
+    private fun activeEffectsSection(footer: List<Component>): List<Component> {
+        val start = footer.indexOfFirst { activeEffectsFooterPattern.matches(it) }
+        if (start == -1) return emptyList()
+        val section = mutableListOf<Component>()
+        for (index in start until footer.size) {
+            val line = footer[index]
+            if (index != start && line.string.isBlank()) break
+            section.add(line)
+        }
+        return section
+    }
+
+    /**
+     * Reads the remaining time of every effect shown in the given lines (not just the allowlisted
+     * [NonGodPotEffect]s), so consumers can show generic effects like god-splash buffs.
+     */
+    private fun readActiveEffectTimes(lines: List<Component>): List<Duration> {
+        val times = mutableListOf<Duration>()
+        tabEffectPattern.matchAllComponents(lines) {
+            TimeUtils.getDurationOrNull(group("time"))?.let { times.add(it) }
+        }
+        return times
     }
 
     private fun List<Component>.readNonGodPotEffects() = tabEffectPattern.matchAllComponents(this) {

--- a/src/main/java/at/hannibal2/skyhanni/features/bingo/BingoActiveEffectsDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/bingo/BingoActiveEffectsDisplay.kt
@@ -1,0 +1,137 @@
+package at.hannibal2.skyhanni.features.bingo
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.events.GuiRenderEvent
+import at.hannibal2.skyhanni.events.TablistFooterUpdateEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.RenderUtils.VerticalAlignment
+import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
+import at.hannibal2.skyhanni.utils.SafeItemStack
+import at.hannibal2.skyhanni.utils.SkyBlockUtils
+import at.hannibal2.skyhanni.utils.TimeUtils
+import at.hannibal2.skyhanni.utils.renderables.Renderable
+import at.hannibal2.skyhanni.utils.renderables.container.HorizontalContainerRenderable.Companion.horizontal
+import at.hannibal2.skyhanni.utils.renderables.container.VerticalContainerRenderable.Companion.vertical
+import at.hannibal2.skyhanni.utils.renderables.primitives.ItemStackRenderable.Companion.item
+import at.hannibal2.skyhanni.utils.renderables.primitives.text
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import net.minecraft.core.component.DataComponents
+import net.minecraft.network.chat.Component
+import net.minecraft.world.item.Items
+import net.minecraft.world.item.alchemy.PotionContents
+import net.minecraft.world.item.alchemy.Potions
+import kotlin.time.Duration
+
+/**
+ * While on a Bingo profile, shows a small top-right readout of the total active effects and when
+ * they expire (the soonest-expiring buff), so the player knows when to get their next god splash.
+ * Sourced from the tab list's "Active Effects" footer section.
+ */
+@SkyHanniModule
+object BingoActiveEffectsDisplay {
+
+    private val config get() = SkyHanniMod.feature.event.bingo
+
+    private val patternGroup = RepoPattern.group("bingo.activeeffects")
+
+    // A vanilla potion tinted red (an empty potion renders as a colorless water bottle); the
+    // Healing potion's contents give it the classic red potion color.
+    private val potionIcon by lazy {
+        Renderable.item(
+            SafeItemStack(Items.POTION) {
+                set(DataComponents.POTION_CONTENTS, PotionContents(Potions.HEALING))
+            },
+        )
+    }
+
+    /**
+     * REGEX-TEST: Active Effects
+     */
+    private val footerTitlePattern by patternGroup.pattern(
+        "footer.title",
+        "Active Effects",
+    )
+
+    /**
+     * REGEX-TEST: You have 28 active effects. Use "/effects" to see them!
+     * REGEX-TEST: You have 1 non-god effects.
+     */
+    private val effectCountPattern by patternGroup.pattern(
+        "footer.count",
+        "You have (?<count>\\d+) (?:active|non-god) effects?.*",
+    )
+
+    /**
+     * REGEX-TEST: Adrenaline VIII 10m
+     * REGEX-TEST: Wisp's Ice-Flavored Water I 1h 27m
+     */
+    private val effectLinePattern by patternGroup.pattern(
+        "footer.effect-line",
+        "(?<name>.+?)[:\\s]+(?<time>(?:\\d+[wdhms]\\s?)+)\\s*",
+    )
+
+    private var display: Renderable? = null
+
+    @HandleEvent
+    private fun onProfileJoin() {
+        display = null
+    }
+
+    @HandleEvent(onlyOnSkyblock = true)
+    private fun onTabListFooterUpdate(event: TablistFooterUpdateEvent) {
+        display = buildDisplay(event.footer)
+    }
+
+    private fun buildDisplay(footer: List<Component>): Renderable? {
+        val startIndex = footer.indexOfFirst { footerTitlePattern.matches(it) }
+        if (startIndex == -1) return null
+
+        var totalEffects: Int? = null
+        var soonest: Duration? = null
+        var soonestRaw: String? = null
+
+        for (index in startIndex until footer.size) {
+            val line = footer[index].string
+            // The Active Effects block ends at the next blank line (footer section boundary).
+            if (index != startIndex && line.isBlank()) break
+
+            effectCountPattern.matchMatcher(line) {
+                totalEffects = group("count").toIntOrNull()
+            }
+            effectLinePattern.matchMatcher(line) {
+                val raw = group("time").trim()
+                val duration = TimeUtils.getDurationOrNull(raw) ?: return@matchMatcher
+                val current = soonest
+                if (current == null || duration < current) {
+                    soonest = duration
+                    soonestRaw = raw
+                }
+            }
+        }
+
+        val lines = buildList {
+            totalEffects?.let { add("§aTotal Effects: §e$it") }
+            soonestRaw?.let { add("§aEffect Duration: §e$it") }
+        }
+        if (lines.isEmpty()) return null
+
+        return Renderable.horizontal(
+            potionIcon,
+            Renderable.vertical(lines.map { Renderable.text(it) }),
+            spacing = 3,
+            verticalAlign = VerticalAlignment.CENTER,
+        )
+    }
+
+    @HandleEvent
+    private fun onGuiRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
+        if (!isEnabled()) return
+        val current = display ?: return
+        config.activeEffectsPosition.renderRenderable(current, posLabel = "Bingo Active Effects")
+    }
+
+    private fun isEnabled() = SkyBlockUtils.isBingoProfile && config.activeEffectsDisplay
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/bingo/BingoActiveEffectsDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/bingo/BingoActiveEffectsDisplay.kt
@@ -2,40 +2,34 @@ package at.hannibal2.skyhanni.features.bingo
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.effect.EffectApi
 import at.hannibal2.skyhanni.events.GuiRenderEvent
-import at.hannibal2.skyhanni.events.TablistFooterUpdateEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
-import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.RenderUtils.VerticalAlignment
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
-import at.hannibal2.skyhanni.utils.TimeUtils
+import at.hannibal2.skyhanni.utils.TimeUnit
+import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.container.HorizontalContainerRenderable.Companion.horizontal
 import at.hannibal2.skyhanni.utils.renderables.container.VerticalContainerRenderable.Companion.vertical
 import at.hannibal2.skyhanni.utils.renderables.primitives.ItemStackRenderable.Companion.item
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
-import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.core.component.DataComponents
-import net.minecraft.network.chat.Component
 import net.minecraft.world.item.Items
 import net.minecraft.world.item.alchemy.PotionContents
 import net.minecraft.world.item.alchemy.Potions
-import kotlin.time.Duration
 
 /**
  * While on a Bingo profile, shows a small top-right readout of the total active effects and when
- * they expire (the soonest-expiring buff), so the player knows when to get their next god splash.
- * Sourced from the tab list's "Active Effects" footer section.
+ * the soonest one expires, so the player knows when to get their next god splash. The effect data
+ * (count and live remaining time) is parsed centrally by [EffectApi]; this only renders it.
  */
 @SkyHanniModule
 object BingoActiveEffectsDisplay {
 
     private val config get() = SkyHanniMod.feature.event.bingo
-
-    private val patternGroup = RepoPattern.group("bingo.activeeffects")
 
     // A vanilla potion tinted red (an empty potion renders as a colorless water bottle); the
     // Healing potion's contents give it the classic red potion color.
@@ -47,32 +41,6 @@ object BingoActiveEffectsDisplay {
         )
     }
 
-    /**
-     * REGEX-TEST: Active Effects
-     */
-    private val footerTitlePattern by patternGroup.pattern(
-        "footer.title",
-        "Active Effects",
-    )
-
-    /**
-     * REGEX-TEST: You have 28 active effects. Use "/effects" to see them!
-     * REGEX-TEST: You have 1 non-god effects.
-     */
-    private val effectCountPattern by patternGroup.pattern(
-        "footer.count",
-        "You have (?<count>\\d+) (?:active|non-god) effects?.*",
-    )
-
-    /**
-     * REGEX-TEST: Adrenaline VIII 10m
-     * REGEX-TEST: Wisp's Ice-Flavored Water I 1h 27m
-     */
-    private val effectLinePattern by patternGroup.pattern(
-        "footer.effect-line",
-        "(?<name>.+?)[:\\s]+(?<time>(?:\\d+[wdhms]\\s?)+)\\s*",
-    )
-
     private var display: Renderable? = null
 
     @HandleEvent
@@ -80,44 +48,21 @@ object BingoActiveEffectsDisplay {
         display = null
     }
 
-    @HandleEvent(onlyOnSkyblock = true)
-    private fun onTabListFooterUpdate(event: TablistFooterUpdateEvent) {
-        display = buildDisplay(event.footer)
+    @HandleEvent
+    private fun onSecondPassed() {
+        if (!isEnabled()) return
+        display = buildDisplay()
     }
 
-    private fun buildDisplay(footer: List<Component>): Renderable? {
-        val startIndex = footer.indexOfFirst { footerTitlePattern.matches(it) }
-        if (startIndex == -1) return null
-
-        var totalEffects: Int? = null
-        var soonest: Duration? = null
-        var soonestRaw: String? = null
-
-        for (index in startIndex until footer.size) {
-            val line = footer[index].string
-            // The Active Effects block ends at the next blank line (footer section boundary).
-            if (index != startIndex && line.isBlank()) break
-
-            effectCountPattern.matchMatcher(line) {
-                totalEffects = group("count").toIntOrNull()
-            }
-            effectLinePattern.matchMatcher(line) {
-                val raw = group("time").trim()
-                val duration = TimeUtils.getDurationOrNull(raw) ?: return@matchMatcher
-                val current = soonest
-                if (current == null || duration < current) {
-                    soonest = duration
-                    soonestRaw = raw
-                }
+    private fun buildDisplay(): Renderable {
+        val lines = if (EffectApi.totalActiveEffects <= 0) {
+            listOf("§cNo potion effects active")
+        } else buildList {
+            add("§aTotal Effects: §e${EffectApi.totalActiveEffects}")
+            EffectApi.soonestActiveEffectRemaining?.let {
+                add("§aEffect Duration: §e${it.format(TimeUnit.HOUR)}")
             }
         }
-
-        val lines = buildList {
-            totalEffects?.let { add("§aTotal Effects: §e$it") }
-            soonestRaw?.let { add("§aEffect Duration: §e$it") }
-        }
-        if (lines.isEmpty()) return null
-
         return Renderable.horizontal(
             potionIcon,
             Renderable.vertical(lines.map { Renderable.text(it) }),


### PR DESCRIPTION
## What
Adds a small display on Bingo profiles that shows how many potion effects you have and when they run out, so you know when to get your next god splash. 

<details>
<summary>Images</summary>

Config: Events -> Bingo
<img width="646" height="537" alt="image" src="https://github.com/user-attachments/assets/03d34780-0d2c-4eca-a88b-3b6f40eab29f" />

On-screen display with potion effects active:
<img width="310" height="70" alt="Total Eriects 19" src="https://github.com/user-attachments/assets/5a9d86bf-6787-4031-af1e-51af76f77a1c" />

On-screen display with no potion effects active:
<img width="301" height="57" alt="¿ No potion effecte active" src="https://github.com/user-attachments/assets/06e14dab-6b91-441f-a7ee-354c507d1bb1" />


</details>

## Changelog New Features
+ Added a Bingo display showing your total potion effects and when they run out. - RemainingDelta

