### PR TITLE
Fix: Skymart shop page detection

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/SkyMartCopperPrice.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/SkyMartCopperPrice.kt
@@ -48,7 +48,7 @@ object SkyMartCopperPrice {
     @HandleEvent
     fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
         if (!isEnabled()) return
-        if (!event.inventoryName.startsWith("SkyMart ")) return
+        if (!event.inventoryName.matches(Regex("(\\(\\d+/\\d+\\) )?SkyMart .*"))) return
 
         DelayedRun.runOrNextTick {
             inInventory = true


### PR DESCRIPTION
Improved store name detection to inlude store numbers so feature copper to coins would work again on farming essentials pages.

<img width="345" height="29" alt="image" src="https://github.com/user-attachments/assets/347c6146-c32e-4a2d-998a-e22616f1a3e9" />
