### PR TITLE
Backend: Replace Apache Commons Net with a self-contained SNTP client

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -176,10 +176,6 @@ dependencies {
     compileOnly(libs.basicMath)
     "minecraftTestClientRuntimeLibraries"(libs.basicMath)
 
-    // getting clock offset
-    shadowImpl(libs.commons.net)
-    "minecraftTestClientRuntimeLibraries"(libs.commons.net)
-
     // Calculator
     shadowImpl(libs.keval) {
         exclude(group = "org.jetbrains.kotlin")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -179,10 +179,6 @@ dependencies {
     compileOnly(libs.basicMath)
     "minecraftTestClientRuntimeLibraries"(libs.basicMath)
 
-    // getting clock offset
-    includeImplementation(libs.commons.net)
-    "minecraftTestClientRuntimeLibraries"(libs.commons.net)
-
     // Calculator
     includeImplementation(libs.keval) {
         exclude(group = "org.jetbrains.kotlin")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,6 @@ detekt = "2.0.0-alpha.6"
 devauth = "1.2.2"
 junit = "5.14.4"
 mockk = "1.14.11"
-commons-net = "3.13.0"
 keval = "1.2.0"
 httpclient = "4.5.14"
 detektrules-neu = "1.0.0"
@@ -43,7 +42,6 @@ junit = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
 junit-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 mockk-agent = { module = "io.mockk:mockk-agent-jvm", version.ref = "mockk" }
-commons-net = { module = "commons-net:commons-net", version.ref = "commons-net" }
 keval = { module = "com.notkamui.libs:keval", version.ref = "keval" }
 httpclient = { module = "org.apache.httpcomponents:httpclient", version.ref = "httpclient" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,6 @@ detekt = "2.0.0-alpha.5"
 devauth = "1.2.2"
 junit = "5.14.4"
 mockk = "1.14.11"
-commons-net = "3.13.0"
 keval = "1.2.0"
 httpclient = "4.5.14"
 detektrules-neu = "1.0.0"
@@ -43,7 +42,6 @@ junit = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
 junit-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 mockk-agent = { module = "io.mockk:mockk-agent-jvm", version.ref = "mockk" }
-commons-net = { module = "commons-net:commons-net", version.ref = "commons-net" }
 keval = { module = "com.notkamui.libs:keval", version.ref = "keval" }
 httpclient = { module = "org.apache.httpcomponents:httpclient", version.ref = "httpclient" }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/ComputerTimeOffset.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ComputerTimeOffset.kt
@@ -10,8 +10,6 @@ import at.hannibal2.skyhanni.utils.EnumUtils.next
 import at.hannibal2.skyhanni.utils.EnumUtils.previous
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut
-import org.apache.commons.net.ntp.NTPUDPClient
-import java.net.InetAddress
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 import kotlin.time.Duration
@@ -19,7 +17,6 @@ import kotlin.time.Duration.Companion.INFINITE
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.toJavaDuration
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 
@@ -101,14 +98,7 @@ object ComputerTimeOffset {
             }
             return@runCatching null
         }
-        NTPUDPClient().apply {
-            setDefaultTimeout(10.seconds.toJavaDuration())
-        }.use { client ->
-            val address = InetAddress.getByName(ntpServer)
-            val timeInfo = client.getTime(address)
-            timeInfo.computeDetails()
-            timeInfo.offset.milliseconds
-        }
+        SntpClient.getOffset(ntpServer)
     }.onFailure { e ->
         if (e is SocketTimeoutException || e is UnknownHostException) {
             timeoutMap.addOrPut(ntpServer, 1)

--- a/src/main/java/at/hannibal2/skyhanni/utils/ComputerTimeOffset.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ComputerTimeOffset.kt
@@ -66,9 +66,7 @@ object ComputerTimeOffset {
             if (state == State.TOTALLY_OFF) ErrorManager.logErrorStateWithData(
                 "Error when checking Computer Time Offset",
                 "trying to check again even though the previous check is still not done",
-            ) else if (state == State.SLOW) ChatUtils.chat(
-                "Computer Time Offset calculation took longer than normal. Checking less often now.",
-            )
+            ) else if (state == State.SLOW) sendSlowDownMessage("took longer than normal")
             return
         } else if (stableRuns++ > 10 && state != State.NORMAL) {
             stableRuns = 0
@@ -82,6 +80,17 @@ object ComputerTimeOffset {
                 tryDisplayOffset(wasOffsetBefore)
             }
         }
+    }
+
+    private fun sendSlowDownMessage(reason: String) = ChatUtils.chat(
+        "Computer Time Offset calculation $reason. Checking less often now.",
+    )
+
+    private fun onKissOfDeath() {
+        if (state != State.NORMAL) return
+        stableRuns = 0
+        state = State.SLOW
+        sendSlowDownMessage("hit a rate limit")
     }
 
     private fun getNtpOffset(ntpServer: String): Duration? = runCatching {
@@ -100,7 +109,10 @@ object ComputerTimeOffset {
         }
         SntpClient.getOffset(ntpServer)
     }.onFailure { e ->
-        if (e is SocketTimeoutException || e is UnknownHostException) {
+        if (e is SntpClient.KissOfDeathException) {
+            onKissOfDeath()
+            return@onFailure
+        } else if (e is SocketTimeoutException || e is UnknownHostException) {
             timeoutMap.addOrPut(ntpServer, 1)
             return@onFailure
         } else if (SkyBlockUtils.inSkyBlock && config.warnAboutPcTimeOffset) ErrorManager.logErrorWithData(

--- a/src/main/java/at/hannibal2/skyhanni/utils/ComputerTimeOffset.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ComputerTimeOffset.kt
@@ -3,15 +3,12 @@ package at.hannibal2.skyhanni.utils
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
-import at.hannibal2.skyhanni.events.ProfileJoinEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.EnumUtils.next
 import at.hannibal2.skyhanni.utils.EnumUtils.previous
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut
-import org.apache.commons.net.ntp.NTPUDPClient
-import java.net.InetAddress
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 import kotlin.time.Duration
@@ -19,13 +16,11 @@ import kotlin.time.Duration.Companion.INFINITE
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.toJavaDuration
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 
 @SkyHanniModule
 object ComputerTimeOffset {
-
     private val devConfig get() = SkyHanniMod.feature.dev
     private val config get() = SkyHanniMod.feature.misc
     private val timeoutMap: MutableMap<String, Int> = mutableMapOf()
@@ -69,9 +64,7 @@ object ComputerTimeOffset {
             if (state == State.TOTALLY_OFF) ErrorManager.logErrorStateWithData(
                 "Error when checking Computer Time Offset",
                 "trying to check again even though the previous check is still not done",
-            ) else if (state == State.SLOW) ChatUtils.chat(
-                "Computer Time Offset calculation took longer than normal. Checking less often now.",
-            )
+            ) else if (state == State.SLOW) sendSlowDownMessage("took longer than normal")
             return
         } else if (stableRuns++ > 10 && state != State.NORMAL) {
             stableRuns = 0
@@ -85,6 +78,17 @@ object ComputerTimeOffset {
                 tryDisplayOffset(wasOffsetBefore)
             }
         }
+    }
+
+    private fun sendSlowDownMessage(reason: String) = ChatUtils.chat(
+        "Computer Time Offset calculation $reason. Checking less often now.",
+    )
+
+    private fun onKissOfDeath() {
+        if (state != State.NORMAL) return
+        stableRuns = 0
+        state = State.SLOW
+        sendSlowDownMessage("hit a rate limit")
     }
 
     private fun getNtpOffset(ntpServer: String): Duration? = runCatching {
@@ -101,16 +105,12 @@ object ComputerTimeOffset {
             }
             return@runCatching null
         }
-        NTPUDPClient().apply {
-            setDefaultTimeout(10.seconds.toJavaDuration())
-        }.use { client ->
-            val address = InetAddress.getByName(ntpServer)
-            val timeInfo = client.getTime(address)
-            timeInfo.computeDetails()
-            timeInfo.offset.milliseconds
-        }
+        SntpClient.getOffset(ntpServer)
     }.onFailure { e ->
-        if (e is SocketTimeoutException || e is UnknownHostException) {
+        if (e is SntpClient.KissOfDeathException) {
+            onKissOfDeath()
+            return@onFailure
+        } else if (e is SocketTimeoutException || e is UnknownHostException) {
             timeoutMap.addOrPut(ntpServer, 1)
             return@onFailure
         } else if (SkyBlockUtils.inSkyBlock && config.warnAboutPcTimeOffset) ErrorManager.logErrorWithData(
@@ -152,11 +152,11 @@ object ComputerTimeOffset {
         )
     }
 
-    @HandleEvent(ProfileJoinEvent::class)
-    fun onProfileJoin() = DelayedRun.runDelayed(5.seconds, ::tryCheckOffset)
+    @HandleEvent
+    private fun onProfileJoin() = DelayedRun.runDelayed(5.seconds, ::tryCheckOffset)
 
     @HandleEvent
-    fun onDebugDataCollect(event: DebugDataCollectEvent) {
+    private fun onDebugDataCollect(event: DebugDataCollectEvent) {
         event.title("Computer Time Offset")
 
         if (state != State.NORMAL) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/SntpClient.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SntpClient.kt
@@ -1,0 +1,102 @@
+package at.hannibal2.skyhanni.utils
+
+import java.io.IOException
+import java.net.DatagramPacket
+import java.net.DatagramSocket
+import java.net.InetAddress
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Minimal SNTP client (RFC 4330) that queries an NTP server for the offset between its clock and the local one.
+ */
+object SntpClient {
+    private const val NTP_PORT = 123
+    private const val PACKET_SIZE = 48
+    private const val NTP_VERSION = 3
+    private const val MODE_CLIENT = 3
+    private const val MODE_SERVER = 4
+
+    /** Seconds between the NTP epoch (1900-01-01) and the unix epoch (1970-01-01). */
+    private const val EPOCH_OFFSET_SECONDS = 2_208_988_800L
+
+    private const val REFERENCE_IDENTIFIER_INDEX = 12
+    private const val KISS_CODE_LENGTH = 4
+    private const val ORIGINATE_TIMESTAMP_INDEX = 24
+    private const val RECEIVE_TIMESTAMP_INDEX = 32
+    private const val TRANSMIT_TIMESTAMP_INDEX = 40
+
+    private val TIMEOUT = 10.seconds
+
+    /**
+     * Thrown when the server answers with a kiss-of-death packet, asking the client to stop querying or to back off.
+     *
+     * @param code the kiss code sent by the server, e.g. `RATE`, `DENY` or `RSTR`
+     */
+    class KissOfDeathException(val code: String) : IOException("NTP server sent a kiss-of-death ($code)")
+
+    /**
+     * Queries [server] and returns how far the local clock is behind the server clock.
+     *
+     * @throws java.net.UnknownHostException if [server] can not be resolved
+     * @throws java.net.SocketTimeoutException if the server does not respond in time
+     * @throws KissOfDeathException if the server asks the client to stop or slow down
+     * @throws IOException if the response is not a valid NTP server reply
+     */
+    @Suppress("ThrowsCount")
+    fun getOffset(server: String): Duration {
+        val address = InetAddress.getByName(server)
+        val buffer = ByteArray(PACKET_SIZE)
+        buffer[0] = ((NTP_VERSION shl 3) or MODE_CLIENT).toByte()
+
+        DatagramSocket().use { socket ->
+            socket.soTimeout = TIMEOUT.inWholeMilliseconds.toInt()
+
+            val originateTime = System.currentTimeMillis()
+            buffer.writeTimestamp(TRANSMIT_TIMESTAMP_INDEX, originateTime)
+            val request = buffer.copyOfRange(TRANSMIT_TIMESTAMP_INDEX, PACKET_SIZE)
+            socket.send(DatagramPacket(buffer, buffer.size, address, NTP_PORT))
+
+            val response = DatagramPacket(buffer, buffer.size)
+            socket.receive(response)
+            val destinationTime = System.currentTimeMillis()
+
+            if (response.length < PACKET_SIZE) throw IOException("NTP response is too short (${response.length} bytes)")
+            val mode = buffer[0].toInt() and 0x7
+            if (mode != MODE_SERVER) throw IOException("NTP response has unexpected mode $mode")
+            val stratum = buffer[1].toInt() and 0xFF
+            if (stratum == 0) throw KissOfDeathException(buffer.readKissCode())
+            val originate = buffer.copyOfRange(ORIGINATE_TIMESTAMP_INDEX, RECEIVE_TIMESTAMP_INDEX)
+            if (!originate.contentEquals(request)) throw IOException("NTP response does not match the request")
+
+            val receiveTime = buffer.readTimestamp(RECEIVE_TIMESTAMP_INDEX)
+            val transmitTime = buffer.readTimestamp(TRANSMIT_TIMESTAMP_INDEX)
+            return (((receiveTime - originateTime) + (transmitTime - destinationTime)) / 2).milliseconds
+        }
+    }
+
+    private fun ByteArray.readKissCode(): String =
+        String(this, REFERENCE_IDENTIFIER_INDEX, KISS_CODE_LENGTH, Charsets.US_ASCII)
+            .filter { it.isLetterOrDigit() }
+            .ifEmpty { "unknown" }
+
+    private fun ByteArray.writeTimestamp(index: Int, millis: Long) {
+        val seconds = millis / 1000 + EPOCH_OFFSET_SECONDS
+        val fraction = (millis % 1000) * (1L shl 32) / 1000
+        for (i in 0 until 4) {
+            this[index + i] = (seconds shr (24 - i * 8)).toByte()
+            this[index + 4 + i] = (fraction shr (24 - i * 8)).toByte()
+        }
+    }
+
+    private fun ByteArray.readTimestamp(index: Int): Long {
+        var seconds = 0L
+        var fraction = 0L
+        for (i in 0 until 4) {
+            seconds = (seconds shl 8) or (this[index + i].toLong() and 0xFF)
+            fraction = (fraction shl 8) or (this[index + 4 + i].toLong() and 0xFF)
+        }
+        return (seconds - EPOCH_OFFSET_SECONDS) * 1000 + fraction * 1000 / (1L shl 32)
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/utils/SntpClient.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SntpClient.kt
@@ -35,6 +35,7 @@ object SntpClient {
      * @throws java.net.SocketTimeoutException if the server does not respond in time
      * @throws IOException if the response is not a valid NTP server reply
      */
+    @Suppress("ThrowsCount")
     fun getOffset(server: String): Duration {
         val address = InetAddress.getByName(server)
         val buffer = ByteArray(PACKET_SIZE)

--- a/src/main/java/at/hannibal2/skyhanni/utils/SntpClient.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SntpClient.kt
@@ -1,0 +1,87 @@
+package at.hannibal2.skyhanni.utils
+
+import java.io.IOException
+import java.net.DatagramPacket
+import java.net.DatagramSocket
+import java.net.InetAddress
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Minimal SNTP client (RFC 4330) that queries an NTP server for the offset between its clock and the local one.
+ */
+object SntpClient {
+
+    private const val NTP_PORT = 123
+    private const val PACKET_SIZE = 48
+    private const val NTP_VERSION = 3
+    private const val MODE_CLIENT = 3
+    private const val MODE_SERVER = 4
+
+    /** Seconds between the NTP epoch (1900-01-01) and the unix epoch (1970-01-01). */
+    private const val EPOCH_OFFSET_SECONDS = 2_208_988_800L
+
+    private const val ORIGINATE_TIMESTAMP_INDEX = 24
+    private const val RECEIVE_TIMESTAMP_INDEX = 32
+    private const val TRANSMIT_TIMESTAMP_INDEX = 40
+
+    private val TIMEOUT = 10.seconds
+
+    /**
+     * Queries [server] and returns how far the local clock is behind the server clock.
+     *
+     * @throws java.net.UnknownHostException if [server] can not be resolved
+     * @throws java.net.SocketTimeoutException if the server does not respond in time
+     * @throws IOException if the response is not a valid NTP server reply
+     */
+    fun getOffset(server: String): Duration {
+        val address = InetAddress.getByName(server)
+        val buffer = ByteArray(PACKET_SIZE)
+        buffer[0] = ((NTP_VERSION shl 3) or MODE_CLIENT).toByte()
+
+        DatagramSocket().use { socket ->
+            socket.soTimeout = TIMEOUT.inWholeMilliseconds.toInt()
+
+            val originateTime = System.currentTimeMillis()
+            buffer.writeTimestamp(TRANSMIT_TIMESTAMP_INDEX, originateTime)
+            val request = buffer.copyOfRange(TRANSMIT_TIMESTAMP_INDEX, PACKET_SIZE)
+            socket.send(DatagramPacket(buffer, buffer.size, address, NTP_PORT))
+
+            val response = DatagramPacket(buffer, buffer.size)
+            socket.receive(response)
+            val destinationTime = System.currentTimeMillis()
+
+            if (response.length < PACKET_SIZE) throw IOException("NTP response is too short (${response.length} bytes)")
+            val mode = buffer[0].toInt() and 0x7
+            if (mode != MODE_SERVER) throw IOException("NTP response has unexpected mode $mode")
+            val stratum = buffer[1].toInt() and 0xFF
+            if (stratum == 0) throw IOException("NTP server rejected the request (kiss-of-death)")
+            val originate = buffer.copyOfRange(ORIGINATE_TIMESTAMP_INDEX, RECEIVE_TIMESTAMP_INDEX)
+            if (!originate.contentEquals(request)) throw IOException("NTP response does not match the request")
+
+            val receiveTime = buffer.readTimestamp(RECEIVE_TIMESTAMP_INDEX)
+            val transmitTime = buffer.readTimestamp(TRANSMIT_TIMESTAMP_INDEX)
+            return (((receiveTime - originateTime) + (transmitTime - destinationTime)) / 2).milliseconds
+        }
+    }
+
+    private fun ByteArray.writeTimestamp(index: Int, millis: Long) {
+        val seconds = millis / 1000 + EPOCH_OFFSET_SECONDS
+        val fraction = (millis % 1000) * (1L shl 32) / 1000
+        for (i in 0 until 4) {
+            this[index + i] = (seconds shr (24 - i * 8)).toByte()
+            this[index + 4 + i] = (fraction shr (24 - i * 8)).toByte()
+        }
+    }
+
+    private fun ByteArray.readTimestamp(index: Int): Long {
+        var seconds = 0L
+        var fraction = 0L
+        for (i in 0 until 4) {
+            seconds = (seconds shl 8) or (this[index + i].toLong() and 0xFF)
+            fraction = (fraction shl 8) or (this[index + 4 + i].toLong() and 0xFF)
+        }
+        return (seconds - EPOCH_OFFSET_SECONDS) * 1000 + fraction * 1000 / (1L shl 32)
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/utils/SntpClient.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SntpClient.kt
@@ -22,6 +22,8 @@ object SntpClient {
     /** Seconds between the NTP epoch (1900-01-01) and the unix epoch (1970-01-01). */
     private const val EPOCH_OFFSET_SECONDS = 2_208_988_800L
 
+    private const val REFERENCE_IDENTIFIER_INDEX = 12
+    private const val KISS_CODE_LENGTH = 4
     private const val ORIGINATE_TIMESTAMP_INDEX = 24
     private const val RECEIVE_TIMESTAMP_INDEX = 32
     private const val TRANSMIT_TIMESTAMP_INDEX = 40
@@ -29,10 +31,18 @@ object SntpClient {
     private val TIMEOUT = 10.seconds
 
     /**
+     * Thrown when the server answers with a kiss-of-death packet, asking the client to stop querying or to back off.
+     *
+     * @param code the kiss code sent by the server, e.g. `RATE`, `DENY` or `RSTR`
+     */
+    class KissOfDeathException(val code: String) : IOException("NTP server sent a kiss-of-death ($code)")
+
+    /**
      * Queries [server] and returns how far the local clock is behind the server clock.
      *
      * @throws java.net.UnknownHostException if [server] can not be resolved
      * @throws java.net.SocketTimeoutException if the server does not respond in time
+     * @throws KissOfDeathException if the server asks the client to stop or slow down
      * @throws IOException if the response is not a valid NTP server reply
      */
     @Suppress("ThrowsCount")
@@ -57,7 +67,7 @@ object SntpClient {
             val mode = buffer[0].toInt() and 0x7
             if (mode != MODE_SERVER) throw IOException("NTP response has unexpected mode $mode")
             val stratum = buffer[1].toInt() and 0xFF
-            if (stratum == 0) throw IOException("NTP server rejected the request (kiss-of-death)")
+            if (stratum == 0) throw KissOfDeathException(buffer.readKissCode())
             val originate = buffer.copyOfRange(ORIGINATE_TIMESTAMP_INDEX, RECEIVE_TIMESTAMP_INDEX)
             if (!originate.contentEquals(request)) throw IOException("NTP response does not match the request")
 
@@ -66,6 +76,11 @@ object SntpClient {
             return (((receiveTime - originateTime) + (transmitTime - destinationTime)) / 2).milliseconds
         }
     }
+
+    private fun ByteArray.readKissCode(): String =
+        String(this, REFERENCE_IDENTIFIER_INDEX, KISS_CODE_LENGTH, Charsets.US_ASCII)
+            .filter { it.isLetterOrDigit() }
+            .ifEmpty { "unknown" }
 
     private fun ByteArray.writeTimestamp(index: Int, millis: Long) {
         val seconds = millis / 1000 + EPOCH_OFFSET_SECONDS


### PR DESCRIPTION
## What
Removes the dependency on Apache Commons Net and replaces it with a self-contained SNTP client.

## Why
Pulling in the entire Commons Net library for a single feature that can be implemented without dependencies in under 100 lines is unnecessary. Dropping it saves nearly 1 MB on the JAR size.

## Changelog Technical Details
+ Dropped the dependency on Apache Commons Net in favor of a self-contained SntpClient implementation. - Luna