### PR TITLE
Backend: Replace Apache HttpClient with Java HttpClient

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -190,9 +190,6 @@ dependencies {
     detektPlugins(project(":detekt"))
     detektPlugins(libs.detektrules.ktlint)
 
-    shadowImpl(libs.httpclient)
-    "minecraftTestClientRuntimeLibraries"(libs.httpclient)
-
     target.renderChestVersion?.let {
         includeImplementation("net.azureaaron:render-chest:$it")
         "productionRuntimeMods"("net.azureaaron:render-chest:$it")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,6 @@ junit = "5.14.4"
 mockk = "1.14.11"
 commons-net = "3.13.0"
 keval = "1.2.0"
-httpclient = "4.5.14"
 detektrules-neu = "1.0.0"
 
 [libraries]
@@ -45,7 +44,6 @@ mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 mockk-agent = { module = "io.mockk:mockk-agent-jvm", version.ref = "mockk" }
 commons-net = { module = "commons-net:commons-net", version.ref = "commons-net" }
 keval = { module = "com.notkamui.libs:keval", version.ref = "keval" }
-httpclient = { module = "org.apache.httpcomponents:httpclient", version.ref = "httpclient" }
 
 detekt-api = { module = "dev.detekt:detekt-api", version.ref = "detekt" }
 detektrules-ktlint = { module = "dev.detekt:detekt-rules-ktlint-wrapper", version.ref = "detekt" }

--- a/src/main/java/at/hannibal2/skyhanni/utils/api/ApiIntentionContext.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/api/ApiIntentionContext.kt
@@ -1,13 +1,8 @@
 package at.hannibal2.skyhanni.utils.api
 
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addAll
-import org.apache.http.client.methods.CloseableHttpResponse
-import org.apache.http.client.methods.HttpGet
-import org.apache.http.client.methods.HttpPost
-import org.apache.http.client.methods.HttpUriRequest
-import org.apache.http.entity.ContentType
-import org.apache.http.util.EntityUtils
-import java.nio.charset.StandardCharsets
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
 
 /**
  * Represents the intention to perform an API request, and the data associated with it.
@@ -16,28 +11,25 @@ import java.nio.charset.StandardCharsets
  * @param url The URL of the API request.
  * @param apiName The name of the API being requested.
  * @param request The HTTP request to be executed.
- * @param response The HTTP response received from the API request, if any.
+ * @param silentError If true, errors will not be logged unless debugConfig.apiUtilsNeverSilent is true.
+ * @param requestBody The body sent with the request, if any. [HttpRequest] does not expose it once built.
  */
 @PublishedApi
-internal open class ApiIntentionContext(
-    open val url: String,
-    open val apiName: String,
-    val request: HttpUriRequest,
-    open var response: CloseableHttpResponse? = null,
-    open val silentError: Boolean,
+internal class ApiIntentionContext(
+    val url: String,
+    val apiName: String,
+    val request: HttpRequest,
+    val silentError: Boolean,
+    val requestBody: String? = null,
 ) {
-    constructor(request: HttpUriRequest, path: ApiStaticPath) : this(
+    var response: HttpResponse<*>? = null
+
+    constructor(request: HttpRequest, path: ApiStaticPath, requestBody: String? = null) : this(
         url = path.url,
         apiName = path.apiName,
         request = request,
         silentError = path.silentError,
-    )
-
-    constructor(request: HttpUriRequest, apiName: String, silentError: Boolean) : this(
-        url = request.uri.toURL().toString(),
-        apiName = apiName,
-        request = request,
-        silentError = silentError,
+        requestBody = requestBody,
     )
 
     /**
@@ -48,40 +40,21 @@ internal open class ApiIntentionContext(
      * @param this The ApiIntentionContext containing the API request and possibly response data.
      * @return A [List] of pairs where each pair contains a field name and its corresponding value.
      */
-    private fun collectInterestingFields(): List<Pair<String, Any?>> = buildList {
+    fun collectInterestingFields(): List<Pair<String, Any?>> = buildList {
         addAll(
             "api name" to apiName,
             "url" to url,
-            "request method" to request.method,
+            "request method" to request.method(),
         )
         response?.let { resp ->
-            add("response headers" to resp.allHeaders.joinToString { "${it.name}: ${it.value}" })
-            add("response status" to resp.statusLine.toString())
-            add("response status code" to resp.statusLine.statusCode.toString())
+            add("response headers" to resp.headers().map().entries.joinToString { "${it.key}: ${it.value.joinToString()}" })
+            add("response status code" to resp.statusCode().toString())
         }
-        if (request is HttpPost && request.entity != null) {
-            val parsedContent = EntityUtils.toString(request.entity, StandardCharsets.UTF_8)
-                ?: "No content in request entity"
-            val contentType = ContentType.get(request.entity).mimeType
+        requestBody?.let { body ->
             addAll(
-                "post body" to parsedContent,
-                "content mime type" to contentType,
+                "post body" to body,
+                "content mime type" to request.headers().firstValue("Content-Type").orElse("unknown"),
             )
         }
     }
 }
-
-/**
- * See [ApiIntentionContext] for general field definitions.
- * Represents the intention to perform a GET request to an API endpoint.
- * @param tryForceGzip If true, the GET request will attempt to use gzip compression.
- */
-@PublishedApi
-internal data class GetApiIntentionContext(
-    override val url: String,
-    override val apiName: String,
-    val getRequest: HttpGet,
-    override var response: CloseableHttpResponse? = null,
-    override val silentError: Boolean,
-    val tryForceGzip: Boolean = false,
-) : ApiIntentionContext(url, apiName, getRequest, response, silentError)

--- a/src/main/java/at/hannibal2/skyhanni/utils/api/ApiInternalUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/api/ApiInternalUtils.kt
@@ -5,21 +5,16 @@ import at.hannibal2.skyhanni.config.ConfigManager
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.json.fromJson
 import com.google.gson.JsonElement
-import org.apache.http.HttpEntity
-import org.apache.http.client.HttpResponseException
-import org.apache.http.client.config.RequestConfig
-import org.apache.http.client.methods.CloseableHttpResponse
-import org.apache.http.client.methods.HttpGet
-import org.apache.http.client.methods.HttpPost
-import org.apache.http.client.methods.HttpRequestBase
-import org.apache.http.client.protocol.RequestAcceptEncoding
-import org.apache.http.client.protocol.ResponseContentEncoding
-import org.apache.http.impl.client.CloseableHttpClient
-import org.apache.http.impl.client.HttpClients
-import org.apache.http.message.BasicHeader
 import java.io.File
+import java.io.IOException
+import java.io.InputStream
+import java.net.ProxySelector
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
 import java.nio.charset.StandardCharsets
 import java.security.KeyStore
+import java.time.Duration
 import java.util.zip.GZIPInputStream
 import javax.net.ssl.HttpsURLConnection
 import javax.net.ssl.KeyManagerFactory
@@ -30,7 +25,6 @@ import kotlinx.coroutines.withContext
 
 @Suppress("InjectDispatcher")
 object ApiInternalUtils {
-
     private val debugConfig get() = SkyHanniMod.feature.dev.debug
     val neverSilent get() = debugConfig.apiUtilsNeverSilent
 
@@ -56,24 +50,17 @@ object ApiInternalUtils {
         connection.sslSocketFactory = it.socketFactory
     }
 
-    private val defaultHeaders = listOf(
-        BasicHeader("Pragma", "no-cache"),
-        BasicHeader("Cache-Control", "no-cache"),
-    )
-    private val gatedConnectionConfig = RequestConfig.custom()
-        .setConnectTimeout(10_000)
-        .setSocketTimeout(30_000)
-        .setConnectionRequestTimeout(5_000)
-        .build()
+    private val connectTimeout: Duration = Duration.ofSeconds(10)
+    internal val requestTimeout: Duration = Duration.ofSeconds(30)
+
+    /** Binary downloads are whole repository archives, which take far longer than a single API call. */
+    internal val binaryRequestTimeout: Duration = Duration.ofMinutes(5)
 
     @PublishedApi
-    internal val httpClient: CloseableHttpClient = HttpClients.custom()
-        .setUserAgent(SkyHanniMod.userAgent)
-        .setDefaultHeaders(defaultHeaders)
-        .setDefaultRequestConfig(gatedConnectionConfig)
-        .useSystemProperties()
-        .addInterceptorLast(RequestAcceptEncoding())
-        .addInterceptorLast(ResponseContentEncoding())
+    internal val httpClient: HttpClient = HttpClient.newBuilder()
+        .connectTimeout(connectTimeout)
+        .followRedirects(HttpClient.Redirect.NORMAL)
+        .apply { ProxySelector.getDefault()?.let { proxy(it) } }
         .build()
 
     /**
@@ -82,7 +69,7 @@ object ApiInternalUtils {
      * @param file The [File] to save the Binary response to.
      * @return A [BinaryApiResponse] containing the result of the request.
      */
-    internal suspend fun ApiStaticPath.internalGetBinaryResponse(file: File): BinaryApiResponse = withBinaryHttpClient<HttpGet>(file)
+    internal suspend fun ApiStaticPath.internalGetBinaryResponse(file: File): BinaryApiResponse = withBinaryHttpClient(file)
 
     /**
      * Driving logic for posting a JSON body to the API.
@@ -93,9 +80,10 @@ object ApiInternalUtils {
      */
     internal suspend inline fun <reified T : JsonElement> ApiStaticPostPath.internalPostJson(
         jsonBody: String,
-    ): JsonApiResponse<T> = withJsonHttpClient<T, HttpPost>(
-        entityHandler = { it.readEntityJsonResponse(failOnNoContentLength = failOnNoContentLength) },
+    ): JsonApiResponse<T> = withJsonHttpClient(
+        responseReader = { it.readJsonResponse(failOnNoContentLength = failOnNoContentLength) },
         requestFactory = { buildPostRequest(jsonBody) },
+        requestBody = jsonBody,
     )
 
     /**
@@ -106,58 +94,51 @@ object ApiInternalUtils {
      */
     @PublishedApi
     internal suspend inline fun <reified T : JsonElement> ApiStaticGetPath.internalGetJsonResponse(): JsonApiResponse<T> =
-        withJsonHttpClient<T, HttpGet>(
-            entityHandler = { it.readEntityJsonResponse(tryForceGzip) },
+        withJsonHttpClient(
+            responseReader = { it.readJsonResponse(tryForceGzip) },
             requestFactory = { buildGetRequest() },
         )
 
     // <editor-fold desc="Client Execution Wrappers">
     /**
-     * Generic method to execute an API request using the provided HttpClient.
+     * Generic method to execute an API request using the shared [httpClient].
      * Executes the given API intention and returns an [Res] (ApiResponse subtype).
-     * If the request fails, it will call the exceptionHandler with the error.
+     * If the request fails, the error is logged unless the intention is silent.
      * @param Res The type of ApiResponse expected (e.g., [BinaryApiResponse] or [JsonApiResponse]).
      * @param T The type of data expected in the ApiResponse (e.g., [Long] for Binary responses or [JsonElement] for JSON responses).
-     * @param Req The type of HttpRequestBase to be used (e.g., [HttpGet] or [HttpPost]).
-     * @param requestFactory Creates the HttpRequestBase for the API request.
-     * @param entityHandler Processes the HttpEntity from the response and returns data of type [T].
+     * @param requestFactory Creates the [HttpRequest] for the API request.
+     * @param responseReader Reads the response body and returns data of type [T].
      * @param dataConsumer Consumes the data and returns an ApiResponse of type [Res].
-     * @param entityGetter Extracts the HttpEntity from the CloseableHttpResponse.
+     * @param requestBody The body sent with the request, if any, used for error logging only.
+     * @param responseFilter Decides whether the response should be handed to the [responseReader] at all.
      * @return An ApiResponse of type [Res] containing the result of the request.
      */
     @PublishedApi
-    internal suspend inline fun <Res : ApiResponse<T>, T, Req : HttpRequestBase> ApiStaticPath.withHttpClient(
-        crossinline requestFactory: ApiStaticPath.() -> Req,
-        crossinline entityHandler: (HttpEntity?) -> T?,
+    internal suspend inline fun <Res : ApiResponse<T>, T> ApiStaticPath.withHttpClient(
+        crossinline requestFactory: ApiStaticPath.() -> HttpRequest,
+        crossinline responseReader: (HttpResponse<InputStream>?) -> T?,
         crossinline dataConsumer: (Boolean, String, T?) -> Res,
-        crossinline entityGetter: (CloseableHttpResponse) -> HttpEntity? = { it.getEntityOrNull() },
+        requestBody: String? = null,
+        crossinline responseFilter: (HttpResponse<InputStream>) -> HttpResponse<InputStream>? = { it.takeIfSuccessful() },
     ): Res = withContext(Dispatchers.IO) {
-        ApiIntentionContext(requestFactory(), this@withHttpClient).let { apiIntention ->
+        ApiIntentionContext(requestFactory(), this@withHttpClient, requestBody).let { apiIntention ->
             var responseData: T? = null
             runCatching {
-                httpClient.execute(apiIntention.request).use { resp ->
+                httpClient.send(apiIntention.request, HttpResponse.BodyHandlers.ofInputStream()).let { resp ->
                     apiIntention.response = resp
-                    val entity = entityGetter(resp)
-                    responseData = entityHandler(entity)
-                    if (resp.statusLine.statusCode !in 200..299)
-                        throw HttpResponseException(resp.statusLine.statusCode, resp.statusLine.reasonPhrase)
-                    val message = resp.statusLine?.reasonPhrase ?: "OK"
-                    dataConsumer(true, message, responseData)
+                    resp.body().use {
+                        responseData = responseReader(responseFilter(resp))
+                    }
+                    val statusCode = resp.statusCode()
+                    if (statusCode !in 200..299) throw IOException("Request failed with status code $statusCode")
+                    dataConsumer(true, "OK", responseData)
                 }
             }.getOrElse { e ->
                 val message = e.message ?: "Request to ${apiIntention.apiName} failed"
                 if (neverSilent || !apiIntention.silentError) ErrorManager.logErrorWithData(
                     e,
                     message,
-                    extraData = listOf(
-                        "api name" to apiIntention.apiName,
-                        "url" to apiIntention.url,
-                        "request method" to apiIntention.request.method,
-                        "response status" to apiIntention.response?.statusLine.toString(),
-                        "response headers" to apiIntention.response?.allHeaders?.joinToString { header ->
-                            "${header.name}: ${header.value}"
-                        },
-                    ).toTypedArray()
+                    extraData = apiIntention.collectInterestingFields().toTypedArray(),
                 )
                 dataConsumer(false, message, responseData)
             }
@@ -169,59 +150,75 @@ object ApiInternalUtils {
      * Specific to fetching a response expecting a JSON body of some type [T].
      * Executes the given API intention and returns a JsonApiResponse of type [T].
      * @param T The type of JsonElement expected in the ApiResponse.
-     * @param Req The type of HttpRequestBase to be used (e.g., [HttpPost] or [HttpGet]).
      * @param this The [ApiStaticPath] to execute on the client.
      * @return A [JsonApiResponse] containing the result of the request.
      */
     @PublishedApi
-    internal suspend inline fun <reified T : JsonElement, reified Req : HttpRequestBase> ApiStaticPath.withJsonHttpClient(
-        crossinline entityHandler: (HttpEntity?) -> T?,
-        crossinline requestFactory: ApiStaticPath.() -> Req = ApiStaticPath::buildRequest,
+    internal suspend inline fun <reified T : JsonElement> ApiStaticPath.withJsonHttpClient(
+        crossinline responseReader: (HttpResponse<InputStream>?) -> T?,
+        crossinline requestFactory: ApiStaticPath.() -> HttpRequest = ApiStaticPath::buildRequest,
+        requestBody: String? = null,
     ): JsonApiResponse<T> = withHttpClient(
         requestFactory,
-        entityHandler,
+        responseReader,
         ::JsonApiResponse,
-        entityGetter = CloseableHttpResponse::getEntity,
+        requestBody,
+        responseFilter = { it },
     )
 
     /**
      * See [withHttpClient] for general field definitions.
      * Specific to fetching a Binary response and saving it to a file.
      * Executes the given API intention and returns a BinaryApiResponse.
-     * @param Req The type of HttpRequestBase to be used (e.g., [HttpGet]).
      * @param this The [ApiStaticPath] to execute on the client.
      * @param file The [File] to save the Binary response to.
      * @return A [BinaryApiResponse] containing the result of the request.
      */
-    internal suspend inline fun <reified Req : HttpRequestBase> ApiStaticPath.withBinaryHttpClient(
+    internal suspend inline fun ApiStaticPath.withBinaryHttpClient(
         file: File,
-        crossinline entityHandler: (HttpEntity?) -> Long? = { it.readEntityToFile(file) },
-        crossinline requestFactory: ApiStaticPath.() -> Req = {
-            buildRequest { addHeader("Accept-Encoding", "gzip") }
-        }
-    ): BinaryApiResponse = withHttpClient(requestFactory, entityHandler, ::BinaryApiResponse)
+        crossinline responseReader: (HttpResponse<InputStream>?) -> Long? = { it.readBodyToFile(file) },
+        crossinline requestFactory: ApiStaticPath.() -> HttpRequest = {
+            buildRequest { timeout(binaryRequestTimeout) }
+        },
+    ): BinaryApiResponse = withHttpClient(requestFactory, responseReader, ::BinaryApiResponse)
 
     /**
-     * The default method to fetch an [HttpEntity] from a [CloseableHttpResponse] (this).
-     * @param this The [CloseableHttpResponse] from which to extract the [HttpEntity].
-     * @return The [HttpEntity] if the response status code is in the range 200-299, or null if the status code indicates an error.
+     * The default filter deciding whether a response carries a body worth reading.
+     * @param this The [HttpResponse] to check.
+     * @return The response if the status code is in the range 200-299 and a body is present, or null otherwise.
      */
     @PublishedApi
-    internal fun CloseableHttpResponse.getEntityOrNull(
+    internal fun HttpResponse<InputStream>.takeIfSuccessful(
         failOnNoContentLength: Boolean = true,
-    ): HttpEntity? = if (this.statusLine.statusCode in 200..299) {
-        this.entity.takeIf { it?.contentLength != 0L || !failOnNoContentLength }
-    } else null
+    ): HttpResponse<InputStream>? = takeIf {
+        statusCode() in 200..299 && (contentLength != 0L || !failOnNoContentLength)
+    }
+
+    /** The announced body length, or -1 if the server did not send a Content-Length header. */
+    @PublishedApi
+    internal val HttpResponse<*>.contentLength: Long
+        get() = headers().firstValueAsLong("content-length").orElse(-1L)
 
     /**
-     * Reads the content of the HttpEntity and writes it to a file.
-     * @param this The [HttpEntity] to read from.
-     * @param file The [File] to write the content to.
-     * @return The number of bytes written to the file, or null if the entity is null or an error occurs.
+     * The response body, gzip decoded when applicable. [java.net.http.HttpClient] never decodes content encodings itself.
+     * @param forceGzip If true, the body is gzip decoded even if the server did not announce the encoding.
      */
-    internal fun HttpEntity?.readEntityToFile(file: File): Long? =
+    @PublishedApi
+    internal fun HttpResponse<InputStream>.decodedBody(forceGzip: Boolean = false): InputStream {
+        val gzipped = forceGzip || headers().firstValue("content-encoding")
+            .map { it.equals("gzip", ignoreCase = true) }.orElse(false)
+        return if (gzipped) GZIPInputStream(body()) else body()
+    }
+
+    /**
+     * Reads the response body and writes it to a file.
+     * @param this The [HttpResponse] to read from.
+     * @param file The [File] to write the content to.
+     * @return The number of bytes written to the file, or null if the response is null or an error occurs.
+     */
+    internal fun HttpResponse<InputStream>?.readBodyToFile(file: File): Long? =
         this?.runCatching {
-            content.use { input ->
+            decodedBody().use { input ->
                 file.outputStream().use { output ->
                     input.copyTo(output)
                 }
@@ -230,22 +227,20 @@ object ApiInternalUtils {
         }?.getOrNull()
 
     /**
-     * Reads the content of the HttpEntity and parses it as a JsonElement.
-     * @param this The [HttpEntity] to read from.
-     * @param tryForceGzip If true, the content will be read as a GZIP stream.
+     * Reads the response body and parses it as a JsonElement.
+     * @param this The [HttpResponse] to read from.
+     * @param tryForceGzip If true, the body will be gzip decoded even if the server did not announce the encoding.
      * @param failOnNoContentLength If true, the method will return null if the content length is 0.
      * @return A parsed [JsonElement] or null if the content is empty or an error occurs.
      */
-    @Suppress("UNCHECKED_CAST")
     @PublishedApi
-    internal inline fun <reified T : JsonElement> HttpEntity?.readEntityJsonResponse(
+    internal inline fun <reified T : JsonElement> HttpResponse<InputStream>?.readJsonResponse(
         tryForceGzip: Boolean = false,
         failOnNoContentLength: Boolean = true,
     ): T? = when {
-        this == null || (this.contentLength == 0L && failOnNoContentLength) -> null
+        this == null || (contentLength == 0L && failOnNoContentLength) -> null
         else -> runCatching {
-            val raw = if (tryForceGzip) GZIPInputStream(this.content) else this.content
-            val text = raw.bufferedReader(StandardCharsets.UTF_8).use { it.readText() }
+            val text = decodedBody(tryForceGzip).bufferedReader(StandardCharsets.UTF_8).use { it.readText() }
             if (text.isBlank()) null
             else ConfigManager.gson.fromJson<T>(text)
         }.getOrNull()

--- a/src/main/java/at/hannibal2/skyhanni/utils/api/ApiStaticPath.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/api/ApiStaticPath.kt
@@ -1,10 +1,9 @@
 package at.hannibal2.skyhanni.utils.api
 
-import org.apache.http.client.methods.HttpGet
-import org.apache.http.client.methods.HttpPost
-import org.apache.http.client.methods.HttpRequestBase
-import org.apache.http.entity.ContentType
-import org.apache.http.entity.StringEntity
+import at.hannibal2.skyhanni.SkyHanniMod
+import java.net.URI
+import java.net.http.HttpRequest
+import java.nio.charset.StandardCharsets
 
 /**
  * Represents a static API path that can be used to fetch data from a predefined URL.
@@ -20,16 +19,25 @@ open class ApiStaticPath(
     fun toGet(tryForceGzip: Boolean = false) = ApiStaticGetPath(url, apiName, silentError, tryForceGzip)
     fun toPost(failOnNoContentLength: Boolean = false) = ApiStaticPostPath(url, apiName, silentError, failOnNoContentLength)
 
-    inline fun <reified T : HttpRequestBase> buildRequest(block: T.() -> Unit = {}): T {
-        val ctor = T::class.java.getConstructor(String::class.java)
-        return ctor.newInstance(url).apply(block)
-    }
+    /**
+     * Builds a request for this path, pre-filled with the headers every SkyHanni request shares.
+     * @param block Applied to the builder, may override any of the defaults.
+     */
+    fun buildRequest(block: HttpRequest.Builder.() -> Unit = {}): HttpRequest =
+        HttpRequest.newBuilder(URI.create(url))
+            .timeout(ApiInternalUtils.requestTimeout)
+            .header("User-Agent", SkyHanniMod.userAgent)
+            .header("Pragma", "no-cache")
+            .header("Cache-Control", "no-cache")
+            .header("Accept-Encoding", "gzip")
+            .apply(block)
+            .build()
 }
 
 /**
  * See [ApiStaticPath] for general field definitions.
  * Represents a static API path with a URL and API name, with the intention to GET data from it.
- * @param tryForceGzip If true, the request will attempt to use gzip compression. Only relevant for GET requests.
+ * @param tryForceGzip If true, the response body will be gzip decoded even if the server does not announce it.
  */
 data class ApiStaticGetPath(
     override val url: String,
@@ -37,11 +45,7 @@ data class ApiStaticGetPath(
     override val silentError: Boolean = true,
     val tryForceGzip: Boolean = false,
 ) : ApiStaticPath(url, apiName, silentError) {
-
-    fun buildGetRequest() = super.buildRequest<HttpGet> {
-        if (tryForceGzip) addHeader("Accept-Encoding", "gzip")
-    }
-
+    fun buildGetRequest(): HttpRequest = buildRequest { GET() }
 }
 
 /**
@@ -54,10 +58,10 @@ data class ApiStaticPostPath(
     override val apiName: String,
     override val silentError: Boolean = true,
     val failOnNoContentLength: Boolean = false,
-    val contentType: ContentType = ContentType.APPLICATION_JSON,
+    val contentType: String = "application/json; charset=UTF-8",
 ) : ApiStaticPath(url, apiName, silentError) {
-
-    fun buildPostRequest(body: String) = super.buildRequest<HttpPost> {
-        entity = StringEntity(body, contentType)
+    fun buildPostRequest(body: String): HttpRequest = buildRequest {
+        header("Content-Type", contentType)
+        POST(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8))
     }
 }


### PR DESCRIPTION
## What
Removes the dependency on Apache HttpClient and replaces it with Java HttpClient.

## Why
Minecraft used to bundle this library, but they dropped it in 1.21.11. There is no real benefit to us using it, so dropping it saves ~1.5 MB on the JAR size.

## Changelog Technical Details
+ Dropped the dependency on Apache HttpClient in favor of Java's built-in HttpClient. - Luna