### PR TITLE
Fix: Don't fetch weight profile if leaderboard features are disabled

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/leaderboards/EliteFarmersLeaderboardsConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/leaderboards/EliteFarmersLeaderboardsConfig.kt
@@ -17,7 +17,7 @@ class EliteFarmersLeaderboardsConfig {
     @ConfigOption(name = "Enabled", desc = "Enable leaderboard features.")
     @ConfigEditorBoolean
     @FeatureToggle
-    var enabled: Boolean = true
+    val enabled: Property<Boolean> = Property.of(true)
 
     @Expose
     @ConfigOption(

--- a/src/main/java/at/hannibal2/skyhanni/data/garden/FarmingWeightData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/garden/FarmingWeightData.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.data.garden
 
 import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.SkyHanniMod.launch
 import at.hannibal2.skyhanni.api.EliteDevApi
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigManager
@@ -58,6 +59,8 @@ object FarmingWeightData {
     private var hasFetchedCropWeights = false
     private var shouldRecalculateWeight = false
 
+    private val cropWeightsCoroutine = CoroutineSettings("get crop weights")
+
     @HandleEvent(onlyOnIsland = GARDEN)
     private fun onConfigLoad() {
         config.enabled.onEnable {
@@ -95,7 +98,7 @@ object FarmingWeightData {
         if (!isEnabled()) return
         if (!event.isMod(5)) return
 
-        SkyHanniMod.launchIOCoroutine("get crop weights") {
+        cropWeightsCoroutine.launch {
             getCropWeights()
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/data/garden/FarmingWeightData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/garden/FarmingWeightData.kt
@@ -65,6 +65,8 @@ object FarmingWeightData {
     @HandleEvent
     private fun onConfigLoad() {
         config.enabled.onEnable {
+            // This is intentionally checked inside onEnable, using onlyOnIsland would be wrong here.
+            @Suppress("IsInIslandEarlyReturn")
             if (!IslandType.GARDEN.isInIsland()) return@onEnable
             ChatUtils.debug("Updating EliteSkyBlock collections because leaderboard features were toggled on")
             updateCollections()

--- a/src/main/java/at/hannibal2/skyhanni/data/garden/FarmingWeightData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/garden/FarmingWeightData.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.config.ConfigManager
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierArguments
 import at.hannibal2.skyhanni.data.HypixelData
+import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.garden.CropCollectionApi.getCollection
 import at.hannibal2.skyhanni.data.garden.CropCollectionApi.lastGainedCrop
 import at.hannibal2.skyhanni.data.garden.CropCollectionApi.setCollectionCounter
@@ -61,9 +62,10 @@ object FarmingWeightData {
 
     private val cropWeightsCoroutine = CoroutineSettings("get crop weights")
 
-    @HandleEvent(onlyOnIsland = GARDEN)
+    @HandleEvent
     private fun onConfigLoad() {
         config.enabled.onEnable {
+            if (!IslandType.GARDEN.isInIsland()) return@onEnable
             ChatUtils.debug("Updating EliteSkyBlock collections because leaderboard features were toggled on")
             updateCollections()
         }

--- a/src/main/java/at/hannibal2/skyhanni/data/garden/FarmingWeightData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/garden/FarmingWeightData.kt
@@ -4,11 +4,9 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.EliteDevApi
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigManager
-import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierArguments
 import at.hannibal2.skyhanni.data.HypixelData
-import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.garden.CropCollectionApi.getCollection
 import at.hannibal2.skyhanni.data.garden.CropCollectionApi.lastGainedCrop
 import at.hannibal2.skyhanni.data.garden.CropCollectionApi.setCollectionCounter
@@ -16,15 +14,14 @@ import at.hannibal2.skyhanni.data.garden.EliteFarmersLeaderboard.getLeaderboardP
 import at.hannibal2.skyhanni.data.jsonobjects.elitedev.EliteLeaderboardMode
 import at.hannibal2.skyhanni.data.jsonobjects.elitedev.EliteLeaderboardType
 import at.hannibal2.skyhanni.data.jsonobjects.elitedev.EliteWeightsJson
-import at.hannibal2.skyhanni.data.jsonobjects.elitedev.FarmingWeight
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
-import at.hannibal2.skyhanni.events.IslandChangeEvent
+import at.hannibal2.skyhanni.events.IslandJoinEvent
 import at.hannibal2.skyhanni.events.garden.farming.CropCollectionAddEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
-import at.hannibal2.skyhanni.features.garden.CropCollectionType
 import at.hannibal2.skyhanni.features.garden.CropType
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.EnumUtils.isAnyOf
 import at.hannibal2.skyhanni.utils.OSUtils
 import at.hannibal2.skyhanni.utils.PlayerUtils
@@ -42,6 +39,8 @@ import kotlinx.coroutines.sync.withLock
 
 @SkyHanniModule
 object FarmingWeightData {
+    private val config get() = SkyHanniMod.feature.garden.eliteFarmersLeaderboards
+
     var apiError = false
     var profileId: String = ""
 
@@ -60,20 +59,25 @@ object FarmingWeightData {
     private var shouldRecalculateWeight = false
 
     @HandleEvent
-    fun onIslandChange(event: IslandChangeEvent) {
-        if (event.newIsland != IslandType.GARDEN) return
-        updateCollections()
+    private fun onConfigLoad() {
+        ConditionalUtils.onToggle(config.enabled) {
+            if (!isEnabled()) return@onToggle
+            ChatUtils.debug("Updating EliteSkyBlock collections because leaderboard features were toggled on")
+            updateCollections()
+        }
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
-    fun onProfileJoin() {
+    @HandleEvent(onlyOnIsland = GARDEN)
+    private fun onIslandJoin(event: IslandJoinEvent) {
+        if (!isEnabled()) return
+        ChatUtils.debug("Updating EliteSkyBlock collections on Garden join")
         updateCollections()
     }
 
     @HandleEvent
-    fun onCollectionUpdate(event: CropCollectionAddEvent) {
-        if (event.cropCollectionType == CropCollectionType.MOOSHROOM_COW) {
-            if (lastGainedCrop?.isAnyOf(CropType.CACTUS, CropType.SUGAR_CANE) == true) {
+    private fun onCollectionUpdate(event: CropCollectionAddEvent) {
+        if (event.cropCollectionType == MOOSHROOM_COW) {
+            if (lastGainedCrop?.isAnyOf(CACTUS, SUGAR_CANE) == true) {
                 addWeight(event.amount / (event.crop.getFactor() * 2))
                 return
             }
@@ -83,7 +87,7 @@ object FarmingWeightData {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onTick(event: SkyHanniTickEvent) {
+    private fun onTick(event: SkyHanniTickEvent) {
         if (!event.isMod(5)) return
 
         SkyHanniMod.launchIOCoroutine("get crop weights") {
@@ -99,10 +103,10 @@ object FarmingWeightData {
     fun getWeight(leaderboardMode: EliteLeaderboardMode, override: Boolean = false, cropWeightOnly: Boolean = false): Double? {
         if (weightMap[leaderboardMode] == null || override) {
             when (leaderboardMode) {
-                EliteLeaderboardMode.ALL_TIME -> {}
+                ALL_TIME -> {}
 
-                EliteLeaderboardMode.MONTHLY ->
-                    getLeaderboardPosition(EliteLeaderboardType.Weight(FarmingWeight.FARMING_WEIGHT, leaderboardMode))
+                MONTHLY ->
+                    getLeaderboardPosition(EliteLeaderboardType.Weight(FARMING_WEIGHT, leaderboardMode))
             }
         }
         if (shouldRecalculateWeight) {
@@ -184,7 +188,7 @@ object FarmingWeightData {
             totalWeight += weight
         }
         if (totalWeight > 0) {
-            weightPerCrop[CropType.MUSHROOM] = specialMushroomWeight(weightPerCrop, totalWeight)
+            weightPerCrop[MUSHROOM] = specialMushroomWeight(weightPerCrop, totalWeight)
         }
         totalWeight = weightPerCrop.values.sum()
         weightGain = 0.0
@@ -193,8 +197,8 @@ object FarmingWeightData {
     }
 
     private fun specialMushroomWeight(weightPerCrop: MutableMap<CropType, Double>, totalWeight: Double): Double {
-        val cactusWeight = weightPerCrop[CropType.CACTUS] ?: -1.0
-        val sugarCaneWeight = weightPerCrop[CropType.SUGAR_CANE] ?: -1.0
+        val cactusWeight = weightPerCrop[CACTUS] ?: -1.0
+        val sugarCaneWeight = weightPerCrop[SUGAR_CANE] ?: -1.0
         val doubleBreakRatio = (cactusWeight + sugarCaneWeight) / totalWeight
         val normalRatio = (totalWeight - cactusWeight - sugarCaneWeight) / totalWeight
 
@@ -260,10 +264,10 @@ object FarmingWeightData {
     }
 
     @HandleEvent
-    fun onCommandRegistration(event: CommandRegistrationEvent) {
+    private fun onCommandRegistration(event: CommandRegistrationEvent) {
         event.registerBrigadier("shfarmingprofile") {
             description = "Look up the farming profile from yourself or another player on ${EliteDevApi.ELITE_DOMAIN}"
-            category = CommandCategory.USERS_ACTIVE
+            category = USERS_ACTIVE
             argCallback("name", BrigadierArguments.string()) { name ->
                 openWebsite(name, ignoreCooldown = true)
             }
@@ -286,7 +290,7 @@ object FarmingWeightData {
     }
 
     @HandleEvent
-    fun onDebugDataCollect(event: DebugDataCollectEvent) {
+    private fun onDebugDataCollect(event: DebugDataCollectEvent) {
         event.title("farming weight")
         event.addIrrelevant {
             CropType.entries.forEach {
@@ -294,4 +298,6 @@ object FarmingWeightData {
             }
         }
     }
+
+    private fun isEnabled() = config.enabled.get()
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/garden/FarmingWeightData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/garden/FarmingWeightData.kt
@@ -99,6 +99,7 @@ object FarmingWeightData {
     private fun onTick(event: SkyHanniTickEvent) {
         if (!isEnabled()) return
         if (!event.isMod(5)) return
+        if (attemptingCropWeightFetch || hasFetchedCropWeights) return
 
         cropWeightsCoroutine.launch {
             getCropWeights()
@@ -261,7 +262,6 @@ object FarmingWeightData {
     )
 
     private suspend fun getCropWeights() {
-        if (attemptingCropWeightFetch || hasFetchedCropWeights) return
         attemptingCropWeightFetch = true
         val apiResponse = ApiUtils.getJsonResponse(weightStatic).assertSuccess() ?: return
         val apiResponseData = apiResponse.data ?: return

--- a/src/main/java/at/hannibal2/skyhanni/data/garden/FarmingWeightData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/garden/FarmingWeightData.kt
@@ -8,7 +8,6 @@ import at.hannibal2.skyhanni.config.ConfigManager
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierArguments
 import at.hannibal2.skyhanni.data.HypixelData
-import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.garden.CropCollectionApi.getCollection
 import at.hannibal2.skyhanni.data.garden.CropCollectionApi.lastGainedCrop
 import at.hannibal2.skyhanni.data.garden.CropCollectionApi.setCollectionCounter
@@ -20,6 +19,7 @@ import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.garden.farming.CropCollectionAddEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.features.garden.CropType
+import at.hannibal2.skyhanni.features.garden.GardenApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ConditionalUtils.onEnable
@@ -67,7 +67,7 @@ object FarmingWeightData {
         config.enabled.onEnable {
             // This is intentionally checked inside onEnable, using onlyOnIsland would be wrong here.
             @Suppress("IsInIslandEarlyReturn")
-            if (!IslandType.GARDEN.isInIsland()) return@onEnable
+            if (!GardenApi.inGarden()) return@onEnable
             ChatUtils.debug("Updating EliteSkyBlock collections because leaderboard features were toggled on")
             updateCollections()
         }

--- a/src/main/java/at/hannibal2/skyhanni/data/garden/FarmingWeightData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/garden/FarmingWeightData.kt
@@ -15,13 +15,12 @@ import at.hannibal2.skyhanni.data.jsonobjects.elitedev.EliteLeaderboardMode
 import at.hannibal2.skyhanni.data.jsonobjects.elitedev.EliteLeaderboardType
 import at.hannibal2.skyhanni.data.jsonobjects.elitedev.EliteWeightsJson
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
-import at.hannibal2.skyhanni.events.IslandJoinEvent
 import at.hannibal2.skyhanni.events.garden.farming.CropCollectionAddEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.features.garden.CropType
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
-import at.hannibal2.skyhanni.utils.ConditionalUtils
+import at.hannibal2.skyhanni.utils.ConditionalUtils.onEnable
 import at.hannibal2.skyhanni.utils.EnumUtils.isAnyOf
 import at.hannibal2.skyhanni.utils.OSUtils
 import at.hannibal2.skyhanni.utils.PlayerUtils
@@ -30,6 +29,7 @@ import at.hannibal2.skyhanni.utils.StringUtils.addSkyHanniUtm
 import at.hannibal2.skyhanni.utils.api.ApiStaticGetPath
 import at.hannibal2.skyhanni.utils.api.ApiUtils
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sumAllValues
+import at.hannibal2.skyhanni.utils.coroutines.CoroutineSettings
 import at.hannibal2.skyhanni.utils.json.fromJson
 import kotlin.math.abs
 import kotlin.time.Duration.Companion.minutes
@@ -58,17 +58,21 @@ object FarmingWeightData {
     private var hasFetchedCropWeights = false
     private var shouldRecalculateWeight = false
 
-    @HandleEvent
+    @HandleEvent(onlyOnIsland = GARDEN)
     private fun onConfigLoad() {
-        ConditionalUtils.onToggle(config.enabled) {
-            if (!isEnabled()) return@onToggle
+        config.enabled.onEnable {
             ChatUtils.debug("Updating EliteSkyBlock collections because leaderboard features were toggled on")
             updateCollections()
         }
     }
 
+    @HandleEvent
+    private fun onProfileJoin() {
+        reset()
+    }
+
     @HandleEvent(onlyOnIsland = GARDEN)
-    private fun onIslandJoin(event: IslandJoinEvent) {
+    private fun onIslandJoin() {
         if (!isEnabled()) return
         ChatUtils.debug("Updating EliteSkyBlock collections on Garden join")
         updateCollections()
@@ -86,8 +90,9 @@ object FarmingWeightData {
         if (weightGain >= 5.0) shouldRecalculateWeight = true // weight desyncs over time due to mushroom weight calc
     }
 
-    @HandleEvent(onlyOnSkyblock = true)
+    @HandleEvent(onlyOnIsland = GARDEN)
     private fun onTick(event: SkyHanniTickEvent) {
+        if (!isEnabled()) return
         if (!event.isMod(5)) return
 
         SkyHanniMod.launchIOCoroutine("get crop weights") {
@@ -110,7 +115,7 @@ object FarmingWeightData {
             }
         }
         if (shouldRecalculateWeight) {
-            weightMap[EliteLeaderboardMode.ALL_TIME] = recalculateTotalWeight()
+            weightMap[ALL_TIME] = recalculateTotalWeight()
         }
         val weight = weightMap[leaderboardMode]
         if (cropWeightOnly) {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/leaderboarddisplays/EliteLeaderboards.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/leaderboarddisplays/EliteLeaderboards.kt
@@ -32,7 +32,7 @@ enum class EliteLeaderboards(
     PEST("Pest Kills", PestDisplay(), EliteLeaderboardType.Pest::class)
     ;
 
-    val isEnabled get() = config.enabled && this in config.display.get()
+    val isEnabled get() = config.enabled.get() && this in config.display.get()
     val position get() = config.displayPositions[ordinal]
     override fun toString() = displayName
 
@@ -56,7 +56,7 @@ enum class EliteLeaderboards(
         @HandleEvent
         fun onGuiRenderTop() {
             if (config.displayPositions.isEmpty()) return
-            if (!config.enabled) return
+            if (!config.enabled.get()) return
             if (InventoryUtils.inAnyInventory()) {
                 InventoryGuiScaleCompat.withOriginalHudScale {
                     renderDisplays()


### PR DESCRIPTION
## What
A user had noticed that SkyHanni was still fetching their profile information from Elite whenever they join the Garden with no way to opt out. This PR disables the automatic weight profile fetch if "Enable leaderboard features" is disabled, and makes it fetch upon enabling it if it wasn't recently fetched.

## Changelog Fixes
+ Fixed some Elite leaderboard requests still being sent with leaderboards disabled. - Luna
