### PR TITLE
Fix: Cape floating behind hidden armor

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/HideArmor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/HideArmor.kt
@@ -16,7 +16,7 @@ import net.minecraft.world.entity.player.Player
 @SkyHanniModule
 object HideArmor {
 
-    val config: HideArmorConfig get() = SkyHanniMod.feature.misc.hideArmor
+    private val config: HideArmorConfig get() = SkyHanniMod.feature.misc.hideArmor
 
     fun shouldHideArmor(entity: Player): Boolean {
         if (!SkyBlockUtils.inSkyBlock) return false
@@ -34,7 +34,7 @@ object HideArmor {
     }
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(91, "misc.hideArmor2", "misc.hideArmor")
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/HideArmor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/HideArmor.kt
@@ -5,11 +5,8 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.config.features.misc.HideArmorConfig
 import at.hannibal2.skyhanni.config.features.misc.HideArmorConfig.ModeEntry
-import at.hannibal2.skyhanni.events.SkyHanniRenderEntityEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.EntityUtils.getArmorInventory
 import at.hannibal2.skyhanni.utils.EntityUtils.isNpc
-import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.compat.EffectsCompat
 import at.hannibal2.skyhanni.utils.compat.EffectsCompat.Companion.hasPotionEffect
@@ -20,7 +17,6 @@ import net.minecraft.world.entity.player.Player
 object HideArmor {
 
     val config: HideArmorConfig get() = SkyHanniMod.feature.misc.hideArmor
-    private var armor = mapOf<Int, SafeItemStack>()
 
     fun shouldHideArmor(entity: Player): Boolean {
         if (!SkyBlockUtils.inSkyBlock) return false
@@ -34,35 +30,6 @@ object HideArmor {
             ModeEntry.OTHERS -> entity !is LocalPlayer
 
             else -> false
-        }
-    }
-
-    @HandleEvent
-    fun onRenderLivingPre(event: SkyHanniRenderEntityEvent.Pre<Player>) {
-        val entity = event.entity
-        if (!shouldHideArmor(entity)) return
-        val armorInventory = entity.getArmorInventory() ?: return
-
-        armor = buildMap {
-            for ((i, stack) in armorInventory.withIndex()) {
-                stack?.let {
-                    if (!config.onlyHelmet || i == 3) {
-                        this[i] = it.copy()
-                        armorInventory[i] = null
-                    }
-                }
-            }
-        }
-    }
-
-    @HandleEvent
-    fun onRenderLivingPost(event: SkyHanniRenderEntityEvent.Post<Player>) {
-        val entity = event.entity
-        if (!shouldHideArmor(entity)) return
-        val armorInventory = entity.getArmorInventory() ?: return
-
-        for ((index, stack) in armor) {
-            armorInventory[index] = stack
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/HideArmor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/HideArmor.kt
@@ -16,7 +16,7 @@ import net.minecraft.world.entity.player.Player
 @SkyHanniModule
 object HideArmor {
 
-    private val config: HideArmorConfig get() = SkyHanniMod.feature.misc.hideArmor
+    internal val config: HideArmorConfig get() = SkyHanniMod.feature.misc.hideArmor
 
     fun shouldHideArmor(entity: Player): Boolean {
         if (!SkyBlockUtils.inSkyBlock) return false

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/HideArmorHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/HideArmorHook.kt
@@ -8,5 +8,5 @@ fun shouldHideArmor(): Boolean = getEntity()?.let {
     it is Player && HideArmor.shouldHideArmor(it)
 } ?: false
 
-fun shouldHideHead(slot: EquipmentSlot) = shouldHideArmor() && !(HideArmor.config.onlyHelmet && slot != EquipmentSlot.HEAD)
+fun shouldHideSlot(slot: EquipmentSlot) = shouldHideArmor() && !(HideArmor.config.onlyHelmet && slot != EquipmentSlot.HEAD)
 

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinCapeLayer.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinCapeLayer.java
@@ -2,10 +2,14 @@ package at.hannibal2.skyhanni.mixins.transformers;
 
 import at.hannibal2.skyhanni.data.entity.EntityTransparencyManager;
 import at.hannibal2.skyhanni.mixins.hooks.EntityRenderDispatcherHookKt;
+import at.hannibal2.skyhanni.mixins.hooks.HideArmorHookKt;
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 import com.llamalad7.mixinextras.sugar.Local;
+import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.renderer.entity.layers.CapeLayer;
 import net.minecraft.client.renderer.rendertype.RenderType;
 import net.minecraft.client.renderer.rendertype.RenderTypes;
+import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.PlayerSkin;
 import org.spongepowered.asm.mixin.Mixin;
@@ -14,6 +18,16 @@ import org.spongepowered.asm.mixin.injection.ModifyArg;
 
 @Mixin(CapeLayer.class)
 public abstract class MixinCapeLayer {
+
+    // Vanilla shifts the cape onto the chestplate to stop it from clipping. With the chestplate hidden,
+    // that offset leaves the cape floating, so it is skipped to put the cape back onto the shoulders.
+    @WrapWithCondition(
+        method = "submit(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;ILnet/minecraft/client/renderer/entity/state/AvatarRenderState;FF)V",
+        at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/vertex/PoseStack;translate(FFF)V")
+    )
+    private boolean skipChestplateCapeOffset(PoseStack instance, float x, float y, float z) {
+        return !HideArmorHookKt.shouldHideSlot(EquipmentSlot.CHEST);
+    }
 
     @ModifyArg(method = "submit(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;ILnet/minecraft/client/renderer/entity/state/AvatarRenderState;FF)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/SubmitNodeCollector;submitModel(Lnet/minecraft/client/model/Model;Ljava/lang/Object;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/rendertype/RenderType;IIILnet/minecraft/client/renderer/feature/ModelFeatureRenderer$CrumblingOverlay;)V"), index = 3)
     private RenderType replaceRenderLayer(RenderType original, @Local PlayerSkin skinTextures) {

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinCapeLayer.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinCapeLayer.java
@@ -25,7 +25,7 @@ public abstract class MixinCapeLayer {
         method = "submit(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;ILnet/minecraft/client/renderer/entity/state/AvatarRenderState;FF)V",
         at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/vertex/PoseStack;translate(FFF)V")
     )
-    private boolean skipChestplateCapeOffset(PoseStack instance, float x, float y, float z) {
+    private boolean wrapChestplateCapeOffset(PoseStack instance, float x, float y, float z) {
         return !HideArmorHookKt.shouldHideSlot(EquipmentSlot.CHEST);
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinHumanoidArmorLayer.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinHumanoidArmorLayer.java
@@ -19,7 +19,7 @@ public abstract class MixinHumanoidArmorLayer {
     private void onRenderArmor(
         PoseStack poseStack, SubmitNodeCollector submitNodeCollector, ItemStack itemStack, EquipmentSlot slot, int i, HumanoidRenderState humanoidRenderState, CallbackInfo ci
     ) {
-        if (HideArmorHookKt.shouldHideHead(slot)) {
+        if (HideArmorHookKt.shouldHideSlot(slot)) {
             ci.cancel();
         }
     }


### PR DESCRIPTION
## What
> To avoid your cape clipping into your armor, Minecraft slightly moves it so that it matches the chestplate instead of the normal on-your-shoulders position. When hiding armor, the cape is not put back to your shoulders, and floats in the air slightly behind you.

– https://discord.com/channels/997079228510117908/1516149914655264912/1516149914655264912

This PR adjusts the cape offset, and removes two dead/unnecessary hooks that never actually did anything (at least not in 26.1) and would be potentially unsafe if they did (messing with the actual inventory at any point is risky).

## Changelog Fixes
+ Fixed Hide Armor leaving the cape in its armored position, causing it to float behind you. - Luna