### PR TITLE
Backend: Improved Enforced Config Values

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
@@ -85,6 +85,8 @@ class ConfigManager {
         }
 
         val features = SkyHanniMod.feature
+        // Has to run before the config is built, so that enforced options are already blocked off
+        EnforcedConfigValues.loadFromLocalRepo()
         recreateConfig()
 
         try {

--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
@@ -73,7 +73,6 @@ class ConfigManager {
         }
         configDirectory.mkdirs()
 
-
         for (fileType in ConfigFileType.entries) {
             val clazzInstance = fileType.clazz.getDeclaredConstructor().newInstance()
             setConfigHolder(fileType, firstLoadFile(fileType.file, fileType, clazzInstance))
@@ -208,18 +207,27 @@ class ConfigManager {
 
     fun saveConfig(fileType: ConfigFileType, reason: String) {
         val json = jsonHolder[fileType] ?: error("Could not find json object for $fileType")
-        saveFile(fileType.file, fileType.fileName, json, reason)
-        saveFile(fileType.backupFile, fileType.fileName, json, reason)
+        saveFile(fileType.file, fileType, json, reason)
+        saveFile(fileType.backupFile, fileType, json, reason)
     }
 
-    private fun saveFile(file: File, fileName: String, data: Any, reason: String) {
+    private fun serialize(fileType: ConfigFileType, data: Any): String {
+        if (fileType != ConfigFileType.FEATURES) return gson.toJson(data)
+        // Enforced values only ever exist in memory, the file keeps the user's own values
+        val json = gson.toJsonTree(data)
+        EnforcedConfigValues.writeUserValues(json)
+        return gson.toJson(json)
+    }
+
+    private fun saveFile(file: File, fileType: ConfigFileType, data: Any, reason: String) {
+        val fileName = fileType.fileName
         if (disableSaving) return
         if (HypixelData.hypixelAlpha && !PlatformUtils.isDevEnvironment) return
         logger.log("saveConfig: $reason")
         try {
             logger.log("Saving $fileName file")
             file.parentFile.mkdirs()
-            StringFileHandler(file).save(gson.toJson(data))
+            StringFileHandler(file).save(serialize(fileType, data))
             logger.log("Saved $fileName file successfully")
         } catch (e: ClassCastException) {
             ErrorManager.logErrorWithData(

--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
@@ -214,9 +214,7 @@ class ConfigManager {
     private fun serialize(fileType: ConfigFileType, data: Any): String {
         if (fileType != ConfigFileType.FEATURES) return gson.toJson(data)
         // Enforced values only ever exist in memory, the file keeps the user's own values
-        val json = gson.toJsonTree(data)
-        EnforcedConfigValues.writeUserValues(json)
-        return gson.toJson(json)
+        return gson.toJson(EnforcedConfigValues.toUserJsonTree(data))
     }
 
     private fun saveFile(file: File, fileType: ConfigFileType, data: Any, reason: String) {

--- a/src/main/java/at/hannibal2/skyhanni/config/EnforcedConfigValues.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/EnforcedConfigValues.kt
@@ -15,14 +15,28 @@ import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.json.Shimmy
 import at.hannibal2.skyhanni.utils.system.PlatformUtils
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.time.Duration.Companion.INFINITE
 
+/**
+ * Overrides config options with values from the repo. By default, the overrides only ever exist in memory: the config
+ * file on disk keeps the user's own values, so lifting an enforcement (or downgrading) never loses them. Enforced
+ * values marked as persistent are written to the config file like any other value instead.
+ */
 @SkyHanniModule
 object EnforcedConfigValues {
     private const val CONSTANT = "misc/EnforcedConfigValues"
 
     private var enforcedConfigValuesData: List<EnforcedValueData> = listOf()
     private var hasSentPSAsOnce = false
+
+    // The user's own values of the options that are currently enforced, keyed by config path.
+    // Accessed from the config auto-save thread as well, hence the concurrent map.
+    private val userValues = ConcurrentHashMap<String, UserValue>()
+
+    private class UserValue(val userValue: JsonElement, val enforcedValue: JsonElement)
 
     /**
      * Applies the values cached in the local repo, so that enforcement does not have to wait for the
@@ -84,7 +98,10 @@ object EnforcedConfigValues {
     }
 
     private fun enforceOntoConfig(config: Any) {
-        for (enforcedValue in enforcedConfigValuesData.flatMap { it.enforcedValues }) {
+        val enforcedValues = enforcedConfigValuesData.flatMap { it.enforcedValues }
+        restoreNoLongerEnforced(config, enforcedValues.mapTo(mutableSetOf()) { it.path })
+
+        for (enforcedValue in enforcedValues) {
             try {
                 enforceValue(config, enforcedValue)
             } catch (e: Exception) {
@@ -100,8 +117,43 @@ object EnforcedConfigValues {
     private fun enforceValue(config: Any, enforcedValue: EnforcedValue) {
         val shimmy = Shimmy(config, enforcedValue.path.split("."))
             ?: ErrorManager.skyHanniError("Could not create shimmy for path ${enforcedValue.path}")
-        if (shimmy.getJson() == enforcedValue.value) return
+        val currentValue = shimmy.getJson()
+        if (enforcedValue.persist) {
+            // Persistent values replace the user's value for good, so there is nothing to restore later
+            userValues.remove(enforcedValue.path)
+        } else if (currentValue != enforcedValue.value) {
+            // When the option is already enforced, the current value is a previously enforced one, not the user's
+            val userValue = userValues[enforcedValue.path]?.userValue ?: currentValue
+            userValues[enforcedValue.path] = UserValue(userValue, enforcedValue.value)
+        }
+        if (currentValue == enforcedValue.value) return
         shimmy.setJson(enforcedValue.value)
+    }
+
+    private fun restoreNoLongerEnforced(config: Any, enforcedPaths: Set<String>) {
+        for (path in userValues.keys.filter { it !in enforcedPaths }) {
+            val backup = userValues.remove(path) ?: continue
+            val shimmy = Shimmy(config, path.split(".")) ?: continue
+            // Keep the current value if anything changed it after it was enforced
+            if (shimmy.getJson() != backup.enforcedValue) continue
+            shimmy.setJson(backup.userValue)
+        }
+    }
+
+    /**
+     * Replaces every enforced option in the serialized [config] with the value the user set themselves,
+     * so that the enforced values never end up in the config file.
+     */
+    fun writeUserValues(config: JsonElement) {
+        for ((path, backup) in userValues) {
+            val segments = path.split(".")
+            val parent = segments.dropLast(1).fold<String, JsonElement?>(config) { element, segment ->
+                (element as? JsonObject)?.get(segment)
+            } as? JsonObject ?: continue
+            // Options that are not part of the file (e.g. not exposed) have nothing to restore
+            if (!parent.has(segments.last())) continue
+            parent.add(segments.last(), backup.userValue)
+        }
     }
 
     fun isBlockedFromEditing(optionPath: String): String? {

--- a/src/main/java/at/hannibal2/skyhanni/config/EnforcedConfigValues.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/EnforcedConfigValues.kt
@@ -7,48 +7,63 @@ import at.hannibal2.skyhanni.data.SkyHanniNotification
 import at.hannibal2.skyhanni.data.jsonobjects.repo.EnforcedConfigValuesJson
 import at.hannibal2.skyhanni.data.jsonobjects.repo.EnforcedValue
 import at.hannibal2.skyhanni.data.jsonobjects.repo.EnforcedValueData
+import at.hannibal2.skyhanni.data.repo.SkyHanniRepoManager
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
-import at.hannibal2.skyhanni.events.render.gui.GuiScreenOpenEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.json.Shimmy
 import at.hannibal2.skyhanni.utils.system.PlatformUtils
 import kotlin.time.Duration.Companion.INFINITE
 
 @SkyHanniModule
 object EnforcedConfigValues {
+    private const val CONSTANT = "misc/EnforcedConfigValues"
+
     private var enforcedConfigValuesData: List<EnforcedValueData> = listOf()
     private var hasSentPSAsOnce = false
 
-    @HandleEvent
-    fun onRepoReload(event: RepositoryReloadEvent) {
-        val constant = event.getConstant<EnforcedConfigValuesJson>("misc/EnforcedConfigValues").enforcedConfigValues
+    /**
+     * Applies the values cached in the local repo, so that enforcement does not have to wait for the
+     * initial repo fetch. Called during config loading, before the config gets built for the first time.
+     */
+    fun loadFromLocalRepo() {
+        val json = SkyHanniRepoManager.readLocalConstantOrNull<EnforcedConfigValuesJson>(CONSTANT) ?: return
+        updateData(json)
+    }
+
+    @HandleEvent(priority = HandleEvent.HIGHEST)
+    private fun onRepoReload(event: RepositoryReloadEvent) {
+        if (!updateData(event.getConstant<EnforcedConfigValuesJson>(CONSTANT))) return
+        hasSentPSAsOnce = false
+        // We have to recreate the whole config when a value changes
+        // so that the option is blocked off inside the config
+        SkyHanniMod.configManager.recreateConfig()
+        trySendPSAs()
+    }
+
+    // Returns whether the set of enforced values changed.
+    private fun updateData(json: EnforcedConfigValuesJson): Boolean {
         val oldEnforcedValues = enforcedConfigValuesData
-        enforcedConfigValuesData = constant.filter {
+        enforcedConfigValuesData = json.enforcedConfigValues.filter {
             SkyHanniMod.modVersion <= it.affectedVersion &&
                 (it.minimumAffectedVersion?.let { minVersion -> SkyHanniMod.modVersion >= minVersion } ?: true)
         }.filter {
             it.affectedMinecraftVersions?.contains(PlatformUtils.MC_VERSION) ?: true
         }
-        if (oldEnforcedValues == enforcedConfigValuesData) return
-        hasSentPSAsOnce = false
-        // We have to recreate the whole config when a value changes
-        // so that the option is blocked off inside the config
-        SkyHanniMod.configManager.recreateConfig()
+        enforceOntoConfig(SkyHanniMod.feature)
+        return oldEnforcedValues != enforcedConfigValuesData
     }
 
     @HandleEvent
-    fun onGuiOpen(event: GuiScreenOpenEvent) {
-        enforceOntoConfig(SkyHanniMod.feature)
-    }
+    private fun onWorldChange() = trySendPSAs()
 
-    @HandleEvent(onlyOnSkyblock = true)
-    fun onTick() {
-        if (hasSentPSAsOnce) return
+    // PSAs need a player to be shown to, so they wait until the user is actually on Hypixel.
+    private fun trySendPSAs() {
+        if (hasSentPSAsOnce || !SkyBlockUtils.onHypixel) return
         hasSentPSAsOnce = true
         sendPSAs()
-        enforceOntoConfig(SkyHanniMod.feature)
     }
 
     private fun sendPSAs() {

--- a/src/main/java/at/hannibal2/skyhanni/config/EnforcedConfigValues.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/EnforcedConfigValues.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.NotificationManager
 import at.hannibal2.skyhanni.data.SkyHanniNotification
 import at.hannibal2.skyhanni.data.jsonobjects.repo.EnforcedConfigValuesJson
+import at.hannibal2.skyhanni.data.jsonobjects.repo.EnforcedValue
 import at.hannibal2.skyhanni.data.jsonobjects.repo.EnforcedValueData
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.events.render.gui.GuiScreenOpenEvent
@@ -17,7 +18,6 @@ import kotlin.time.Duration.Companion.INFINITE
 
 @SkyHanniModule
 object EnforcedConfigValues {
-
     private var enforcedConfigValuesData: List<EnforcedValueData> = listOf()
     private var hasSentPSAsOnce = false
 
@@ -33,7 +33,7 @@ object EnforcedConfigValues {
         }
         if (oldEnforcedValues == enforcedConfigValuesData) return
         hasSentPSAsOnce = false
-        // we have to recreate the whole config when a value changes
+        // We have to recreate the whole config when a value changes
         // so that the option is blocked off inside the config
         SkyHanniMod.configManager.recreateConfig()
     }
@@ -70,16 +70,23 @@ object EnforcedConfigValues {
 
     private fun enforceOntoConfig(config: Any) {
         for (enforcedValue in enforcedConfigValuesData.flatMap { it.enforcedValues }) {
-            val shimmy = Shimmy(config, enforcedValue.path.split(".")) ?: try {
-                ErrorManager.skyHanniError("Could not create shimmy for path ${enforcedValue.path}")
-            } catch (_: Exception) {
-                continue
-            }
-            val currentValue = shimmy.getJson()
-            if (currentValue != enforcedValue.value) {
-                shimmy.setJson(enforcedValue.value)
+            try {
+                enforceValue(config, enforcedValue)
+            } catch (e: Exception) {
+                ErrorManager.logErrorWithData(
+                    e, "Failed to enforce a config value from the repo",
+                    "path" to enforcedValue.path,
+                    "value" to enforcedValue.value,
+                )
             }
         }
+    }
+
+    private fun enforceValue(config: Any, enforcedValue: EnforcedValue) {
+        val shimmy = Shimmy(config, enforcedValue.path.split("."))
+            ?: ErrorManager.skyHanniError("Could not create shimmy for path ${enforcedValue.path}")
+        if (shimmy.getJson() == enforcedValue.value) return
+        shimmy.setJson(enforcedValue.value)
     }
 
     fun isBlockedFromEditing(optionPath: String): String? {
@@ -88,5 +95,4 @@ object EnforcedConfigValues {
         } ?: return null
         return firstEnforcedValue.extraMessage.orEmpty()
     }
-
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/EnforcedConfigValues.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/EnforcedConfigValues.kt
@@ -70,10 +70,10 @@ object EnforcedConfigValues {
         return oldEnforcedValues != enforcedConfigValuesData
     }
 
-    @HandleEvent
-    private fun onWorldChange() = trySendPSAs()
-
     // PSAs need a player to be shown to, so they wait until the user is actually on Hypixel.
+    @HandleEvent
+    private fun onTick() = trySendPSAs()
+
     private fun trySendPSAs() {
         if (hasSentPSAsOnce || !SkyBlockUtils.onHypixel) return
         hasSentPSAsOnce = true
@@ -118,16 +118,15 @@ object EnforcedConfigValues {
         val shimmy = Shimmy(config, enforcedValue.path.split("."))
             ?: ErrorManager.skyHanniError("Could not create shimmy for path ${enforcedValue.path}")
         val currentValue = shimmy.getJson()
-        if (enforcedValue.persist) {
-            // Persistent values replace the user's value for good, so there is nothing to restore later
-            userValues.remove(enforcedValue.path)
-        } else if (currentValue != enforcedValue.value) {
-            // When the option is already enforced, the current value is a previously enforced one, not the user's
-            val userValue = userValues[enforcedValue.path]?.userValue ?: currentValue
-            userValues[enforcedValue.path] = UserValue(userValue, enforcedValue.value)
-        }
+        // Persistent values replace the user's value for good, so there is nothing to restore later
+        if (enforcedValue.persist) userValues.remove(enforcedValue.path)
         if (currentValue == enforcedValue.value) return
         shimmy.setJson(enforcedValue.value)
+        if (enforcedValue.persist) return
+        // Only recorded after a successful update, so a rejected value cannot corrupt the backup.
+        // When the option is already enforced, the current value is a previously enforced one, not the user's
+        val userValue = userValues[enforcedValue.path]?.userValue ?: currentValue
+        userValues[enforcedValue.path] = UserValue(userValue, enforcedValue.value)
     }
 
     private fun restoreNoLongerEnforced(config: Any, enforcedPaths: Set<String>) {

--- a/src/main/java/at/hannibal2/skyhanni/config/EnforcedConfigValues.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/EnforcedConfigValues.kt
@@ -141,13 +141,13 @@ object EnforcedConfigValues {
         try {
             shimmy.setJson(enforcedValue.value)
         } finally {
-            // A property observer can throw after the value has already been applied, so the backup is recorded
-            // regardless. It is re-read so that it compares equal to what the field serializes to later
+            // A property observer can throw after the value has already been applied, so the bookkeeping happens
+            // regardless. Persistent values replace the user's value for good, so there is nothing to restore later.
+            // The backup is re-read so that it compares equal to what the field serializes to later
             // (e.g. a float from the repo JSON does not equal the same float serialized by Gson)
-            userValues[enforcedValue.path] = UserValue(userValue, shimmy.getJson())
+            if (enforcedValue.persist) userValues.remove(enforcedValue.path)
+            else userValues[enforcedValue.path] = UserValue(userValue, shimmy.getJson())
         }
-        // Persistent values replace the user's value for good, so there is nothing to restore later
-        if (enforcedValue.persist) userValues.remove(enforcedValue.path)
     }
 
     private fun restoreNoLongerEnforced(config: Any, enforcedPaths: Set<String>) {
@@ -156,7 +156,15 @@ object EnforcedConfigValues {
             val shimmy = Shimmy(config, path.split(".")) ?: continue
             // Keep the current value if anything changed it after it was enforced
             if (shimmy.getJson() != backup.enforcedValue) continue
-            shimmy.setJson(backup.userValue)
+            try {
+                shimmy.setJson(backup.userValue)
+            } catch (e: Exception) {
+                ErrorManager.logErrorWithData(
+                    e, "Failed to restore a config value that is no longer enforced",
+                    "path" to path,
+                    "value" to backup.userValue,
+                )
+            }
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/config/EnforcedConfigValues.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/EnforcedConfigValues.kt
@@ -122,7 +122,10 @@ object EnforcedConfigValues {
 
     private fun enforceValue(config: Any, enforcedValue: EnforcedValue) {
         val shimmy = Shimmy(config, enforcedValue.path.split("."))
-            ?: ErrorManager.skyHanniError("Could not create shimmy for path ${enforcedValue.path}")
+        if (shimmy == null) {
+            ChatUtils.debug("EnforcedConfigValues: Could not create shimmy for path ${enforcedValue.path}; skipping")
+            return
+        }
         val currentValue = shimmy.getJson()
         shimmy.setJson(enforcedValue.value)
         // Only touched after a successful update, so a rejected value can neither corrupt nor drop the backup

--- a/src/main/java/at/hannibal2/skyhanni/config/EnforcedConfigValues.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/EnforcedConfigValues.kt
@@ -12,6 +12,7 @@ import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.json.Shimmy
 import at.hannibal2.skyhanni.utils.system.PlatformUtils
@@ -55,12 +56,16 @@ object EnforcedConfigValues {
 
     @HandleEvent(priority = HandleEvent.HIGHEST)
     private fun onRepoReload(event: RepositoryReloadEvent) {
-        if (!updateData(event.getConstant<EnforcedConfigValuesJson>(CONSTANT))) return
-        hasSentPSAsOnce = false
-        // We have to recreate the whole config when a value changes
-        // so that the option is blocked off inside the config
-        SkyHanniMod.configManager.recreateConfig()
-        trySendPSAs()
+        val json = event.getConstant<EnforcedConfigValuesJson>(CONSTANT)
+        // The repo reloads from a coroutine, but property observers expect the client thread
+        DelayedRun.runOrNextTick("EnforcedConfigValues.onRepoReload") {
+            if (!updateData(json)) return@runOrNextTick
+            hasSentPSAsOnce = false
+            // We have to recreate the whole config when a value changes
+            // so that the option is blocked off inside the config
+            SkyHanniMod.configManager.recreateConfig()
+            trySendPSAs()
+        }
     }
 
     // Returns whether the set of enforced values changed.
@@ -126,6 +131,8 @@ object EnforcedConfigValues {
             ChatUtils.debug("EnforcedConfigValues: Could not create shimmy for path ${enforcedValue.path}; skipping")
             return
         }
+        // Config options are never null, and Shimmy leaves explicit nulls to the caller
+        require(!enforcedValue.value.isJsonNull) { "Enforced value for ${enforcedValue.path} is null" }
         val currentValue = shimmy.getJson()
         shimmy.setJson(enforcedValue.value)
         // Only touched after a successful update, so a rejected value can neither corrupt nor drop the backup

--- a/src/main/java/at/hannibal2/skyhanni/config/EnforcedConfigValues.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/EnforcedConfigValues.kt
@@ -17,7 +17,6 @@ import at.hannibal2.skyhanni.utils.json.Shimmy
 import at.hannibal2.skyhanni.utils.system.PlatformUtils
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
-import java.util.concurrent.ConcurrentHashMap
 import kotlin.time.Duration.Companion.INFINITE
 
 /**
@@ -33,8 +32,8 @@ object EnforcedConfigValues {
     private var hasSentPSAsOnce = false
 
     // The user's own values of the options that are currently enforced, keyed by config path.
-    // Accessed from the config auto-save thread as well, hence the concurrent map.
-    private val userValues = ConcurrentHashMap<String, UserValue>()
+    // Guarded by its own monitor: the config auto-save thread reads it while it serializes the config.
+    private val userValues = mutableMapOf<String, UserValue>()
 
     private class UserValue(val userValue: JsonElement, val enforcedValue: JsonElement)
 
@@ -97,7 +96,7 @@ object EnforcedConfigValues {
         }
     }
 
-    private fun enforceOntoConfig(config: Any) {
+    private fun enforceOntoConfig(config: Any) = synchronized(userValues) {
         val enforcedValues = enforcedConfigValuesData.flatMap { it.enforcedValues }
         restoreNoLongerEnforced(config, enforcedValues.mapTo(mutableSetOf()) { it.path })
 
@@ -118,15 +117,18 @@ object EnforcedConfigValues {
         val shimmy = Shimmy(config, enforcedValue.path.split("."))
             ?: ErrorManager.skyHanniError("Could not create shimmy for path ${enforcedValue.path}")
         val currentValue = shimmy.getJson()
-        // Persistent values replace the user's value for good, so there is nothing to restore later
-        if (enforcedValue.persist) userValues.remove(enforcedValue.path)
-        if (currentValue == enforcedValue.value) return
         shimmy.setJson(enforcedValue.value)
-        if (enforcedValue.persist) return
-        // Only recorded after a successful update, so a rejected value cannot corrupt the backup.
+        // Only touched after a successful update, so a rejected value can neither corrupt nor drop the backup
+        if (enforcedValue.persist) {
+            // Persistent values replace the user's value for good, so there is nothing to restore later
+            userValues.remove(enforcedValue.path)
+            return
+        }
         // When the option is already enforced, the current value is a previously enforced one, not the user's
         val userValue = userValues[enforcedValue.path]?.userValue ?: currentValue
-        userValues[enforcedValue.path] = UserValue(userValue, enforcedValue.value)
+        // The value is re-read so that the backup compares equal to what the field serializes to later
+        // (e.g. a float from the repo JSON does not equal the same float serialized by Gson)
+        userValues[enforcedValue.path] = UserValue(userValue, shimmy.getJson())
     }
 
     private fun restoreNoLongerEnforced(config: Any, enforcedPaths: Set<String>) {
@@ -140,19 +142,21 @@ object EnforcedConfigValues {
     }
 
     /**
-     * Replaces every enforced option in the serialized [config] with the value the user set themselves,
+     * Serializes [config] with every enforced option replaced by the value the user set themselves,
      * so that the enforced values never end up in the config file.
      */
-    fun writeUserValues(config: JsonElement) {
+    fun toUserJsonTree(config: Any): JsonElement = synchronized(userValues) {
+        val json = ConfigManager.gson.toJsonTree(config)
         for ((path, backup) in userValues) {
             val segments = path.split(".")
-            val parent = segments.dropLast(1).fold<String, JsonElement?>(config) { element, segment ->
+            val parent = segments.dropLast(1).fold<String, JsonElement?>(json) { element, segment ->
                 (element as? JsonObject)?.get(segment)
             } as? JsonObject ?: continue
             // Options that are not part of the file (e.g. not exposed) have nothing to restore
             if (!parent.has(segments.last())) continue
             parent.add(segments.last(), backup.userValue)
         }
+        json
     }
 
     fun isBlockedFromEditing(optionPath: String): String? {

--- a/src/main/java/at/hannibal2/skyhanni/config/EnforcedConfigValues.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/EnforcedConfigValues.kt
@@ -43,7 +43,14 @@ object EnforcedConfigValues {
      */
     fun loadFromLocalRepo() {
         val json = SkyHanniRepoManager.readLocalConstantOrNull<EnforcedConfigValuesJson>(CONSTANT) ?: return
-        updateData(json)
+        try {
+            updateData(json)
+        } catch (e: Exception) {
+            // Gson does not enforce Kotlin nullability, so a malformed cache can still fail here.
+            // Nothing is enforced until the repo reload delivers proper data, rather than failing the config load.
+            enforcedConfigValuesData = listOf()
+            ErrorManager.logErrorWithData(e, "Failed to apply cached enforced config values")
+        }
     }
 
     @HandleEvent(priority = HandleEvent.HIGHEST)

--- a/src/main/java/at/hannibal2/skyhanni/config/EnforcedConfigValues.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/EnforcedConfigValues.kt
@@ -131,8 +131,10 @@ object EnforcedConfigValues {
             userValues.remove(enforcedValue.path)
             return
         }
-        // When the option is already enforced, the current value is a previously enforced one, not the user's
-        val userValue = userValues[enforcedValue.path]?.userValue ?: currentValue
+        // When the option is already enforced, the current value is a previously enforced one, not the user's,
+        // unless the user changed it in the meantime (e.g. via /shconfig set)
+        val previous = userValues[enforcedValue.path]
+        val userValue = if (previous != null && currentValue == previous.enforcedValue) previous.userValue else currentValue
         // The value is re-read so that the backup compares equal to what the field serializes to later
         // (e.g. a float from the repo JSON does not equal the same float serialized by Gson)
         userValues[enforcedValue.path] = UserValue(userValue, shimmy.getJson())
@@ -161,6 +163,8 @@ object EnforcedConfigValues {
             } as? JsonObject ?: continue
             // Options that are not part of the file (e.g. not exposed) have nothing to restore
             if (!parent.has(segments.last())) continue
+            // Keep the current value if anything changed it after it was enforced
+            if (Shimmy(config, segments)?.getJson() != backup.enforcedValue) continue
             parent.add(segments.last(), backup.userValue)
         }
         json

--- a/src/main/java/at/hannibal2/skyhanni/config/EnforcedConfigValues.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/EnforcedConfigValues.kt
@@ -138,8 +138,10 @@ object EnforcedConfigValues {
         // unless the user changed it in the meantime (e.g. via /shconfig set)
         val previous = userValues[enforcedValue.path]
         val userValue = if (previous != null && currentValue == previous.enforcedValue) previous.userValue else currentValue
+        // A value that cannot be deserialized fails here, before the write, and leaves any existing backup untouched
+        val newValue = shimmy.fromJson(enforcedValue.value)
         try {
-            shimmy.setJson(enforcedValue.value)
+            shimmy.value = newValue
         } finally {
             // A property observer can throw after the value has already been applied, so the bookkeeping happens
             // regardless. Persistent values replace the user's value for good, so there is nothing to restore later.

--- a/src/main/java/at/hannibal2/skyhanni/config/EnforcedConfigValues.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/EnforcedConfigValues.kt
@@ -171,10 +171,9 @@ object EnforcedConfigValues {
             val parent = segments.dropLast(1).fold<String, JsonElement?>(json) { element, segment ->
                 (element as? JsonObject)?.get(segment)
             } as? JsonObject ?: continue
-            // Options that are not part of the file (e.g. not exposed) have nothing to restore
-            if (!parent.has(segments.last())) continue
-            // Keep the current value if anything changed it after it was enforced
-            if (Shimmy(config, segments)?.getJson() != backup.enforcedValue) continue
+            // Skips options that are not part of the file (e.g. not exposed) and values changed after enforcement.
+            // The snapshot is compared rather than the live field, which the client thread can change in between
+            if (parent.get(segments.last()) != backup.enforcedValue) continue
             parent.add(segments.last(), backup.userValue)
         }
         json

--- a/src/main/java/at/hannibal2/skyhanni/config/EnforcedConfigValues.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/EnforcedConfigValues.kt
@@ -34,9 +34,9 @@ object EnforcedConfigValues {
 
     // The user's own values of the options that are currently enforced, keyed by config path.
     // Guarded by its own monitor: the config auto-save thread reads it while it serializes the config.
-    private val userValues = mutableMapOf<String, UserValue>()
+    internal val userValues = mutableMapOf<String, UserValue>()
 
-    private class UserValue(val userValue: JsonElement, val enforcedValue: JsonElement)
+    internal class UserValue(val userValue: JsonElement, val enforcedValue: JsonElement)
 
     /**
      * Applies the values cached in the local repo, so that enforcement does not have to wait for the
@@ -125,7 +125,7 @@ object EnforcedConfigValues {
         }
     }
 
-    private fun enforceValue(config: Any, enforcedValue: EnforcedValue) {
+    internal fun enforceValue(config: Any, enforcedValue: EnforcedValue) {
         val shimmy = Shimmy(config, enforcedValue.path.split("."))
         if (shimmy == null) {
             ChatUtils.debug("EnforcedConfigValues: Could not create shimmy for path ${enforcedValue.path}; skipping")
@@ -134,20 +134,20 @@ object EnforcedConfigValues {
         // Config options are never null, and Shimmy leaves explicit nulls to the caller
         require(!enforcedValue.value.isJsonNull) { "Enforced value for ${enforcedValue.path} is null" }
         val currentValue = shimmy.getJson()
-        shimmy.setJson(enforcedValue.value)
-        // Only touched after a successful update, so a rejected value can neither corrupt nor drop the backup
-        if (enforcedValue.persist) {
-            // Persistent values replace the user's value for good, so there is nothing to restore later
-            userValues.remove(enforcedValue.path)
-            return
-        }
         // When the option is already enforced, the current value is a previously enforced one, not the user's,
         // unless the user changed it in the meantime (e.g. via /shconfig set)
         val previous = userValues[enforcedValue.path]
         val userValue = if (previous != null && currentValue == previous.enforcedValue) previous.userValue else currentValue
-        // The value is re-read so that the backup compares equal to what the field serializes to later
-        // (e.g. a float from the repo JSON does not equal the same float serialized by Gson)
-        userValues[enforcedValue.path] = UserValue(userValue, shimmy.getJson())
+        try {
+            shimmy.setJson(enforcedValue.value)
+        } finally {
+            // A property observer can throw after the value has already been applied, so the backup is recorded
+            // regardless. It is re-read so that it compares equal to what the field serializes to later
+            // (e.g. a float from the repo JSON does not equal the same float serialized by Gson)
+            userValues[enforcedValue.path] = UserValue(userValue, shimmy.getJson())
+        }
+        // Persistent values replace the user's value for good, so there is nothing to restore later
+        if (enforcedValue.persist) userValues.remove(enforcedValue.path)
     }
 
     private fun restoreNoLongerEnforced(config: Any, enforcedPaths: Set<String>) {

--- a/src/main/java/at/hannibal2/skyhanni/data/IslandType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/IslandType.kt
@@ -2,7 +2,6 @@ package at.hannibal2.skyhanni.data
 
 import at.hannibal2.skyhanni.SkyHanniMod.launch
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.api.event.HandleEvent.Companion.HIGHEST
 import at.hannibal2.skyhanni.data.jsonobjects.repo.IslandTypeJson
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -93,7 +92,6 @@ enum class IslandType(private val nameFallback: String, private val apiNameFallb
 
     @SkyHanniModule
     companion object {
-
         fun Collection<IslandType>.isInAnyIsland(): Boolean = any { it.isInIsland() }
         private val repoReloadCoroutine = CoroutineSettings("island type repo reload")
 
@@ -116,8 +114,8 @@ enum class IslandType(private val nameFallback: String, private val apiNameFallb
         fun getByIdOrNull(id: String): IslandType? = entries.find { it.apiName == id }
         fun getByIdOrUnknown(id: String): IslandType = getByIdOrNull(id) ?: UNKNOWN
 
-        @HandleEvent(priority = HIGHEST)
-        fun onRepoReload(event: RepositoryReloadEvent) = repoReloadCoroutine.launch {
+        @HandleEvent(priority = HandleEvent.HIGH)
+        private fun onRepoReload(event: RepositoryReloadEvent) = repoReloadCoroutine.launch {
             val data = event.getConstantAsync<IslandTypeJson>("misc/IslandType")
 
             entries.forEach { islandType ->

--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/EnforcedConfigValuesJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/EnforcedConfigValuesJson.kt
@@ -26,4 +26,6 @@ data class EnforcedValueData(
 data class EnforcedValue(
     @Expose val path: String,
     @Expose val value: JsonElement,
+    // Whether the enforced value also gets written to the config file instead of only being applied in memory
+    @Expose val persist: Boolean = false,
 )

--- a/src/main/java/at/hannibal2/skyhanni/data/repo/AbstractRepoManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/repo/AbstractRepoManager.kt
@@ -33,7 +33,6 @@ import kotlinx.coroutines.withContext
 
 @Suppress("TooManyFunctions")
 abstract class AbstractRepoManager<E : AbstractRepoReloadEvent> {
-
     /**
      * Should be user-friendly, e.g. "SkyHanni" or "NotEnoughUpdates".
      * Gets used in error messages and logging.
@@ -166,10 +165,11 @@ abstract class AbstractRepoManager<E : AbstractRepoReloadEvent> {
     internal fun resolvePath(dir: String, name: String) = "$dir/$name.json"
 
     @PublishedApi
-    internal fun readJsonElement(path: String): JsonElement? {
+    internal fun readJsonElement(path: String, logMissing: Boolean = true): JsonElement? {
         if (repoFileSystem.exists(path)) return repoFileSystem.readJson(path)
         val fallback = repoDirectory.resolve(path)
         if (fallback.isFile) return fallback.getJson()
+        if (!logMissing) return null
         val repoDiagnostic = when {
             !repoDirectory.exists() -> "repo directory does not exist at '${repoDirectory.absolutePath}'"
             !repoDirectory.isDirectory -> "repo path exists but is not a directory: '${repoDirectory.absolutePath}'"
@@ -178,6 +178,20 @@ abstract class AbstractRepoManager<E : AbstractRepoReloadEvent> {
         }
         logger.error("Repo file not found: $path ($repoDiagnostic)")
         return null
+    }
+
+    /**
+     * Reads a constant straight from the repo files already present on disk, without downloading
+     * or reloading anything. Meant for data that is needed before the first repo reload happens.
+     *
+     * Returns null if the constant is not cached locally yet or could not be parsed.
+     */
+    inline fun <reified T : Any> readLocalConstantOrNull(constant: String): T? {
+        val json = readJsonElement(resolvePath("constants", constant), logMissing = false) ?: return null
+        return runCatching { ConfigManager.gson.fromJson<T>(json) }.getOrElse { e ->
+            logger.error("Could not read local constant '$constant': ${e.message}")
+            null
+        }
     }
 
     @PublishedApi

--- a/src/main/java/at/hannibal2/skyhanni/data/repo/AbstractRepoManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/repo/AbstractRepoManager.kt
@@ -187,8 +187,10 @@ abstract class AbstractRepoManager<E : AbstractRepoReloadEvent> {
      * Returns null if the constant is not cached locally yet or could not be parsed.
      */
     inline fun <reified T : Any> readLocalConstantOrNull(constant: String): T? {
-        val json = readJsonElement(resolvePath("constants", constant), logMissing = false) ?: return null
-        return runCatching { ConfigManager.gson.fromJson<T>(json) }.getOrElse { e ->
+        return runCatching {
+            val json = readJsonElement(resolvePath("constants", constant), logMissing = false)
+            json?.let { ConfigManager.gson.fromJson<T>(it) }
+        }.getOrElse { e ->
             logger.error("Could not read local constant '$constant': ${e.message}")
             null
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/PowderMiningChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/PowderMiningChatFilter.kt
@@ -27,7 +27,6 @@ import java.util.regex.Pattern
 
 @SkyHanniModule
 object PowderMiningChatFilter {
-
     private val config get() = SkyHanniMod.feature.chat.filterType.powderMining
     private val gemstoneConfig get() = config.gemstone
 
@@ -316,8 +315,8 @@ object PowderMiningChatFilter {
     private var rewardPatterns: Map<Pair<Pattern, PowderMiningConfig.SimplePowderMiningRewardTypes>, String> =
         emptyMap()
 
-    @HandleEvent(priority = HandleEvent.HIGHEST)
-    fun onRepoReload(event: RepositoryReloadEvent) {
+    @HandleEvent(priority = HandleEvent.HIGH)
+    private fun onRepoReload(event: RepositoryReloadEvent) {
         rewardPatterns = mapOf(
             ascensionRopeRewardPattern to ASCENSION_ROPE to "powder_mining_ascension_rope",
             wishingCompassRewardPattern to WISHING_COMPASS to "powder_mining_wishing_compass",

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/RemainingSlayerKills.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/RemainingSlayerKills.kt
@@ -2,7 +2,6 @@ package at.hannibal2.skyhanni.features.slayer
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.api.event.HandleEvent.Companion.HIGHEST
 import at.hannibal2.skyhanni.api.pet.CurrentPetApi
 import at.hannibal2.skyhanni.data.ElectionApi
 import at.hannibal2.skyhanni.data.SlayerApi
@@ -43,7 +42,6 @@ import kotlin.time.Duration.Companion.minutes
 
 @SkyHanniModule
 object RemainingSlayerKills {
-
     private val config get() = SlayerApi.config.slayerRemainingKills
     private val debugToggle get() = SkyHanniMod.feature.dev.debug.remainingKillsDebug
 
@@ -119,7 +117,7 @@ object RemainingSlayerKills {
     private var lastReminder = SimpleTimeMark.farPast()
     private var killComboWisdom = 0
 
-    @HandleEvent(priority = HIGHEST)
+    @HandleEvent(priority = HandleEvent.HIGH)
     private fun onRepoReload(event: RepositoryReloadEvent) {
         data = event.getConstant<SlayerData>("Slayer")
     }
@@ -275,7 +273,6 @@ object RemainingSlayerKills {
      * https://hypixelskyblock.minecraft.wiki/w/Combat_Wisdom#Notes
      */
     private fun getAdditivelyMultiplicativeValues(): Double {
-
         var additiveWithMultMultipliers = 1.0
 
         val championLevel = (InventoryUtils.getItemInHand()?.getHypixelEnchantments().orEmpty()["champion"] ?: 0) - 1
@@ -372,4 +369,3 @@ object RemainingSlayerKills {
 
     private fun isEnabled() = SkyBlockUtils.inSkyBlock && config.display
 }
-

--- a/src/main/java/at/hannibal2/skyhanni/utils/json/Shimmy.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/json/Shimmy.kt
@@ -4,37 +4,51 @@ import at.hannibal2.skyhanni.config.ConfigManager
 import at.hannibal2.skyhanni.utils.ReflectionUtils.getPrivateField
 import at.hannibal2.skyhanni.utils.ReflectionUtils.getPrivateFieldValue
 import com.google.gson.JsonElement
+import com.google.gson.reflect.TypeToken
 import io.github.notenoughupdates.moulconfig.observer.Property
 import java.lang.reflect.Field
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
 
 // Copied (+ adapted to Kotlin) from NEU
-class Shimmy private constructor(val source: Any, val reflectField: Field) {
+/**
+ * [type] is the type used for json (de)serialization. It is usually the generic type of [reflectField], except when
+ * this shimmy points inside a moulconfig [Property], where the field type is erased to [Object] and the real type is
+ * recovered from the property declaration instead.
+ */
+class Shimmy private constructor(val source: Any, val reflectField: Field, val type: Type) {
     val clazz: Class<*> = reflectField.type
     var value: Any?
         get() = reflectField.get(source)
         set(v) = reflectField.set(source, v)
 
-    fun getJson(): JsonElement = ConfigManager.gson.toJsonTree(value)
+    fun getJson(): JsonElement = ConfigManager.gson.toJsonTree(value, type)
     fun setJson(element: JsonElement) {
-        value = ConfigManager.gson.fromJson(element, clazz)
+        val newValue = ConfigManager.gson.fromJson<Any?>(element, type)
+        // Gson silently returns null for unknown enum constants, which would crash whoever reads the field later
+        require(newValue != null || element.isJsonNull) {
+            "Could not deserialize $element into ${TypeToken.get(type).rawType.name} for field ${reflectField.name}"
+        }
+        value = newValue
     }
 
     companion object {
         private fun traverse(source: Any?, fieldName: String): Any? =
             runCatching { source?.getPrivateFieldValue(fieldName) }.getOrNull()
 
+        private fun field(source: Any, fieldName: String): Field? =
+            runCatching { source.getPrivateField(fieldName) }.getOrNull()
+
         operator fun invoke(source: Any?, path: List<String>): Shimmy? {
             if (path.isEmpty()) return null
             val parent = path.dropLast(1).fold(source) { obj, part -> traverse(obj, part) } ?: return null
-            return try {
-                val field = parent.getPrivateField(path.last())
-                val shimmy = Shimmy(parent, field)
-                if (shimmy.clazz != Property::class.java) return shimmy
-                val propertySource = traverse(parent, path.last()) ?: return shimmy
-                invoke(propertySource, listOf("value")) ?: shimmy
-            } catch (e: NoSuchFieldException) {
-                null
-            }
+            val field = field(parent, path.last()) ?: return null
+            val shimmy = Shimmy(parent, field, field.genericType)
+            if (shimmy.clazz != Property::class.java) return shimmy
+            val propertySource = traverse(parent, path.last()) ?: return shimmy
+            val valueField = field(propertySource, "value") ?: return shimmy
+            val propertyType = (field.genericType as? ParameterizedType)?.actualTypeArguments?.firstOrNull()
+            return Shimmy(propertySource, valueField, propertyType ?: valueField.genericType)
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/json/Shimmy.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/json/Shimmy.kt
@@ -33,9 +33,9 @@ class Shimmy private constructor(
     fun getJson(): JsonElement = ConfigManager.gson.toJsonTree(value, type)
     fun setJson(element: JsonElement) {
         val newValue = ConfigManager.gson.fromJson<Any?>(element, type)
-        // Config options are never null. Gson also silently returns null for unknown enum constants,
-        // and either would crash whoever reads the field later
-        require(newValue != null) {
+        // Gson silently returns null for unknown enum constants, which would crash whoever reads the field later.
+        // An explicit null is left to the caller: storage has nullable fields, config options do not
+        require(newValue != null || element.isJsonNull) {
             "Could not deserialize $element into ${TypeToken.get(type).rawType.name} for field ${reflectField.name}"
         }
         value = newValue

--- a/src/main/java/at/hannibal2/skyhanni/utils/json/Shimmy.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/json/Shimmy.kt
@@ -27,19 +27,25 @@ class Shimmy private constructor(
     var value: Any?
         get() = reflectField.get(source)
         set(v) {
+            // Property.set notifies observers even for an unchanged value, which e.g. resets the update checker
+            if (value == v) return
             if (property != null) property.set(v) else reflectField.set(source, v)
         }
 
     fun getJson(): JsonElement = ConfigManager.gson.toJsonTree(value, type)
     fun setJson(element: JsonElement) {
+        value = fromJson(element)
+    }
+
+    /** Deserializes [element] into the field's type without writing it. */
+    fun fromJson(element: JsonElement): Any? {
         val newValue = ConfigManager.gson.fromJson<Any?>(element, type)
         // Gson silently returns null for unknown enum constants, which would crash whoever reads the field later.
         // An explicit null is left to the caller: storage has nullable fields, config options do not
         require(newValue != null || element.isJsonNull) {
             "Could not deserialize $element into ${TypeToken.get(type).rawType.name} for field ${reflectField.name}"
         }
-        // Property.set notifies observers even for an unchanged value, which e.g. resets the update checker
-        if (value != newValue) value = newValue
+        return newValue
     }
 
     companion object {

--- a/src/main/java/at/hannibal2/skyhanni/utils/json/Shimmy.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/json/Shimmy.kt
@@ -38,7 +38,8 @@ class Shimmy private constructor(
         require(newValue != null || element.isJsonNull) {
             "Could not deserialize $element into ${TypeToken.get(type).rawType.name} for field ${reflectField.name}"
         }
-        value = newValue
+        // Property.set notifies observers even for an unchanged value, which e.g. resets the update checker
+        if (value != newValue) value = newValue
     }
 
     companion object {

--- a/src/main/java/at/hannibal2/skyhanni/utils/json/Shimmy.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/json/Shimmy.kt
@@ -33,8 +33,9 @@ class Shimmy private constructor(
     fun getJson(): JsonElement = ConfigManager.gson.toJsonTree(value, type)
     fun setJson(element: JsonElement) {
         val newValue = ConfigManager.gson.fromJson<Any?>(element, type)
-        // Gson silently returns null for unknown enum constants, which would crash whoever reads the field later
-        require(newValue != null || element.isJsonNull) {
+        // Config options are never null. Gson also silently returns null for unknown enum constants,
+        // and either would crash whoever reads the field later
+        require(newValue != null) {
             "Could not deserialize $element into ${TypeToken.get(type).rawType.name} for field ${reflectField.name}"
         }
         value = newValue

--- a/src/main/java/at/hannibal2/skyhanni/utils/json/Shimmy.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/json/Shimmy.kt
@@ -16,11 +16,19 @@ import java.lang.reflect.Type
  * this shimmy points inside a moulconfig [Property], where the field type is erased to [Object] and the real type is
  * recovered from the property declaration instead.
  */
-class Shimmy private constructor(val source: Any, val reflectField: Field, val type: Type) {
+class Shimmy private constructor(
+    val source: Any,
+    val reflectField: Field,
+    val type: Type,
+    // Set when this shimmy points inside a moulconfig property, so that writes notify its observers
+    private val property: Property<Any?>? = null,
+) {
     val clazz: Class<*> = reflectField.type
     var value: Any?
         get() = reflectField.get(source)
-        set(v) = reflectField.set(source, v)
+        set(v) {
+            if (property != null) property.set(v) else reflectField.set(source, v)
+        }
 
     fun getJson(): JsonElement = ConfigManager.gson.toJsonTree(value, type)
     fun setJson(element: JsonElement) {
@@ -45,10 +53,12 @@ class Shimmy private constructor(val source: Any, val reflectField: Field, val t
             val field = field(parent, path.last()) ?: return null
             val shimmy = Shimmy(parent, field, field.genericType)
             if (shimmy.clazz != Property::class.java) return shimmy
-            val propertySource = traverse(parent, path.last()) ?: return shimmy
-            val valueField = field(propertySource, "value") ?: return shimmy
+            // The property's own type argument is not known at runtime, so the value can only be set unchecked
+            @Suppress("UNCHECKED_CAST")
+            val property = traverse(parent, path.last()) as? Property<Any?> ?: return shimmy
+            val valueField = field(property, "value") ?: return shimmy
             val propertyType = (field.genericType as? ParameterizedType)?.actualTypeArguments?.firstOrNull()
-            return Shimmy(propertySource, valueField, propertyType ?: valueField.genericType)
+            return Shimmy(property, valueField, propertyType ?: valueField.genericType, property)
         }
     }
 }

--- a/src/test/java/at/hannibal2/skyhanni/test/config/EnforcedConfigValuesTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/config/EnforcedConfigValuesTest.kt
@@ -7,6 +7,7 @@ import io.github.notenoughupdates.moulconfig.observer.Property
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.Test
 
@@ -29,6 +30,19 @@ class EnforcedConfigValuesTest {
         val backup = EnforcedConfigValues.userValues["enabled"]
         assertEquals(JsonPrimitive(true), backup?.userValue)
         assertEquals(JsonPrimitive(false), backup?.enforcedValue)
+    }
+
+    @Test
+    fun `drops the backup of a persistent value even when a property observer throws`() {
+        val config = Config()
+        config.enabled.whenChanged { _, _ -> error("observer failed") }
+
+        assertThrows<IllegalStateException> {
+            EnforcedConfigValues.enforceValue(config, EnforcedValue("enabled", JsonPrimitive(false), persist = true))
+        }
+
+        assertFalse(config.enabled.get())
+        assertNull(EnforcedConfigValues.userValues["enabled"])
     }
 
     @Test

--- a/src/test/java/at/hannibal2/skyhanni/test/config/EnforcedConfigValuesTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/config/EnforcedConfigValuesTest.kt
@@ -1,0 +1,46 @@
+package at.hannibal2.skyhanni.test.config
+
+import at.hannibal2.skyhanni.config.EnforcedConfigValues
+import at.hannibal2.skyhanni.data.jsonobjects.repo.EnforcedValue
+import com.google.gson.JsonPrimitive
+import io.github.notenoughupdates.moulconfig.observer.Property
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.Test
+
+class EnforcedConfigValuesTest {
+    private class Config { val enabled: Property<Boolean> = Property.of(true) }
+
+    @AfterEach
+    fun cleanup() = EnforcedConfigValues.userValues.clear()
+
+    @Test
+    fun `records the backup even when a property observer throws`() {
+        val config = Config()
+        config.enabled.whenChanged { _, _ -> error("observer failed") }
+
+        assertThrows<IllegalStateException> {
+            EnforcedConfigValues.enforceValue(config, EnforcedValue("enabled", JsonPrimitive(false)))
+        }
+
+        assertFalse(config.enabled.get())
+        val backup = EnforcedConfigValues.userValues["enabled"]
+        assertEquals(JsonPrimitive(true), backup?.userValue)
+        assertEquals(JsonPrimitive(false), backup?.enforcedValue)
+    }
+
+    @Test
+    fun `re-enforcing the same value keeps the backup without notifying observers`() {
+        val config = Config()
+        EnforcedConfigValues.enforceValue(config, EnforcedValue("enabled", JsonPrimitive(false)))
+        var notifications = 0
+        config.enabled.whenChanged { _, _ -> notifications++ }
+
+        EnforcedConfigValues.enforceValue(config, EnforcedValue("enabled", JsonPrimitive(false)))
+
+        assertEquals(0, notifications)
+        assertEquals(JsonPrimitive(true), EnforcedConfigValues.userValues["enabled"]?.userValue)
+    }
+}

--- a/src/test/java/at/hannibal2/skyhanni/test/config/EnforcedConfigValuesTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/config/EnforcedConfigValuesTest.kt
@@ -12,7 +12,12 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.Test
 
 class EnforcedConfigValuesTest {
-    private class Config { val enabled: Property<Boolean> = Property.of(true) }
+    private enum class Channel { RELEASES, BETA }
+
+    private class Config {
+        val enabled: Property<Boolean> = Property.of(true)
+        val channel: Property<Channel> = Property.of(Channel.RELEASES)
+    }
 
     @AfterEach
     fun cleanup() = EnforcedConfigValues.userValues.clear()
@@ -43,6 +48,19 @@ class EnforcedConfigValuesTest {
 
         assertFalse(config.enabled.get())
         assertNull(EnforcedConfigValues.userValues["enabled"])
+    }
+
+    @Test
+    fun `keeps the backup when a persistent override fails to deserialize`() {
+        val config = Config()
+        EnforcedConfigValues.enforceValue(config, EnforcedValue("channel", JsonPrimitive("BETA")))
+
+        assertThrows<IllegalArgumentException> {
+            EnforcedConfigValues.enforceValue(config, EnforcedValue("channel", JsonPrimitive("NIGHTLY"), persist = true))
+        }
+
+        assertEquals(Channel.BETA, config.channel.get())
+        assertEquals(JsonPrimitive("RELEASES"), EnforcedConfigValues.userValues["channel"]?.userValue)
     }
 
     @Test

--- a/src/test/java/at/hannibal2/skyhanni/test/utils/ShimmyTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/utils/ShimmyTest.kt
@@ -1,20 +1,26 @@
 package at.hannibal2.skyhanni.test.utils
 
+import at.hannibal2.skyhanni.config.features.About
 import at.hannibal2.skyhanni.utils.json.Shimmy
 import com.google.gson.JsonPrimitive
 import io.github.notenoughupdates.moulconfig.observer.Property
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.assertNotNull
+import org.junit.jupiter.api.assertNull
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.Test
 
 abstract class ShimmyTestBase {
-
-    protected class Simple { var value: String = "hello"; var number: Int = 42 }
+    protected class Simple {
+        var value: String = "hello"
+        var number: Int = 42
+    }
     protected class Nested { val inner = Simple() }
     protected class DeepNested { val middle = Nested() }
     protected class WithProperty { val prop: Property<String> = Property.of("propertyValue") }
     protected class WithNullable { val inner: Simple? = null }
+    protected enum class Example { FIRST, SECOND }
+    protected class WithEnumProperty { val prop: Property<Example> = Property.of(Example.FIRST) }
 
     protected abstract fun shimmy(source: Any?, path: List<String>): ShimmyCompat?
 
@@ -25,69 +31,121 @@ abstract class ShimmyTestBase {
         fun setJson(element: com.google.gson.JsonElement)
     }
 
-    @Test fun `returns null for empty path`() = assertNull(shimmy(Simple(), emptyList()))
-    @Test fun `returns null for null source`() = assertNull(shimmy(null, listOf("value")))
-    @Test fun `returns null for non-existent field`() = assertNull(shimmy(Simple(), listOf("doesNotExist")))
+    @Test
+    fun `returns null for empty path`() = assertNull(shimmy(Simple(), emptyList()))
 
-    @Test fun `resolves single field`() {
+    @Test
+    fun `returns null for null source`() = assertNull(shimmy(null, listOf("value")))
+
+    @Test
+    fun `returns null for non-existent field`() = assertNull(shimmy(Simple(), listOf("doesNotExist")))
+
+    @Test
+    fun `resolves single field`() {
         val s = shimmy(Simple(), listOf("value"))
-        assertNotNull(s); assertEquals("hello", s!!.value)
+        assertNotNull(s)
+        assertEquals("hello", s.value)
     }
 
-    @Test fun `resolves nested path`() {
+    @Test
+    fun `resolves nested path`() {
         val s = shimmy(Nested(), listOf("inner", "value"))
-        assertNotNull(s); assertEquals("hello", s!!.value)
+        assertNotNull(s)
+        assertEquals("hello", s.value)
     }
 
-    @Test fun `resolves deeply nested path`() {
+    @Test
+    fun `resolves deeply nested path`() {
         val s = shimmy(DeepNested(), listOf("middle", "inner", "number"))
-        assertNotNull(s); assertEquals(42, s!!.value)
+        assertNotNull(s)
+        assertEquals(42, s.value)
     }
 
-    @Test fun `sets value on single field`() {
+    @Test
+    fun `sets value on single field`() {
         val source = Simple()
         shimmy(source, listOf("value"))!!.also { it.value = "world" }
         assertEquals("world", source.value)
     }
 
-    @Test fun `sets value on nested field`() {
+    @Test
+    fun `sets value on nested field`() {
         val source = Nested()
         shimmy(source, listOf("inner", "number"))!!.also { it.value = 99 }
         assertEquals(99, source.inner.number)
     }
 
-    @Test fun `getJson returns correct json element`() =
+    @Test
+    fun `getJson returns correct json element`() =
         assertEquals(JsonPrimitive("hello"), shimmy(Simple(), listOf("value"))!!.getJson())
 
-    @Test fun `setJson sets value from json`() {
+    @Test
+    fun `setJson sets value from json`() {
         val source = Simple()
         shimmy(source, listOf("value"))!!.setJson(JsonPrimitive("fromJson"))
         assertEquals("fromJson", source.value)
     }
 
-    @Test fun `unwraps moulconfig Property transparently`() {
+    @Test
+    fun `unwraps moulconfig Property transparently`() {
         val s = shimmy(WithProperty(), listOf("prop"))
-        assertNotNull(s); assertEquals("propertyValue", s!!.value)
+        assertNotNull(s)
+        assertEquals("propertyValue", s.value)
     }
 
-    @Test fun `sets value through moulconfig Property`() {
+    @Test
+    fun `sets value through moulconfig Property`() {
         val source = WithProperty()
         shimmy(source, listOf("prop"))!!.also { it.value = "newValue" }
         assertEquals("newValue", source.prop.get())
     }
 
-    @Test fun `clazz reflects actual field type`() =
+    @Test
+    fun `getJson through moulconfig Property returns the enum name`() =
+        assertEquals(JsonPrimitive("FIRST"), shimmy(WithEnumProperty(), listOf("prop"))!!.getJson())
+
+    @Test
+    fun `setJson through moulconfig Property resolves the enum constant`() {
+        val source = WithEnumProperty()
+        shimmy(source, listOf("prop"))!!.setJson(JsonPrimitive("SECOND"))
+        assertEquals(Example.SECOND, source.prop.get())
+    }
+
+    @Test
+    fun `setJson rejects an unknown enum constant instead of writing null`() {
+        val source = WithEnumProperty()
+        assertThrows<IllegalArgumentException> {
+            shimmy(source, listOf("prop"))!!.setJson(JsonPrimitive("THIRD"))
+        }
+        assertEquals(Example.FIRST, source.prop.get())
+    }
+
+    @Test
+    fun `clazz reflects actual field type`() =
         assertEquals(Int::class.java, shimmy(Simple(), listOf("number"))!!.clazz)
 
-    @Test fun `returns null when intermediate path segment is null`() =
+    @Test
+    fun `returns null when intermediate path segment is null`() =
         assertNull(shimmy(WithNullable(), listOf("inner", "value")))
+
+    // This is the shape EnforcedConfigValues uses to remotely override an enum option
+    @Test
+    fun `enforces an enum onto the real config class`() {
+        val about = About()
+        shimmy(about, listOf("updateStream"))!!.setJson(JsonPrimitive("BETA"))
+        assertEquals(About.UpdateStream.BETA, about.updateStream.get())
+    }
 }
 
-// Tests against our kotlin version
+// Tests against our Kotlin version
 class ShimmyNewTest : ShimmyTestBase() {
     override fun shimmy(source: Any?, path: List<String>) = Shimmy(source, path)?.let {
         object : ShimmyCompat {
-            override var value get() = it.value; set(v) { it.value = v }
+            override var value
+                get() = it.value
+                set(v) {
+                    it.value = v
+                }
             override val clazz get() = it.clazz
             override fun getJson() = it.getJson()
             override fun setJson(element: com.google.gson.JsonElement) = it.setJson(element)

--- a/src/test/java/at/hannibal2/skyhanni/test/utils/ShimmyTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/utils/ShimmyTest.kt
@@ -138,6 +138,16 @@ abstract class ShimmyTestBase {
     fun `returns null when intermediate path segment is null`() =
         assertNull(shimmy(WithNullable(), listOf("inner", "value")))
 
+    // Enforced values are re-applied on every repo reload, which must not keep resetting observers
+    @Test
+    fun `setJson with an unchanged value does not notify observers`() {
+        val source = WithProperty()
+        var notifications = 0
+        source.prop.whenChanged { _, _ -> notifications++ }
+        shimmy(source, listOf("prop"))!!.setJson(JsonPrimitive("propertyValue"))
+        assertEquals(0, notifications)
+    }
+
     // This is the shape EnforcedConfigValues uses to remotely override an enum option
     @Test
     fun `enforces an enum onto the real config class`() {

--- a/src/test/java/at/hannibal2/skyhanni/test/utils/ShimmyTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/utils/ShimmyTest.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.test.utils
 
 import at.hannibal2.skyhanni.config.features.About
 import at.hannibal2.skyhanni.utils.json.Shimmy
+import com.google.gson.JsonNull
 import com.google.gson.JsonPrimitive
 import io.github.notenoughupdates.moulconfig.observer.Property
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -116,6 +117,15 @@ abstract class ShimmyTestBase {
         val source = WithEnumProperty()
         assertThrows<IllegalArgumentException> {
             shimmy(source, listOf("prop"))!!.setJson(JsonPrimitive("THIRD"))
+        }
+        assertEquals(Example.FIRST, source.prop.get())
+    }
+
+    @Test
+    fun `setJson rejects null instead of writing it`() {
+        val source = WithEnumProperty()
+        assertThrows<IllegalArgumentException> {
+            shimmy(source, listOf("prop"))!!.setJson(JsonNull.INSTANCE)
         }
         assertEquals(Example.FIRST, source.prop.get())
     }

--- a/src/test/java/at/hannibal2/skyhanni/test/utils/ShimmyTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/utils/ShimmyTest.kt
@@ -22,6 +22,7 @@ abstract class ShimmyTestBase {
     protected class WithNullable { val inner: Simple? = null }
     protected enum class Example { FIRST, SECOND }
     protected class WithEnumProperty { val prop: Property<Example> = Property.of(Example.FIRST) }
+    protected class WithNullableEnum { var value: Example? = Example.FIRST }
 
     protected abstract fun shimmy(source: Any?, path: List<String>): ShimmyCompat?
 
@@ -121,13 +122,12 @@ abstract class ShimmyTestBase {
         assertEquals(Example.FIRST, source.prop.get())
     }
 
+    // /shconfig set clears nullable storage fields this way
     @Test
-    fun `setJson rejects null instead of writing it`() {
-        val source = WithEnumProperty()
-        assertThrows<IllegalArgumentException> {
-            shimmy(source, listOf("prop"))!!.setJson(JsonNull.INSTANCE)
-        }
-        assertEquals(Example.FIRST, source.prop.get())
+    fun `setJson writes an explicit null`() {
+        val source = WithNullableEnum()
+        shimmy(source, listOf("value"))!!.setJson(JsonNull.INSTANCE)
+        assertNull(source.value)
     }
 
     @Test


### PR DESCRIPTION
## What
This PR includes several improvements to the Enforced Config Values system, listed in the changelog.

## Changelog Technical Details
+ Enforced config values now support enforcing enum values without crashing, and have been hardened against other invalid values. - Luna
+ Enforced config values are now applied early on game start and whenever the repo is reloaded, without requiring the player to open a GUI or be on SkyBlock. It also no longer tries to apply every tick. - Luna
+ Enforced config values are no longer persisted to the user's config unless `"persist": true` is specified, so the user's original config value is automatically restored once the value is no longer enforced instead of being lost. - Luna