### PR TITLE
Backend: Remove tweakClass arguments

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,8 +62,6 @@ loom.apply {
                 property("devauth.configDir", rootProject.file(".devauth").absolutePath)
             }
             vmArgs("-Xmx4G", "-Dnarrator.none=true")
-            programArgs("--tweakClass", "at.hannibal2.skyhanni.tweaker.SkyHanniTweaker")
-            programArgs("--tweakClass", "io.github.notenoughupdates.moulconfig.tweaker.DevelopmentResourceTweaker")
         }
         removeIf { it.name == "server" }
     }


### PR DESCRIPTION
## What
Removes `--tweakClass` arguments from `runConfig`. These are Forge arguments that are completely ignored by Fabric Loader and therefore are redundant ever since we dropped 1.8.9 support.

## Changelog Technical Details
+ Removed redundant tweakClass arguments left over from the Forge era from the development run configuration. - Luna
