### PR TITLE
Fix: Fishing Hook Display Stop not working sometimes

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHookDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHookDisplay.kt
@@ -55,8 +55,8 @@ object FishingHookDisplay {
     @HandleEvent(onlyOnSkyblock = true)
     private fun onEntityTextUpdate(event: EntityCustomNameUpdateEvent<ArmorStand>) {
         if (!isEnabled()) return
-
         val newName = event.newName ?: return
+        val bobber = FishingApi.bobber ?: return
 
         val displayText = fishingHookPattern.matchMatcher(newName) {
             if (groupOrNull("alert") != null) {
@@ -70,8 +70,7 @@ object FishingHookDisplay {
 
         val current = timerEntity
         if (current != null && current.id != event.entity.id) {
-            val bobber = FishingApi.bobber ?: return
-
+            // Prefer the closest entity to the bobber if there ar multiple
             if (current.position.distanceTo(bobber.position()) < position.distanceTo(bobber.position())) {
                 return
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHookDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHookDisplay.kt
@@ -70,7 +70,7 @@ object FishingHookDisplay {
 
         val current = timerEntity
         if (current != null && current.id != event.entity.id) {
-            // Prefer the closest entity to the bobber if there ar multiple
+            // Prefer the closest entity to the bobber if there are multiple
             if (current.position.distanceTo(bobber.position()) < position.distanceTo(bobber.position())) {
                 return
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHookDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHookDisplay.kt
@@ -5,96 +5,121 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.config.core.config.Position
 import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
-import at.hannibal2.skyhanni.events.GuiRenderEvent
-import at.hannibal2.skyhanni.events.entity.EntityEnterWorldEvent
-import at.hannibal2.skyhanni.events.fishing.FishingBobberCastEvent
+import at.hannibal2.skyhanni.events.entity.EntityCustomNameUpdateEvent
+import at.hannibal2.skyhanni.events.entity.EntityRemovedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
+import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
-import at.hannibal2.skyhanni.utils.compat.deceased
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.world.entity.decoration.ArmorStand
+import net.minecraft.world.phys.Vec3
 
 @SkyHanniModule
 object FishingHookDisplay {
 
     private val config get() = SkyHanniMod.feature.fishing.fishingHookDisplay
-    private var armorStand: ArmorStand? = null
-    private val potentialArmorStands = mutableListOf<ArmorStand>()
 
-    // Todo repo pattern?
-    private val pattern = "§e§l(\\d+(\\.\\d+)?)".toPattern()
+    private data class TimerEntity(
+        val id: Int,
+        val display: Renderable,
+        val position: Vec3,
+    )
+
+    private var timerEntity: TimerEntity? = null
+
+    /**
+     * REGEX-TEST: 3.0
+     * REGEX-TEST: 1.2
+     * REGEX-TEST: !!!
+     */
+    private val fishingHookPattern by RepoPattern.pattern(
+        "fishing.hook-display",
+        "(?:§.)*?(?:(?<time>\\d+(?:\\.\\d+)?)|(?<alert>!!!))"
+    )
+
     private var isRendering = false
 
     @HandleEvent
-    fun onWorldChange() = reset()
+    private fun onWorldChange() {
+        reset()
+    }
 
     @HandleEvent
-    fun onBobberThrow(event: FishingBobberCastEvent) = reset()
+    private fun onBobberCast() {
+        reset()
+    }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onTick() {
+    private fun onEntityTextUpdate(event: EntityCustomNameUpdateEvent<ArmorStand>) {
         if (!isEnabled()) return
 
-        if (armorStand == null) {
-            val filter = potentialArmorStands.filter { it.hasCustomName() && it.hasCorrectName() }
-            if (filter.size == 1) {
-                armorStand = filter[0]
+        val newName = event.newName ?: return
+
+        val displayText = fishingHookPattern.matchMatcher(newName) {
+            if (groupOrNull("alert") != null) {
+                config.customAlertText.replace("&", "§").asComponent()
+            } else {
+                newName
             }
+        } ?: return
+
+        val position = event.entity.position()
+
+        val current = timerEntity
+        if (current != null && current.id != event.entity.id) {
+            val bobber = FishingApi.bobber ?: return
+
+            if (current.position.distanceTo(bobber.position()) < position.distanceTo(bobber.position())) {
+                return
+            }
+        }
+
+        timerEntity = TimerEntity(
+            event.entity.id,
+            Renderable.text(displayText),
+            position,
+        )
+    }
+
+    @HandleEvent(onlyOnSkyblock = true)
+    private fun onEntityTextRemoved(event: EntityRemovedEvent<ArmorStand>) {
+        if (event.entity.id == timerEntity?.id) {
+            reset()
         }
     }
 
-    private fun reset() {
-        potentialArmorStands.clear()
-        armorStand = null
-    }
-
     @HandleEvent(onlyOnSkyblock = true)
-    fun onJoinWorld(event: EntityEnterWorldEvent<ArmorStand>) {
-        if (!isEnabled()) return
-        potentialArmorStands.add(event.entity)
-    }
-
-    @HandleEvent(onlyOnSkyblock = true)
-    fun onCheckRender(event: CheckRenderEntityEvent<ArmorStand>) {
+    private fun onEntityTextCheckRender(event: CheckRenderEntityEvent<ArmorStand>) {
         if (!isEnabled()) return
         if (!config.hideArmorStand) return
         if (!isRendering) return
 
-        if (event.entity == armorStand) {
+        if (event.entity.id == timerEntity?.id) {
             event.cancel()
         }
     }
 
-    // TODO add a cache instead of re-calculating every frame
     @HandleEvent(onlyOnSkyblock = true)
-    fun onGuiRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
+    private fun onGuiRenderOverlay() {
         if (!isEnabled()) return
         isRendering = false
-
-        val armorStand = armorStand ?: return
-        if (armorStand.deceased) {
-            reset()
-            return
-        }
-        if (!armorStand.hasCustomName() || !armorStand.isCustomNameVisible) return
-        val alertText = Renderable.text(
-            if (armorStand.name.string == "!!!") config.customAlertText.replace("&", "§")
-            else armorStand.name.formattedTextCompatLessResets(),
-        )
-
+        val timerEntity = timerEntity ?: return
         isRendering = true
-        config.position.renderRenderable(alertText, posLabel = "Fishing Hook Display")
+        config.position.renderRenderable(timerEntity.display, posLabel = "Fishing Hook Display")
+    }
+
+    private fun reset() {
+        timerEntity = null
     }
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.transform(72, "fishing.fishingHookDisplay.position", Position::migrate)
     }
-
-    private fun ArmorStand.hasCorrectName(): Boolean =
-        (name.string == "!!!") || pattern.matcher(name.formattedTextCompatLessResets()).matches()
 
     fun isEnabled() = config.enabled && FishingApi.holdingRod
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHookDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHookDisplay.kt
@@ -35,12 +35,13 @@ object FishingHookDisplay {
      * REGEX-TEST: §e§l3.0
      * REGEX-TEST: §e§l1.2
      * REGEX-TEST: §c§l!!!
-     * REGEX-TEST: 3.0
      * REGEX-TEST: !!!
+     * REGEX-FAIL: §736
+     * REGEX-FAIL: §772
      */
     private val timerPattern by RepoPattern.pattern(
         "fishing.hook.timer",
-        "(?:§.)*(?:(?<time>\\d+(?:\\.\\d+)?)|(?<alert>!!!))",
+        "§e§l(?<time>\\d+(?:\\.\\d+)?)|(?:§.)*(?<alert>!!!)",
     )
 
     private var isRendering = false

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHookDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHookDisplay.kt
@@ -11,7 +11,6 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
-import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -61,7 +60,7 @@ object FishingHookDisplay {
 
         val displayText = fishingHookPattern.matchMatcher(newName) {
             if (groupOrNull("alert") != null) {
-                config.customAlertText.replace("&", "§").asComponent()
+                config.customAlertText.replace("&", "§")
             } else {
                 newName
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHookDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHookDisplay.kt
@@ -8,36 +8,39 @@ import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
 import at.hannibal2.skyhanni.events.entity.EntityCustomNameUpdateEvent
 import at.hannibal2.skyhanni.events.entity.EntityRemovedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
+import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.world.entity.decoration.ArmorStand
-import net.minecraft.world.phys.Vec3
 
 @SkyHanniModule
 object FishingHookDisplay {
 
     private val config get() = SkyHanniMod.feature.fishing.fishingHookDisplay
 
-    private data class TimerEntity(
+    private data class TimerDisplay(
         val id: Int,
-        val display: Renderable,
-        val position: Vec3,
+        val renderable: Renderable,
+        val position: LorenzVec,
     )
 
-    private var timerEntity: TimerEntity? = null
+    private var timerDisplay: TimerDisplay? = null
 
     /**
+     * REGEX-TEST: §e§l3.0
+     * REGEX-TEST: §e§l1.2
+     * REGEX-TEST: §c§l!!!
      * REGEX-TEST: 3.0
-     * REGEX-TEST: 1.2
      * REGEX-TEST: !!!
      */
-    private val fishingHookPattern by RepoPattern.pattern(
-        "fishing.hook-display",
-        "(?:§.)*?(?:(?<time>\\d+(?:\\.\\d+)?)|(?<alert>!!!))"
+    private val timerPattern by RepoPattern.pattern(
+        "fishing.hook.timer",
+        "(?:§.)*(?:(?<time>\\d+(?:\\.\\d+)?)|(?<alert>!!!))",
     )
 
     private var isRendering = false
@@ -53,12 +56,12 @@ object FishingHookDisplay {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    private fun onEntityTextUpdate(event: EntityCustomNameUpdateEvent<ArmorStand>) {
+    private fun onEntityCustomNameUpdate(event: EntityCustomNameUpdateEvent<ArmorStand>) {
         if (!isEnabled()) return
         val newName = event.newName ?: return
         val bobber = FishingApi.bobber ?: return
 
-        val displayText = fishingHookPattern.matchMatcher(newName) {
+        val displayText = timerPattern.matchMatcher(newName) {
             if (groupOrNull("alert") != null) {
                 config.customAlertText.replace("&", "§")
             } else {
@@ -66,17 +69,16 @@ object FishingHookDisplay {
             }
         } ?: return
 
-        val position = event.entity.position()
+        val position = event.entity.getLorenzVec()
 
-        val current = timerEntity
+        val current = timerDisplay
         if (current != null && current.id != event.entity.id) {
             // Prefer the closest entity to the bobber if there are multiple
-            if (current.position.distanceTo(bobber.position()) < position.distanceTo(bobber.position())) {
-                return
-            }
+            val bobberPosition = bobber.getLorenzVec()
+            if (current.position.distance(bobberPosition) < position.distance(bobberPosition)) return
         }
 
-        timerEntity = TimerEntity(
+        timerDisplay = TimerDisplay(
             event.entity.id,
             Renderable.text(displayText),
             position,
@@ -84,19 +86,19 @@ object FishingHookDisplay {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    private fun onEntityTextRemoved(event: EntityRemovedEvent<ArmorStand>) {
-        if (event.entity.id == timerEntity?.id) {
+    private fun onEntityRemoved(event: EntityRemovedEvent<ArmorStand>) {
+        if (event.entity.id == timerDisplay?.id) {
             reset()
         }
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    private fun onEntityTextCheckRender(event: CheckRenderEntityEvent<ArmorStand>) {
+    private fun onCheckRender(event: CheckRenderEntityEvent<ArmorStand>) {
         if (!isEnabled()) return
         if (!config.hideArmorStand) return
         if (!isRendering) return
 
-        if (event.entity.id == timerEntity?.id) {
+        if (event.entity.id == timerDisplay?.id) {
             event.cancel()
         }
     }
@@ -105,13 +107,13 @@ object FishingHookDisplay {
     private fun onGuiRenderOverlay() {
         if (!isEnabled()) return
         isRendering = false
-        val timerEntity = timerEntity ?: return
+        val timerDisplay = timerDisplay ?: return
         isRendering = true
-        config.position.renderRenderable(timerEntity.display, posLabel = "Fishing Hook Display")
+        config.position.renderRenderable(timerDisplay.renderable, posLabel = "Fishing Hook Display")
     }
 
     private fun reset() {
-        timerEntity = null
+        timerDisplay = null
     }
 
     @HandleEvent


### PR DESCRIPTION
## What
Instead of doing a check each tick, it will see all custom name changes and create the display/renderable once.
If it's there is not known entity it uses the detected one,
if it's the same entity as the previous it just updates,
and if it's a different entity it uses the one closest to the bobber.

I have tested in torrhus, and it works.
(Some users report that it currently randomly stops showing the display like 1h after fishing, but I can't replicate that or prove this fixed it. but I hope the "closest to bobber" logic maybe fixes that)

## Changelog Fixes
+ Fixed the Fishing Hook Display not showing while other players are fishing nearby. - Avrg

## Changelog Technical Details
+ Improved FishingHookDisplay to only run on entity custom name change instead of each tick. - Avrg