### PR TITLE
Backend: Update Detekt to 2.0.0-alpha.6

### DIFF
--- a/detekt/build.gradle.kts
+++ b/detekt/build.gradle.kts
@@ -1,7 +1,5 @@
 import dev.detekt.gradle.Detekt
 import dev.detekt.gradle.DetektCreateBaselineTask
-import org.gradle.api.artifacts.ComponentMetadataContext
-import org.gradle.api.artifacts.ComponentMetadataRule
 
 plugins {
     kotlin("jvm")
@@ -9,32 +7,7 @@ plugins {
     id("dev.detekt")
 }
 
-// TODO remove this once Detekt 2.0.0-alpha.6 is out
-// https://github.com/detekt/detekt/issues/9409
-abstract class DetektTestMetadataRule : ComponentMetadataRule {
-
-    override fun execute(context: ComponentMetadataContext) {
-        val version = context.details.id.version
-        if (version != "2.0.0-alpha.4" && version != "2.0.0-alpha.5") return
-
-        context.details.withVariant("runtimeElements") {
-            withDependencies {
-                // detekt-test 2.0.0-alpha.4 and 2.0.0-alpha.5 request detekt-api test fixtures, but
-                // detekt-api only publishes fixture sources.
-                removeAll { it.group == "dev.detekt" && it.name == "detekt-api" }
-                add("dev.detekt:detekt-api:$version")
-            }
-        }
-    }
-}
-
 dependencies {
-    // TODO remove this once Detekt 2.0.0-alpha.6 is out
-    // https://github.com/detekt/detekt/issues/9409
-    components {
-        withModule<DetektTestMetadataRule>("dev.detekt:detekt-test")
-    }
-
     compileOnly(libs.detekt.api)
     ksp(libs.autoservice.ksp)
     implementation(libs.autoservice.annotations)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ shadow = "9.6.0"
 loom = "1.17-SNAPSHOT"
 kotlin = "2.4.10"
 ksp = "2.3.10"
-detekt = "2.0.0-alpha.5"
+detekt = "2.0.0-alpha.6"
 
 devauth = "1.2.2"
 junit = "5.14.4"

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/translation/TranslatableLanguage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/translation/TranslatableLanguage.kt
@@ -1,7 +1,6 @@
 package at.hannibal2.skyhanni.features.chat.translation
 
-enum class TranslatableLanguage(private val englishName: String, private val nativeName: String, val languageCode: String) {
-
+enum class TranslatableLanguage(englishName: String, nativeName: String, val languageCode: String) {
     // 1. First Language - The primary language of the application.
     ENGLISH("English", "", "en"),
 

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/seaCreatureXMLGui/SpecificSeaCreatureStorageXMLHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/seaCreatureXMLGui/SpecificSeaCreatureStorageXMLHelper.kt
@@ -4,10 +4,7 @@ import at.hannibal2.skyhanni.utils.ConfigUtils.asStructuredText
 import io.github.notenoughupdates.moulconfig.common.text.StructuredText
 import io.github.notenoughupdates.moulconfig.xml.Bind
 
-
-class SpecificSeaCreatureStorageXMLHelper(
-    private val from: SpecificSeaCreatureSettings,
-) {
+class SpecificSeaCreatureStorageXMLHelper(from: SpecificSeaCreatureSettings) {
     @field:Bind
     var name: String = from.name
 
@@ -39,9 +36,5 @@ class SpecificSeaCreatureStorageXMLHelper(
     var shouldWarnWhenCocooned: Boolean? = from.shouldWarnWhenCocooned
 
     @Bind
-    fun getName(): StructuredText {
-        return name.asStructuredText()
-    }
-
+    fun getName(): StructuredText = name.asStructuredText()
 }
-

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordIPC.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordIPC.kt
@@ -18,10 +18,9 @@ import java.util.UUID
  * @param onDebugInfo Called with diagnostic key-value pairs if pipe discovery fails.
  */
 class DiscordIPC(
-    private val clientId: Long,
+    clientId: Long,
     private val onDebugInfo: (Map<String, String>) -> Unit = {},
 ) : Closeable {
-
     @Volatile
     private var _connected = false
     private var pipe: DiscordIPCPipe? = null

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemUtils.kt
@@ -97,7 +97,6 @@ import kotlin.time.Duration.Companion.seconds
 @SkyHanniModule
 @Suppress("LargeClass")
 object ItemUtils {
-
     private val patternGroup = RepoPattern.group("utils.item")
 
     // <editor-fold desc="Patterns">
@@ -400,13 +399,12 @@ object ItemUtils {
     }
 
     class AutoUpdatingRepoSkullItemStack internal constructor(
-        private val displayName: String,
-        private val uuid: String,
-        private val repoSkullId: String,
-        private val lore: List<String>,
-        private val extraOps: (SafeItemStack.() -> Unit)?,
+        displayName: String,
+        uuid: String,
+        repoSkullId: String,
+        lore: List<String>,
+        extraOps: (SafeItemStack.() -> Unit)?,
     ) : ItemStackProvider {
-
         private val value = StableOrTransientValue(1.seconds) {
             val texture = SkullTextureHolder.getTexture(repoSkullId)
             val stack = createSkull(


### PR DESCRIPTION
## What
Updates Detekt to 2.0.0-alpha.6 and fixes new errors.

## Changelog Technical Details
+ Updated Detekt from 2.0.0-alpha.5 to 2.0.0-alpha.6. - Luna