### PR TITLE
Backend: Reduce unnecessary glfwSetWindowOpacity calls

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/SeeThroughWindow.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/SeeThroughWindow.kt
@@ -17,6 +17,7 @@ object SeeThroughWindow {
     private val config get() = SkyHanniMod.feature.garden.seeThroughWindow
 
     private var isActive = false
+    private var opacityChanged = false
 
     @HandleEvent
     fun onConfigLoad(event: ConfigLoadEvent) {
@@ -42,10 +43,19 @@ object SeeThroughWindow {
     private fun setOpacity() {
         val handle = Minecraft.getInstance().window.handle()
         if (!isActive) {
-            GLFW.glfwSetWindowOpacity(handle, 1f)
+            if (opacityChanged) {
+                GLFW.glfwSetWindowOpacity(handle, 1f)
+                opacityChanged = false
+            }
             return
         }
         val alpha = (config.seeThroughFarming.get() / 100f).coerceAtLeast(0.05f).coerceAtMost(1f)
-        GLFW.glfwSetWindowOpacity(handle, alpha)
+        if (alpha != 1f) {
+            GLFW.glfwSetWindowOpacity(handle, alpha)
+            opacityChanged = true
+        } else if (opacityChanged) {
+            GLFW.glfwSetWindowOpacity(handle, 1f)
+            opacityChanged = false
+        }
     }
 }


### PR DESCRIPTION
## What

I was getting these weird errors logged under Linux Wayland:

[Render thread/ERROR]: ########## GL ERROR ##########
[Render thread/ERROR]: @ Render
[Render thread/ERROR]: 65548: Wayland: The platform does not support setting the window opacity

It does not cause a crash or any rendering issue, despite being a GL ERROR, the error comes from the GLFW windowing library and using Wayland windowing backend.

The errors in the logs were however still annoying, so I decided to find the cause.

I traced the root cause back to SkyHanni's SeeThroughWindow feature. The weird thing was that I had that feature disabled. I noticed that the feature always calls setWindowOpacity(handle, 1f) on each world change, even if feature was never enabled to start with in the config.

There is unfortunately no way to fix the error entirely if the feature was actually turned on and being used at a non-100% opacity - that is something GLFW or Wayland protocols need to implement.

However, SkyHanni can reduce it's unnecessary calls to GLFW's JNI functions, which will also improve performance slightly as JNI calls in Java are not entirely free, while avoiding the error on Linux if the feature was disabled, or enabled and set to 100% opacity. It would still error if feature was enabled and opacity from config is set to a value other than 100%, but there is nothing that can be done on SkyHanni's side about that (except disabling the feature on Linux - but I believe the feature can still be used on X11, just not on Wayland - and eventually when 26.3 SDL happens or if GLFW/Wayland implements setting opacity functionality), as said above.

The PR introduces a new "opacityChanged" variable to track state.

When !isActive and !opacityChanged, we no longer call glfwSetWindowOpacity; no errors emitted on Linux and a JNI call is skipped.

The call is also skipped if the feature is turned on and the opacity is set to 100%, and we have not changed the opacity before (handles the edge case where feature is turned on and config opacity was for example 50%, then goes to 100% - we want to update it back to full opacity one last time, so the else if opacityChanged case handles that)

## Changelog Technical Details
+ Reduced window opacity changes from the See Through Window feature, which was causing errors on Linux. - Mustafa