### PR TITLE
Fix: Don't resolve ambiguous display names to an arbitrary item

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/enoughupdates/ItemResolutionQuery.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/enoughupdates/ItemResolutionQuery.kt
@@ -42,10 +42,9 @@ import net.minecraft.world.inventory.ChestMenu
 import net.minecraft.world.item.Item
 import net.minecraft.world.item.Items
 
-// Code taken from NotEnoughUpdates
+// Code originally from NotEnoughUpdates
 class ItemResolutionQuery {
-
-    private var compound: DataComponentMap = DataComponentMap.EMPTY
+    private var compound = DataComponentMap.EMPTY
 
     private var itemType: Item? = null
     private var knownInternalName: NeuInternalName? = null
@@ -53,6 +52,7 @@ class ItemResolutionQuery {
 
     @SkyHanniModule
     companion object {
+        private const val MAX_CANDIDATE_INTERNAL_NAMES = 20
 
         private val patternGroup = RepoPattern.group("misc.itemresolution")
 
@@ -76,13 +76,13 @@ class ItemResolutionQuery {
 
         val petRarities = listOf("COMMON", "UNCOMMON", "RARE", "EPIC", "LEGENDARY", "MYTHIC")
 
-        private val BAZAAR_ENCHANTMENT_PATTERN = "ENCHANTMENT_(\\D*)_(\\d+)".toPattern()
+        private val bazaarEnchantmentPattern = "ENCHANTMENT_(\\D*)_(\\d+)".toPattern()
 
         private var renamedEnchantments: Map<String, String> = mapOf()
         private var shardNameOverrides: Map<String, String> = mapOf()
 
         @HandleEvent
-        fun onRepoReload(event: RepositoryReloadEvent) {
+        private fun onRepoReload(event: RepositoryReloadEvent) {
             val data = event.getConstant<ItemsJson>("Items")
             renamedEnchantments = data.renamedEnchantments
             shardNameOverrides = data.shardNameOverrides
@@ -92,14 +92,13 @@ class ItemResolutionQuery {
             ItemUtils.bazaarOverrides[hypixelId]?.let {
                 return it
             }
-            val matcher = BAZAAR_ENCHANTMENT_PATTERN.matcher(hypixelId)
-            if (matcher.matches()) {
-                return matcher.group(1) + ";" + matcher.group(2)
+            bazaarEnchantmentPattern.matchMatcher(hypixelId) {
+                return group(1) + ";" + group(2)
             }
             return hypixelId.replace(":", "-")
         }
 
-        fun findInternalNameByDisplayName(displayName: String, mayBeMangled: Boolean): NeuInternalName? {
+        fun findInternalNameByDisplayName(displayName: String, mayBeMangled: Boolean = false): NeuInternalName? {
             return filterInternalNameCandidates(
                 findInternalNameCandidatesForDisplayName(displayName),
                 displayName,
@@ -121,6 +120,7 @@ class ItemResolutionQuery {
             val cleanDisplayName = itemName.removeColor()
             var bestMatch: NeuInternalName? = null
             var bestMatchLength = -1
+            var bestMatchIsAmbiguous = false
             loop@ for (internalName in candidateInternalNames.map { it.toInternalName() }) {
                 if (NeuItems.isIgnoredDisplayNameItem(internalName)) continue
                 val unCleanItemDisplayName: String = EnoughUpdatesManager.getDisplayName(internalName)
@@ -143,7 +143,27 @@ class ItemResolutionQuery {
                 if (cleanItemDisplayName.length > bestMatchLength) {
                     bestMatchLength = cleanItemDisplayName.length
                     bestMatch = internalName
+                    bestMatchIsAmbiguous = false
+                } else if (cleanItemDisplayName.length == bestMatchLength) {
+                    bestMatchIsAmbiguous = true
                 }
+            }
+            // Many items share a display name, most notably every enchanted book is just called
+            // "Enchanted Book". Picking one of them would depend on the candidate iteration order,
+            // which silently attributes the wrong item to whatever asked for it.
+            if (bestMatchIsAmbiguous) {
+                ErrorManager.logErrorStateWithData(
+                    "Ambiguous item name: \"$displayName\"",
+                    "ItemResolutionQuery got an ambiguous display name",
+                    "candidateInternalNames" to buildString {
+                        append(candidateInternalNames.take(MAX_CANDIDATE_INTERNAL_NAMES).joinToString(", "))
+                        if (candidateInternalNames.size > MAX_CANDIDATE_INTERNAL_NAMES) {
+                            append(", ... (${candidateInternalNames.size - MAX_CANDIDATE_INTERNAL_NAMES} more items)")
+                        }
+                    },
+                    "mayBeMangled" to mayBeMangled,
+                )
+                return null
             }
             return bestMatch
         }
@@ -315,7 +335,7 @@ class ItemResolutionQuery {
             val s = lore[15]
             if (s == "§7Selected Drop") {
                 val displayName = lore[16]
-                return findInternalNameByDisplayName(displayName, false)
+                return findInternalNameByDisplayName(displayName)
             }
         }
 
@@ -344,7 +364,7 @@ class ItemResolutionQuery {
             return resolveEnchantmentByName(displayName)
         }
         if (itemType === Items.PLAYER_HEAD && displayName.contains("Essence")) {
-            findInternalNameByDisplayName(displayName, false)?.let { return it }
+            findInternalNameByDisplayName(displayName)?.let { return it }
         }
 
         return if (displayName.endsWith("Enchanted Book") && guiName.startsWith("Superpairs")) {
@@ -357,7 +377,7 @@ class ItemResolutionQuery {
         } else if (guiName == "Catacombs RNG Meter") {
             resolveItemInCatacombsRngMeter()
         } else if (guiName.startsWith("Choose Pet")) {
-            findInternalNameByDisplayName(displayName, false)
+            findInternalNameByDisplayName(displayName)
         } else if (guiName.endsWith("Experimentation Table RNG")) {
             resolveEnchantmentByName(displayName)
         } else if (AttributeShardsData.attributeMenuInventory.isInside()) {
@@ -377,7 +397,7 @@ class ItemResolutionQuery {
                 }
             }
         } else if (guiName == "Dye Compendium") {
-            findInternalNameByDisplayName(displayName, false)
+            findInternalNameByDisplayName(displayName)
         } else null
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemNameResolver.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemNameResolver.kt
@@ -52,7 +52,7 @@ object ItemNameResolver {
                 val gemstoneQuery = "${
                     resolveGemstoneToStat(split[1])?.hypixelIcon ?: ' '
                 } ${split.joinToString("_").allLettersFirstUppercase()}"
-                ItemResolutionQuery.findInternalNameByDisplayName(gemstoneQuery, true)?.let {
+                ItemResolutionQuery.findInternalNameByDisplayName(gemstoneQuery, mayBeMangled = true)?.let {
                     return itemNameCache.getOrPut(lowercase) { it }
                 }
             }
@@ -61,7 +61,7 @@ object ItemNameResolver {
         val internalName = when (itemName) {
             "SUPERBOOM TNT" -> "SUPERBOOM_TNT".toInternalName()
             else -> {
-                ItemResolutionQuery.findInternalNameByDisplayName(itemName, true)?.let {
+                ItemResolutionQuery.findInternalNameByDisplayName(itemName, mayBeMangled = true)?.let {
                     // This fixes a NEU bug with §9Hay Bale (cosmetic item)
                     if (it == HAY_BALE) HAY_BLOCK else it
                 } ?: return null

--- a/src/test/java/at/hannibal2/skyhanni/test/ItemResolutionQueryTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/ItemResolutionQueryTest.kt
@@ -1,0 +1,88 @@
+package at.hannibal2.skyhanni.test
+
+import at.hannibal2.skyhanni.api.enoughupdates.EnoughUpdatesManager
+import at.hannibal2.skyhanni.api.enoughupdates.ItemResolutionQuery
+import at.hannibal2.skyhanni.data.jsonobjects.repo.neu.NeuItemJson
+import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
+import at.hannibal2.skyhanni.utils.StringUtils.cleanString
+import io.mockk.MockKMatcherScope
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.TreeMap
+
+class ItemResolutionQueryTest {
+    companion object {
+        /**
+         * Mimics how [EnoughUpdatesManager] fills its item map and title word map while reading the NEU repo.
+         */
+        private fun registerItem(internalName: String, displayName: String) {
+            val name = internalName.toInternalName()
+            EnoughUpdatesManager.getItemInformation()[name] = NeuItemJson(
+                itemId = "minecraft:enchanted_book",
+                displayName = displayName,
+                nbtTagAny = "",
+                internalName = name,
+            )
+            for ((index, part) in displayName.split(" ").withIndex()) {
+                EnoughUpdatesManager.titleWordMap.getOrPut(part.cleanString()) { TreeMap() }
+                    .getOrPut(name.asString()) { mutableListOf() }.add(index)
+            }
+        }
+
+        @JvmStatic
+        @BeforeAll
+        fun registerItems() {
+            // Every enchanted book in the NEU repo shares the same display name
+            registerItem("KARMA;1", "§fEnchanted Book")
+            registerItem("PALEONTOLOGIST;5", "§fEnchanted Book")
+            registerItem("HYPERION", "§dHyperion")
+        }
+    }
+
+    /** All arguments have to be matched explicitly, otherwise the default arguments are matched by value. */
+    private fun MockKMatcherScope.anyErrorState() = ErrorManager.logErrorStateWithData(
+        any(),
+        any(),
+        *anyVararg(),
+        ignoreErrorCache = any(),
+        noStackTrace = any(),
+        betaOnly = any(),
+        condition = any(),
+    )
+
+    @BeforeEach
+    fun setUp() {
+        // Logging an error needs a running Minecraft client
+        mockkObject(ErrorManager)
+        every { anyErrorState() } returns true
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkObject(ErrorManager)
+    }
+
+    @Test
+    fun testAmbiguousDisplayNameIsNotResolved() {
+        assertNull(ItemResolutionQuery.findInternalNameByDisplayName("§fEnchanted Book"))
+        assertNull(ItemResolutionQuery.findInternalNameByDisplayName("§fEnchanted Book", mayBeMangled = true))
+        verify { anyErrorState() }
+    }
+
+    @Test
+    fun testUniqueDisplayNameIsResolved() {
+        assertEquals(
+            "HYPERION".toInternalName(),
+            ItemResolutionQuery.findInternalNameByDisplayName("§dHyperion"),
+        )
+    }
+}


### PR DESCRIPTION
## What
Fixes item resolution returning an arbitrary item when given an ambiguous display name – such as the infamous "every enchanted book is Paleontologist V".

We'll have to test to make sure failing loudly won't spam users' chat, but I'd say ideally we keep loud failure and just silence known cases that don't need any more reports via SkyHanni-REPO.

## Changelog Fixes
+ Fixed SkyHanni arbitrarily picking an item when given an ambiguous name (e.g. Paleontologist V for enchanted books). - Luna