### PR TITLE
Improvement: Tab completion for /sh config categories (#209)

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -15,6 +15,7 @@ import at.hannibal2.skyhanni.config.StorageData
 import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierArguments
+import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierUtils.dynamicContainsSuggestionProvider
 import at.hannibal2.skyhanni.config.storage.AchievementStorage
 import at.hannibal2.skyhanni.config.storage.CustomTodosStorage
 import at.hannibal2.skyhanni.config.storage.OrderedWaypointsRoutes
@@ -43,8 +44,6 @@ import at.hannibal2.skyhanni.utils.coroutines.SkyHanniCoroutineManager
 import at.hannibal2.skyhanni.utils.render.item.SkyHanniItemRenderCoordinator
 import at.hannibal2.skyhanni.utils.system.ModVersion
 import at.hannibal2.skyhanni.utils.system.PlatformUtils
-import com.mojang.brigadier.suggestion.SuggestionProvider
-import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource
 import net.minecraft.client.gui.screens.Screen
 import net.minecraft.resources.Identifier
 import org.apache.logging.log4j.Level
@@ -161,20 +160,6 @@ object SkyHanniMod : CompatCoroutineManager by SkyHanniCoroutineManager(
 
     private const val MAX_CONFIG_TAB_COMPLETE_SUGGESTIONS = 200
 
-    private val configTabCompleteSuggestionProvider: SuggestionProvider<FabricClientCommandSource> =
-        SuggestionProvider { _, builder ->
-            val remaining = builder.remainingLowerCase
-            var count = 0
-            for (suggestion in configTabCompleteSuggestions) {
-                if (suggestion.lowercase().contains(remaining)) {
-                    builder.suggest(suggestion)
-                    count++
-                    if (count >= MAX_CONFIG_TAB_COMPLETE_SUGGESTIONS) break
-                }
-            }
-            builder.buildFuture()
-        }
-
     @HandleEvent
     fun onCommandRegistration(event: CommandRegistrationEvent) {
         event.registerBrigadier("sh") {
@@ -186,7 +171,9 @@ object SkyHanniMod : CompatCoroutineManager by SkyHanniCoroutineManager(
             argCallback(
                 "search",
                 BrigadierArguments.greedyString(),
-                suggestions = configTabCompleteSuggestionProvider,
+                suggestions = dynamicContainsSuggestionProvider(limit = MAX_CONFIG_TAB_COMPLETE_SUGGESTIONS) {
+                    configTabCompleteSuggestions
+                },
             ) { search ->
                 val optionField = optionPathToField[search.lowercase()]
                 if (optionField != null) {

--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -4,8 +4,10 @@ import at.hannibal2.skyhanni.api.enoughupdates.EnoughUpdatesRepoManager
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.api.event.SkyHanniEvents
 import at.hannibal2.skyhanni.config.ConfigFileType
-import at.hannibal2.skyhanni.config.ConfigGuiManager.categoryNames
+import at.hannibal2.skyhanni.config.ConfigGuiManager.configTabCompleteSuggestions
 import at.hannibal2.skyhanni.config.ConfigGuiManager.openConfigGui
+import at.hannibal2.skyhanni.config.ConfigGuiManager.openConfigOption
+import at.hannibal2.skyhanni.config.ConfigGuiManager.optionPathToField
 import at.hannibal2.skyhanni.config.ConfigManager
 import at.hannibal2.skyhanni.config.SackData
 import at.hannibal2.skyhanni.config.SkyHanniConfig
@@ -13,7 +15,6 @@ import at.hannibal2.skyhanni.config.StorageData
 import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierArguments
-import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierUtils.toSuggestionProvider
 import at.hannibal2.skyhanni.config.storage.AchievementStorage
 import at.hannibal2.skyhanni.config.storage.CustomTodosStorage
 import at.hannibal2.skyhanni.config.storage.OrderedWaypointsRoutes
@@ -42,6 +43,8 @@ import at.hannibal2.skyhanni.utils.coroutines.SkyHanniCoroutineManager
 import at.hannibal2.skyhanni.utils.render.item.SkyHanniItemRenderCoordinator
 import at.hannibal2.skyhanni.utils.system.ModVersion
 import at.hannibal2.skyhanni.utils.system.PlatformUtils
+import com.mojang.brigadier.suggestion.SuggestionProvider
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource
 import net.minecraft.client.gui.screens.Screen
 import net.minecraft.resources.Identifier
 import org.apache.logging.log4j.Level
@@ -156,6 +159,22 @@ object SkyHanniMod : CompatCoroutineManager by SkyHanniCoroutineManager(
         logger.log(Level.INFO, message)
     }
 
+    private const val MAX_CONFIG_TAB_COMPLETE_SUGGESTIONS = 200
+
+    private val configTabCompleteSuggestionProvider: SuggestionProvider<FabricClientCommandSource> =
+        SuggestionProvider { _, builder ->
+            val remaining = builder.remainingLowerCase
+            var count = 0
+            for (suggestion in configTabCompleteSuggestions) {
+                if (suggestion.lowercase().contains(remaining)) {
+                    builder.suggest(suggestion)
+                    count++
+                    if (count >= MAX_CONFIG_TAB_COMPLETE_SUGGESTIONS) break
+                }
+            }
+            builder.buildFuture()
+        }
+
     @HandleEvent
     fun onCommandRegistration(event: CommandRegistrationEvent) {
         event.registerBrigadier("sh") {
@@ -167,9 +186,14 @@ object SkyHanniMod : CompatCoroutineManager by SkyHanniCoroutineManager(
             argCallback(
                 "search",
                 BrigadierArguments.greedyString(),
-                suggestions = categoryNames.toSuggestionProvider(),
+                suggestions = configTabCompleteSuggestionProvider,
             ) { search ->
-                openConfigGui(search)
+                val optionField = optionPathToField[search.lowercase()]
+                if (optionField != null) {
+                    openConfigOption(optionField)
+                } else {
+                    openConfigGui(search)
+                }
             }
             simpleCallback {
                 openConfigGui()

--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.api.enoughupdates.EnoughUpdatesRepoManager
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.api.event.SkyHanniEvents
 import at.hannibal2.skyhanni.config.ConfigFileType
+import at.hannibal2.skyhanni.config.ConfigGuiManager.categoryNames
 import at.hannibal2.skyhanni.config.ConfigGuiManager.openConfigGui
 import at.hannibal2.skyhanni.config.ConfigManager
 import at.hannibal2.skyhanni.config.SackData
@@ -12,6 +13,7 @@ import at.hannibal2.skyhanni.config.StorageData
 import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierArguments
+import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierUtils.toSuggestionProvider
 import at.hannibal2.skyhanni.config.storage.AchievementStorage
 import at.hannibal2.skyhanni.config.storage.CustomTodosStorage
 import at.hannibal2.skyhanni.config.storage.OrderedWaypointsRoutes
@@ -162,7 +164,11 @@ object SkyHanniMod : CompatCoroutineManager by SkyHanniCoroutineManager(
             literalCallback("gui") {
                 GuiEditManager.openGuiPositionEditor(hotkeyReminder = true)
             }
-            argCallback("search", BrigadierArguments.greedyString()) { search ->
+            argCallback(
+                "search",
+                BrigadierArguments.greedyString(),
+                suggestions = categoryNames.toSuggestionProvider(),
+            ) { search ->
                 openConfigGui(search)
             }
             simpleCallback {

--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -5,9 +5,9 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.api.event.SkyHanniEvents
 import at.hannibal2.skyhanni.config.ConfigFileType
 import at.hannibal2.skyhanni.config.ConfigGuiManager.configTabCompleteSuggestionProvider
+import at.hannibal2.skyhanni.config.ConfigGuiManager.getOptionFieldForPath
 import at.hannibal2.skyhanni.config.ConfigGuiManager.openConfigGui
 import at.hannibal2.skyhanni.config.ConfigGuiManager.openConfigOption
-import at.hannibal2.skyhanni.config.ConfigGuiManager.optionPathToField
 import at.hannibal2.skyhanni.config.ConfigManager
 import at.hannibal2.skyhanni.config.SackData
 import at.hannibal2.skyhanni.config.SkyHanniConfig
@@ -170,7 +170,7 @@ object SkyHanniMod : CompatCoroutineManager by SkyHanniCoroutineManager(
                 BrigadierArguments.greedyString(),
                 suggestions = configTabCompleteSuggestionProvider,
             ) { search ->
-                val optionField = optionPathToField[search.lowercase()]
+                val optionField = getOptionFieldForPath(search)
                 if (optionField != null) {
                     openConfigOption(optionField)
                 } else {

--- a/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
+++ b/src/main/java/at/hannibal2/skyhanni/SkyHanniMod.kt
@@ -4,7 +4,7 @@ import at.hannibal2.skyhanni.api.enoughupdates.EnoughUpdatesRepoManager
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.api.event.SkyHanniEvents
 import at.hannibal2.skyhanni.config.ConfigFileType
-import at.hannibal2.skyhanni.config.ConfigGuiManager.configTabCompleteSuggestions
+import at.hannibal2.skyhanni.config.ConfigGuiManager.configTabCompleteSuggestionProvider
 import at.hannibal2.skyhanni.config.ConfigGuiManager.openConfigGui
 import at.hannibal2.skyhanni.config.ConfigGuiManager.openConfigOption
 import at.hannibal2.skyhanni.config.ConfigGuiManager.optionPathToField
@@ -15,7 +15,6 @@ import at.hannibal2.skyhanni.config.StorageData
 import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierArguments
-import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierUtils.dynamicContainsSuggestionProvider
 import at.hannibal2.skyhanni.config.storage.AchievementStorage
 import at.hannibal2.skyhanni.config.storage.CustomTodosStorage
 import at.hannibal2.skyhanni.config.storage.OrderedWaypointsRoutes
@@ -158,8 +157,6 @@ object SkyHanniMod : CompatCoroutineManager by SkyHanniCoroutineManager(
         logger.log(Level.INFO, message)
     }
 
-    private const val MAX_CONFIG_TAB_COMPLETE_SUGGESTIONS = 200
-
     @HandleEvent
     fun onCommandRegistration(event: CommandRegistrationEvent) {
         event.registerBrigadier("sh") {
@@ -171,9 +168,7 @@ object SkyHanniMod : CompatCoroutineManager by SkyHanniCoroutineManager(
             argCallback(
                 "search",
                 BrigadierArguments.greedyString(),
-                suggestions = dynamicContainsSuggestionProvider(limit = MAX_CONFIG_TAB_COMPLETE_SUGGESTIONS) {
-                    configTabCompleteSuggestions
-                },
+                suggestions = configTabCompleteSuggestionProvider,
             ) { search ->
                 val optionField = optionPathToField[search.lowercase()]
                 if (optionField != null) {

--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigGuiManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigGuiManager.kt
@@ -6,13 +6,14 @@ import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.ConfigUtils
+import io.github.notenoughupdates.moulconfig.Config
 import io.github.notenoughupdates.moulconfig.annotations.Category
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 import io.github.notenoughupdates.moulconfig.gui.MoulConfigEditor
 import io.github.notenoughupdates.moulconfig.processor.ConfigProcessorDriver
 import io.github.notenoughupdates.moulconfig.processor.ConfigStructureReader
 import java.lang.reflect.Field
-import java.util.Stack
+import java.util.IdentityHashMap
 
 @SkyHanniModule
 object ConfigGuiManager {
@@ -77,26 +78,34 @@ object ConfigGuiManager {
 
     private class OptionPathReader : ConfigStructureReader {
         val options = mutableMapOf<String, Field>()
-        private val pathStack = Stack<String>()
+        private val instancePath = IdentityHashMap<Any, String>()
 
-        override fun beginCategory(baseObject: Any?, field: Field?, name: String, description: String) = Unit
+        override fun beginConfig(configClass: Class<out Config>, driver: ConfigProcessorDriver, config: Config) {
+            instancePath[config] = ""
+        }
+
+        override fun beginCategory(baseObject: Any?, field: Field?, name: String, description: String) {
+            if (field != null) mapChildInstance(baseObject, field)
+        }
 
         override fun endCategory() = Unit
 
-        override fun beginAccordion(baseObject: Any?, field: Field?, option: ConfigOption?, id: Int) = Unit
+        override fun beginAccordion(baseObject: Any?, field: Field?, option: ConfigOption?, id: Int) {
+            if (field != null) mapChildInstance(baseObject, field)
+        }
 
         override fun endAccordion() = Unit
 
-        override fun pushPath(fieldPath: String) {
-            pathStack.push(fieldPath)
-        }
-
-        override fun popPath() {
-            pathStack.pop()
+        private fun mapChildInstance(baseObject: Any?, field: Field) {
+            val parent = baseObject ?: return
+            val parentPath = instancePath[parent] ?: return
+            val child = field.get(parent) ?: return
+            instancePath[child] = if (parentPath.isEmpty()) field.name else "$parentPath.${field.name}"
         }
 
         override fun emitOption(baseObject: Any, field: Field, option: ConfigOption) {
-            options[pathStack.joinToString(".") + "." + field.name] = field
+            val path = instancePath[baseObject]
+            options[if (path.isNullOrEmpty()) field.name else "$path.${field.name}"] = field
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigGuiManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigGuiManager.kt
@@ -6,17 +6,22 @@ import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.ConfigUtils
+import com.mojang.brigadier.suggestion.SuggestionProvider
 import io.github.notenoughupdates.moulconfig.Config
 import io.github.notenoughupdates.moulconfig.annotations.Category
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 import io.github.notenoughupdates.moulconfig.gui.MoulConfigEditor
 import io.github.notenoughupdates.moulconfig.processor.ConfigProcessorDriver
 import io.github.notenoughupdates.moulconfig.processor.ConfigStructureReader
+import io.github.notenoughupdates.moulconfig.processor.ProcessedOption
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource
 import java.lang.reflect.Field
 import java.util.IdentityHashMap
 
 @SkyHanniModule
 object ConfigGuiManager {
+
+    private const val MAX_CONFIG_TAB_COMPLETE_SUGGESTIONS = 200
 
     private val widenConfig get() = SkyHanniMod.feature.gui.widenConfig
 
@@ -32,11 +37,62 @@ object ConfigGuiManager {
         collectOptionPaths(SkyHanniMod.feature)
     }
 
+    /** All config option paths mapped to their processed options, resolved through the config editor. */
+    val optionPathToOption: Map<String, ProcessedOption> by lazy {
+        val editor = getEditorInstance()
+        optionPathToField.mapNotNull { (path, field) ->
+            editor.getOptionFromField(field)?.let { path to it }
+        }.toMap()
+    }
+
     /** All config option paths, sorted alphabetically. */
     val allOptionPaths: List<String> by lazy { optionPathToField.keys.sorted() }
 
     /** Suggestions for the /sh search: category names followed by all config option paths. */
     val configTabCompleteSuggestions: List<String> by lazy { categoryNames + allOptionPaths }
+
+    /**
+     * Checks whether a config option matches a /sh search, reusing MoulConfig's own matching
+     * ([GuiOptionEditor.fulfillsSearch]) in addition to matching against the option's path.
+     * Mirrors the config editor's search semantics: trimmed and case-insensitive, with
+     * `+`-separated terms that all have to match.
+     */
+    internal fun configOptionMatchesSearch(input: String, path: String, option: ProcessedOption): Boolean =
+        searchTerms(input).all { term ->
+            path.contains(term) || option.getEditor().fulfillsSearch(term)
+        }
+
+    /** Checks whether a config category name matches a /sh search with the same semantics as [configOptionMatchesSearch]. */
+    internal fun categoryMatchesSearch(categoryName: String, input: String): Boolean =
+        searchTerms(input).all { term -> categoryName.lowercase().contains(term) }
+
+    private fun searchTerms(input: String): List<String> {
+        val search = input.trim().lowercase()
+        return if (search.isEmpty()) emptyList() else search.split("+")
+    }
+
+    /** Suggestions for the /sh search: category names and option paths matching MoulConfig's search. */
+    val configTabCompleteSuggestionProvider: SuggestionProvider<FabricClientCommandSource> by lazy {
+        SuggestionProvider { _, builder ->
+            val input = builder.remainingLowerCase
+            var count = 0
+            for (category in categoryNames) {
+                if (count >= MAX_CONFIG_TAB_COMPLETE_SUGGESTIONS) break
+                if (categoryMatchesSearch(category, input)) {
+                    builder.suggest(category)
+                    count++
+                }
+            }
+            for ((path, option) in optionPathToOption) {
+                if (count >= MAX_CONFIG_TAB_COMPLETE_SUGGESTIONS) break
+                if (configOptionMatchesSearch(input, path, option)) {
+                    builder.suggest(path)
+                    count++
+                }
+            }
+            builder.buildFuture()
+        }
+    }
 
     internal fun collectOptionPaths(config: SkyHanniConfig): Map<String, Field> {
         val reader = OptionPathReader()

--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigGuiManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigGuiManager.kt
@@ -53,7 +53,7 @@ object ConfigGuiManager {
      */
     internal fun configOptionMatchesSearch(input: String, path: String, option: ProcessedOption): Boolean =
         searchTerms(input).all { term ->
-            path.contains(term) || option.getEditor().fulfillsSearch(term)
+            path.lowercase().contains(term) || option.getEditor().fulfillsSearch(term)
         }
 
     /** Checks whether a config category name matches a /sh search with the same semantics as [configOptionMatchesSearch]. */

--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigGuiManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigGuiManager.kt
@@ -45,12 +45,6 @@ object ConfigGuiManager {
         }.toMap()
     }
 
-    /** All config option paths, sorted alphabetically. */
-    val allOptionPaths: List<String> by lazy { optionPathToField.keys.sorted() }
-
-    /** Suggestions for the /sh search: category names followed by all config option paths. */
-    val configTabCompleteSuggestions: List<String> by lazy { categoryNames + allOptionPaths }
-
     /**
      * Checks whether a config option matches a /sh search, reusing MoulConfig's own matching
      * ([GuiOptionEditor.fulfillsSearch]) in addition to matching against the option's path.

--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigGuiManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigGuiManager.kt
@@ -6,12 +6,20 @@ import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.ConfigUtils
+import io.github.notenoughupdates.moulconfig.annotations.Category
 import io.github.notenoughupdates.moulconfig.gui.MoulConfigEditor
 
 @SkyHanniModule
 object ConfigGuiManager {
 
     private val widenConfig get() = SkyHanniMod.feature.gui.widenConfig
+
+    /** The names of all top-level config categories, extracted from the [Category] annotations of [SkyHanniConfig]. */
+    val categoryNames: List<String> by lazy {
+        SkyHanniConfig::class.java.declaredFields
+            .mapNotNull { it.getAnnotation(Category::class.java)?.name }
+            .toList()
+    }
 
     @HandleEvent(ConfigLoadEvent::class)
     fun onConfigLoad() {

--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigGuiManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigGuiManager.kt
@@ -53,7 +53,7 @@ object ConfigGuiManager {
      */
     internal fun configOptionMatchesSearch(input: String, path: String, option: ProcessedOption): Boolean =
         searchTerms(input).all { term ->
-            path.lowercase().contains(term) || option.getEditor().fulfillsSearch(term)
+            path.lowercase().contains(term) || option.getEditor()?.fulfillsSearch(term) == true
         }
 
     /** Checks whether a config category name matches a /sh search with the same semantics as [configOptionMatchesSearch]. */
@@ -64,6 +64,12 @@ object ConfigGuiManager {
         val search = input.trim().lowercase()
         return if (search.isEmpty()) emptyList() else search.split("+")
     }
+
+    /** Resolves a /sh search input to the config option field with a matching path, ignoring case and surrounding whitespace. */
+    fun getOptionFieldForPath(search: String): Field? = findOptionFieldForPath(optionPathToField, search)
+
+    internal fun findOptionFieldForPath(paths: Map<String, Field>, search: String): Field? =
+        paths.entries.firstOrNull { it.key.equals(search.trim(), ignoreCase = true) }?.value
 
     /** Suggestions for the /sh search: category names and option paths matching MoulConfig's search. */
     val configTabCompleteSuggestionProvider: SuggestionProvider<FabricClientCommandSource> by lazy {

--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigGuiManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigGuiManager.kt
@@ -7,7 +7,12 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.ConfigUtils
 import io.github.notenoughupdates.moulconfig.annotations.Category
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 import io.github.notenoughupdates.moulconfig.gui.MoulConfigEditor
+import io.github.notenoughupdates.moulconfig.processor.ConfigProcessorDriver
+import io.github.notenoughupdates.moulconfig.processor.ConfigStructureReader
+import java.lang.reflect.Field
+import java.util.Stack
 
 @SkyHanniModule
 object ConfigGuiManager {
@@ -19,6 +24,34 @@ object ConfigGuiManager {
         SkyHanniConfig::class.java.declaredFields
             .mapNotNull { it.getAnnotation(Category::class.java)?.name }
             .toList()
+    }
+
+    /** All config option paths mapped to their fields, extracted by processing the config with a [ConfigStructureReader]. */
+    val optionPathToField: Map<String, Field> by lazy {
+        collectOptionPaths(SkyHanniMod.feature)
+    }
+
+    /** All config option paths, sorted alphabetically. */
+    val allOptionPaths: List<String> by lazy { optionPathToField.keys.sorted() }
+
+    /** Suggestions for the /sh search: category names followed by all config option paths. */
+    val configTabCompleteSuggestions: List<String> by lazy { categoryNames + allOptionPaths }
+
+    internal fun collectOptionPaths(config: SkyHanniConfig): Map<String, Field> {
+        val reader = OptionPathReader()
+        val driver = ConfigProcessorDriver(reader)
+        driver.warnForPrivateFields = false
+        driver.processConfig(config)
+        return reader.options
+    }
+
+    fun openConfigOption(field: Field) {
+        val editor = getEditorInstance()
+        val option = editor.getOptionFromField(field)
+        if (option == null || !editor.goToOption(option)) {
+            editor.search("")
+        }
+        ConfigUtils.openEditor(editor)
     }
 
     @HandleEvent(ConfigLoadEvent::class)
@@ -40,5 +73,30 @@ object ConfigGuiManager {
             editor.search(search)
         }
         ConfigUtils.openEditor(editor)
+    }
+
+    private class OptionPathReader : ConfigStructureReader {
+        val options = mutableMapOf<String, Field>()
+        private val pathStack = Stack<String>()
+
+        override fun beginCategory(baseObject: Any?, field: Field?, name: String, description: String) = Unit
+
+        override fun endCategory() = Unit
+
+        override fun beginAccordion(baseObject: Any?, field: Field?, option: ConfigOption?, id: Int) = Unit
+
+        override fun endAccordion() = Unit
+
+        override fun pushPath(fieldPath: String) {
+            pathStack.push(fieldPath)
+        }
+
+        override fun popPath() {
+            pathStack.pop()
+        }
+
+        override fun emitOption(baseObject: Any, field: Field, option: ConfigOption) {
+            options[pathStack.joinToString(".") + "." + field.name] = field
+        }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/BrigadierUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/BrigadierUtils.kt
@@ -32,8 +32,9 @@ object BrigadierUtils {
      * Convert a static collection to be suggestions for an argument
      */
     fun Collection<String>.toSuggestionProvider() = SuggestionProvider<FabricClientCommandSource> { _, builder ->
+        val remaining = builder.remainingLowerCase
         for (s in this) {
-            if (s.startsWith(builder.remainingLowerCase)) {
+            if (s.lowercase().startsWith(remaining)) {
                 builder.suggest(s)
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/BrigadierUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/BrigadierUtils.kt
@@ -55,27 +55,6 @@ object BrigadierUtils {
             builder.buildFuture()
         }
 
-    /**
-     * Dynamically generates suggestions for an argument based on a collection provided by a supplier,
-     * matching anywhere inside the suggestion instead of only at the start. Limits the number of suggestions
-     * shown per request to avoid flooding the client with large collections.
-     */
-    fun dynamicContainsSuggestionProvider(
-        limit: Int = Int.MAX_VALUE,
-        supplier: () -> Collection<String>,
-    ) = SuggestionProvider<FabricClientCommandSource> { _, builder ->
-        val remaining = builder.remainingLowerCase
-        var count = 0
-        for (option in supplier()) {
-            if (option.lowercase().contains(remaining)) {
-                builder.suggest(option)
-                count++
-                if (count >= limit) break
-            }
-        }
-        builder.buildFuture()
-    }
-
     private fun isCharAllowed(c: Char): Boolean = StringReader.isAllowedInUnquotedString(c) || c == SINGLE_QUOTE
 
     /** The same as [StringReader.readString], except it doesn't accept escaping with `'`. */

--- a/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/BrigadierUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/commands/brigadier/BrigadierUtils.kt
@@ -55,6 +55,27 @@ object BrigadierUtils {
             builder.buildFuture()
         }
 
+    /**
+     * Dynamically generates suggestions for an argument based on a collection provided by a supplier,
+     * matching anywhere inside the suggestion instead of only at the start. Limits the number of suggestions
+     * shown per request to avoid flooding the client with large collections.
+     */
+    fun dynamicContainsSuggestionProvider(
+        limit: Int = Int.MAX_VALUE,
+        supplier: () -> Collection<String>,
+    ) = SuggestionProvider<FabricClientCommandSource> { _, builder ->
+        val remaining = builder.remainingLowerCase
+        var count = 0
+        for (option in supplier()) {
+            if (option.lowercase().contains(remaining)) {
+                builder.suggest(option)
+                count++
+                if (count >= limit) break
+            }
+        }
+        builder.buildFuture()
+    }
+
     private fun isCharAllowed(c: Char): Boolean = StringReader.isAllowedInUnquotedString(c) || c == SINGLE_QUOTE
 
     /** The same as [StringReader.readString], except it doesn't accept escaping with `'`. */

--- a/src/test/java/at/hannibal2/skyhanni/test/config/ConfigCategoryNamesTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/config/ConfigCategoryNamesTest.kt
@@ -1,0 +1,35 @@
+package at.hannibal2.skyhanni.test.config
+
+import at.hannibal2.skyhanni.config.ConfigGuiManager
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ConfigCategoryNamesTest {
+
+    @Test
+    fun `category names are extracted from the config categories`() {
+        assertEquals(
+            listOf(
+                "About",
+                "GUI",
+                "Garden",
+                "Crimson Isle",
+                "The Rift",
+                "Fishing",
+                "Mining",
+                "Foraging",
+                "Hunting",
+                "Combat",
+                "Slayer",
+                "Dungeon",
+                "Inventory",
+                "Events",
+                "Skill Progress",
+                "Chat",
+                "Misc",
+                "Dev",
+            ),
+            ConfigGuiManager.categoryNames,
+        )
+    }
+}

--- a/src/test/java/at/hannibal2/skyhanni/test/config/ConfigOptionIndexTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/config/ConfigOptionIndexTest.kt
@@ -1,0 +1,31 @@
+package at.hannibal2.skyhanni.test.config
+
+import at.hannibal2.skyhanni.config.ConfigGuiManager
+import at.hannibal2.skyhanni.config.SkyHanniConfig
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ConfigOptionIndexTest {
+
+    private val optionPaths = ConfigGuiManager.collectOptionPaths(SkyHanniConfig())
+
+    @Test
+    fun `all config options are collected`() {
+        assertTrue(optionPaths.isNotEmpty())
+        assertTrue(optionPaths.size > 500)
+    }
+
+    @Test
+    fun `option paths contain known examples`() {
+        assertTrue("garden.noBreakItems" in optionPaths)
+        assertTrue("cropMilestones.progress" in optionPaths)
+        assertTrue("chat.filterType.empty" in optionPaths)
+    }
+
+    @Test
+    fun `option paths are well formed`() {
+        assertFalse(optionPaths.keys.any { it.startsWith("config.") })
+        assertFalse(optionPaths.keys.any { it.contains(' ') })
+    }
+}

--- a/src/test/java/at/hannibal2/skyhanni/test/config/ConfigOptionIndexTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/config/ConfigOptionIndexTest.kt
@@ -19,7 +19,7 @@ class ConfigOptionIndexTest {
     @Test
     fun `option paths contain known examples`() {
         assertTrue("garden.noBreakItems" in optionPaths)
-        assertTrue("cropMilestones.progress" in optionPaths)
+        assertTrue("garden.cropMilestones.progress" in optionPaths)
         assertTrue("chat.filterType.empty" in optionPaths)
     }
 

--- a/src/test/java/at/hannibal2/skyhanni/test/config/ConfigSearchMatcherTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/config/ConfigSearchMatcherTest.kt
@@ -5,7 +5,10 @@ import io.github.notenoughupdates.moulconfig.gui.GuiOptionEditor
 import io.github.notenoughupdates.moulconfig.processor.ProcessedOption
 import io.mockk.every
 import io.mockk.mockk
+import java.lang.reflect.Field
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
@@ -58,5 +61,19 @@ class ConfigSearchMatcherTest {
         assertTrue(ConfigGuiManager.categoryMatchesSearch("The Rift", "rift"))
         assertFalse(ConfigGuiManager.categoryMatchesSearch("About", "garden"))
         assertTrue(ConfigGuiManager.categoryMatchesSearch("About", ""))
+    }
+
+    @Test
+    fun `option field lookup is case insensitive and trims whitespace`() {
+        val field = mockk<Field>()
+        val paths = mapOf(
+            "garden.noBreakItems" to field,
+            "cropMilestones.progress" to field,
+        )
+        assertEquals(field, ConfigGuiManager.findOptionFieldForPath(paths, "garden.noBreakItems"))
+        assertEquals(field, ConfigGuiManager.findOptionFieldForPath(paths, "GARDEN.NOBREAKITEMS"))
+        assertEquals(field, ConfigGuiManager.findOptionFieldForPath(paths, "  garden.noBreakItems  "))
+        assertNull(ConfigGuiManager.findOptionFieldForPath(paths, "garden.notFound"))
+        assertNull(ConfigGuiManager.findOptionFieldForPath(paths, ""))
     }
 }

--- a/src/test/java/at/hannibal2/skyhanni/test/config/ConfigSearchMatcherTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/config/ConfigSearchMatcherTest.kt
@@ -1,0 +1,62 @@
+package at.hannibal2.skyhanni.test.config
+
+import at.hannibal2.skyhanni.config.ConfigGuiManager
+import io.github.notenoughupdates.moulconfig.gui.GuiOptionEditor
+import io.github.notenoughupdates.moulconfig.processor.ProcessedOption
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ConfigSearchMatcherTest {
+
+    private fun createOption(fulfillsSearch: (String) -> Boolean): ProcessedOption {
+        val editor = mockk<GuiOptionEditor>()
+        every { editor.fulfillsSearch(any()) } answers { fulfillsSearch(arg<String>(0)) }
+        return mockk {
+            every { getEditor() } returns editor
+        }
+    }
+
+    @Test
+    fun `matches when the path contains the search`() {
+        val option = createOption { false }
+        assertTrue(ConfigGuiManager.configOptionMatchesSearch("noBreak", "garden.noBreakItems", option))
+    }
+
+    @Test
+    fun `matches via MoulConfig search including search tags`() {
+        val option = createOption { it == "milestone" }
+        assertTrue(ConfigGuiManager.configOptionMatchesSearch("milestone", "garden.progress", option))
+        assertFalse(ConfigGuiManager.configOptionMatchesSearch("other", "garden.progress", option))
+    }
+
+    @Test
+    fun `search is case insensitive`() {
+        val option = createOption { false }
+        assertTrue(ConfigGuiManager.configOptionMatchesSearch("NOBREAK", "garden.noBreakItems", option))
+    }
+
+    @Test
+    fun `empty search matches everything`() {
+        val option = createOption { false }
+        assertTrue(ConfigGuiManager.configOptionMatchesSearch("", "garden.progress", option))
+        assertTrue(ConfigGuiManager.configOptionMatchesSearch("   ", "garden.progress", option))
+    }
+
+    @Test
+    fun `all plus separated terms must match`() {
+        val option = createOption { it == "a" }
+        assertTrue(ConfigGuiManager.configOptionMatchesSearch("a+b", "garden.a.b", option))
+        assertFalse(ConfigGuiManager.configOptionMatchesSearch("a+x", "garden.a.b", option))
+    }
+
+    @Test
+    fun `category names match with the same semantics`() {
+        assertTrue(ConfigGuiManager.categoryMatchesSearch("Crimson Isle", "crimson"))
+        assertTrue(ConfigGuiManager.categoryMatchesSearch("The Rift", "rift"))
+        assertFalse(ConfigGuiManager.categoryMatchesSearch("About", "garden"))
+        assertTrue(ConfigGuiManager.categoryMatchesSearch("About", ""))
+    }
+}


### PR DESCRIPTION
# Improvement: Tab completion for /sh config categories and settings (#209)

## What
Adds tab completion for the `/sh` command:

- `/sh <TAB>` suggests all top-level config categories (About, GUI, Garden,
  Crimson Isle, The Rift, ...).
- `/sh <TAB>` also suggests config options, matched with the same logic the
  config GUI search uses.
- Entering an exact option path navigates straight to that setting in the
  config GUI (selects its category and scrolls it into view) via
  `MoulConfigEditor.goToOption`. Non-matching input still falls back to the
  normal text search.

This closes the `/sh <categories>` part of #209. Note that `/shcroptime`
already received tab completion in #5883, and `/shtrackcollection` was
removed in #5764.

Technical details:

- The option index is built by hooking into MoulConfig's runtime config
  walker (`ConfigStructureReader` + `ConfigProcessorDriver`, the same
  mechanism `FeatureToggleProcessor` uses), collecting every
  `@ConfigOption` field with its fully-qualified path
  (`ConfigGuiManager.collectOptionPaths`). Paths are reconstructed from the
  config object tree rather than MoulConfig's path stack, which keeps them
  consistent (always prefixed with the top-level category) and in sync when
  config options are added or renamed.
- Suggestions reuse MoulConfig's own search instead of duplicating it: the
  editor's default search function is literally
  `GuiOptionEditor.fulfillsSearch(String)` (which matches option name,
  description and `@SearchTag`s), so each option is matched via
  `option.getEditor().fulfillsSearch(term)` in addition to the field path.
  Matching mirrors the editor's semantics: trimmed, case-insensitive,
  `+`-separated terms that all have to match.
- Also fixed `BrigadierUtils.toSuggestionProvider()` to match case-
  insensitively, so capitalized suggestions (like category names) work.

Regarding #5883's discussion of `/sh` completion: this suggests the config
categories that `/sh` actually searches (unlike the `CommandCategory` enum
values that were originally tried there), and exact path matches genuinely
navigate to the setting instead of only searching, addressing the
"completion suggests something the command doesn't do" concern.

Covered by unit tests (`ConfigCategoryNamesTest`, `ConfigOptionIndexTest`,
`ConfigSearchMatcherTest`).

## Changelog Improvements
+ Improved `/sh` to tab-complete config categories and settings. - Zelmari

## Changelog Technical Details
+ Built the config option index by hooking into MoulConfig's ConfigStructureReader, reusing its search matching for suggestions. - Zelmari
