### PR TITLE
Feature: Max enchant level in tooltip

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/EnchantParsingConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/EnchantParsingConfig.kt
@@ -15,7 +15,7 @@ class EnchantParsingConfig {
     @Expose
     @ConfigOption(
         name = "Enable",
-        desc = "Toggle for coloring the enchants. Turn this off if you want to use enchant parsing from other mods."
+        desc = "Toggle for coloring the enchants. Turn this off if you want to use enchant parsing from other mods.",
     )
     @ConfigEditorBoolean
     @FeatureToggle
@@ -80,7 +80,7 @@ class EnchantParsingConfig {
     @Expose
     @ConfigOption(
         name = "Hide Vanilla Enchants",
-        desc = "Hide the regular vanilla enchants usually found in the first 1-2 lines of lore."
+        desc = "Hide the regular vanilla enchants usually found in the first 1-2 lines of lore.",
     )
     @ConfigEditorBoolean
     @FeatureToggle
@@ -89,7 +89,7 @@ class EnchantParsingConfig {
     @Expose
     @ConfigOption(
         name = "Hide Enchant Description",
-        desc = "Hide the enchant description after each enchant if available."
+        desc = "Hide the enchant description after each enchant if available.",
     )
     @ConfigEditorBoolean
     @FeatureToggle
@@ -99,8 +99,17 @@ class EnchantParsingConfig {
     @ConfigOption(
         name = "Stacking Enchant Progress",
         desc = "Shows the stacking enchant progress at the bottom of the lore. " +
-            "§eRequires Enchant Parsing to be enabled."
+            "§eRequires Enchant Parsing to be enabled.",
     )
     @ConfigEditorBoolean
     var stackingEnchantProgress: Boolean = true
+
+    @Expose
+    @ConfigOption(
+        name = "Show max enchant level",
+        desc = "Shows the maximum enchant level for an enchant beside the enchantment level. " +
+            "\n§8Example: §9Efficiency 5 §8/ 10",
+    )
+    @ConfigEditorBoolean
+    var showMaxEnchantLevel: Boolean = false
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/EnchantParsingConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/EnchantParsingConfig.kt
@@ -107,8 +107,7 @@ class EnchantParsingConfig {
     @Expose
     @ConfigOption(
         name = "Show max enchant level",
-        desc = "Shows the maximum enchant level for an enchant beside the enchantment level. " +
-            "\n§8Example: §9Efficiency 5 §8/ 10",
+        desc = "Shows the maximum enchant level for an enchant beside the enchantment level. ",
     )
     @ConfigEditorBoolean
     var showMaxEnchantLevel: Boolean = false

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/EnchantParsingConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/EnchantParsingConfig.kt
@@ -107,8 +107,9 @@ class EnchantParsingConfig {
     @Expose
     @ConfigOption(
         name = "Show max enchant level",
-        desc = "Shows the maximum enchant level for an enchant beside the enchantment level. ",
+        desc = "",
     )
-    @ConfigEditorBoolean
-    var showMaxEnchantLevel: Boolean = false
+    @Accordion
+    val showMaxEnchantLevel: ShowMaxEnchants = ShowMaxEnchants()
+
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/ShowMaxEnchants.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/ShowMaxEnchants.kt
@@ -1,0 +1,33 @@
+package at.hannibal2.skyhanni.config.features.inventory
+
+import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorKeybind
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+import org.lwjgl.glfw.GLFW
+
+
+class ShowMaxEnchants {
+    @Expose
+    @ConfigOption(
+        name = "Show max enchant level",
+        desc = "Shows the maximum enchant level for an enchant beside the enchantment level. ",
+    )
+    @ConfigEditorBoolean
+    var enabled: Boolean = false
+
+    @Expose
+    @ConfigOption(
+        name = "Only show on keybind",
+        desc = "Only shows the maximum enchant level when you hold the keybind.\n" +
+            "Unbind to show persistently.",
+    )
+    @ConfigEditorKeybind(defaultKey = GLFW.GLFW_KEY_LEFT_SHIFT)
+    var keybind: Int = GLFW.GLFW_KEY_LEFT_SHIFT
+
+    @Expose
+    @ConfigOption(name = "Use good enchant level", desc = "Instead of max enchant level, use good enchant level")
+    @ConfigEditorBoolean
+    var useGoodEnchantLevel: Boolean = false
+
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/Enchant.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/Enchant.kt
@@ -50,7 +50,13 @@ open class Enchant : Comparable<Enchant> {
     val advanced by lazy { config.advancedEnchantColors }
 
     open fun getComponent(level: Int, itemStack: SafeItemStack?, isRoman: Boolean, appendNewline: Boolean = false): Component {
-        val text = "$loreName ${if (isRoman) level.toRoman() else level}${if (appendNewline) "\n" else ""}"
+        val text = buildString {
+            append(loreName)
+            append(" " + if (isRoman) level.toRoman() else level)
+            if (config.showMaxEnchantLevel && level != maxLevel)
+                append(" §8/ ${if (isRoman) maxLevel.toRoman() else maxLevel}")
+            if (appendNewline) append("\n")
+        }
         return Component.literal(text).setStyle(getStyle(level, itemStack))
     }
 
@@ -121,6 +127,7 @@ open class Enchant : Comparable<Enchant> {
                     }.let { if (config.boldPerfectEnchant.get()) it.withBold(true) else it }
                 } else null
             }
+
             else -> null
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/Enchant.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/Enchant.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.utils.ItemCategory
 import at.hannibal2.skyhanni.utils.ItemUtils.extraAttributes
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
+import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
@@ -23,6 +24,7 @@ import net.minecraft.ChatFormatting
 import net.minecraft.network.chat.Component
 import net.minecraft.network.chat.Style
 import net.minecraft.network.chat.TextColor
+import org.lwjgl.glfw.GLFW
 
 private val PROMISING_SHOVEL = "PROMISING_SHOVEL".toInternalName()
 private val STONK_PICKAXE = "STONK_PICKAXE".toInternalName()
@@ -50,11 +52,17 @@ open class Enchant : Comparable<Enchant> {
     val advanced by lazy { config.advancedEnchantColors }
 
     open fun getComponent(level: Int, itemStack: SafeItemStack?, isRoman: Boolean, appendNewline: Boolean = false): Component {
+        val enchantLevelTarget = if (config.showMaxEnchantLevel.useGoodEnchantLevel && goodLevel > 0) goodLevel else maxLevel
+        val canShowMaxLevel = (config.showMaxEnchantLevel.enabled &&
+            (if (config.showMaxEnchantLevel.keybind != GLFW.GLFW_KEY_UNKNOWN)
+                config.showMaxEnchantLevel.keybind.isKeyHeld() else true
+                )
+            && level < enchantLevelTarget)
+
         val text = buildString {
             append(loreName)
             append(" " + if (isRoman) level.toRoman() else level)
-            if (config.showMaxEnchantLevel && level != maxLevel)
-                append(" §8/ ${if (isRoman) maxLevel.toRoman() else maxLevel}")
+            if (canShowMaxLevel) append(" §8/ ${if (isRoman) enchantLevelTarget.toRoman() else enchantLevelTarget}")
             if (appendNewline) append("\n")
         }
         return Component.literal(text).setStyle(getStyle(level, itemStack))

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
@@ -34,6 +34,7 @@ import net.minecraft.network.chat.Component
 import net.minecraft.network.chat.HoverEvent
 import net.minecraft.network.chat.MutableComponent
 import net.minecraft.network.chat.contents.PlainTextContents
+import org.lwjgl.glfw.GLFW
 import java.util.TreeSet
 
 /**
@@ -178,7 +179,7 @@ object EnchantParser {
                     "SkyHanni's enchant parsing breaks with Aaron's Mod's 'Rainbow Max Enchants'",
                     config::colorParsing,
                     "turn off Aaron's Mod's Rainbow Max Enchants",
-                    { removeAaronMaxEnchant() }
+                    { removeAaronMaxEnchant() },
                 )
             }
             if (config.hideEnchantDescriptions.get()) {
@@ -186,7 +187,7 @@ object EnchantParser {
                     "SkyHanni's hide enchant descriptions breaks with Aaron's Mod's 'Rainbow Max Enchants'",
                     config::hideEnchantDescriptions,
                     "turn off Aaron's Mod's Rainbow Max Enchants",
-                    { removeAaronMaxEnchant() }
+                    { removeAaronMaxEnchant() },
                 )
             }
         }
@@ -207,17 +208,22 @@ object EnchantParser {
         enchants: Map<String, Int>,
         chatComponent: Component?,
     ) {
-        // Check if the lore is already cached so continuous hover isn't 1 fps
-        if (loreCache.isCached(loreList)) {
-            loreList.clear()
-            if (loreCache.cachedLoreAfter.isNotEmpty()) {
-                loreList.addAll(loreCache.cachedLoreAfter)
-            } else {
-                loreList.addAll(loreCache.cachedLoreBefore)
+        // Only do loreCaching checks if showMaxEnchantLevel is not enabled
+        if (!config.showMaxEnchantLevel.enabled &&
+            config.showMaxEnchantLevel.keybind == GLFW.GLFW_KEY_UNKNOWN
+        ) {
+            // Check if the lore is already cached so continuous hover isn't 1 fps
+            if (loreCache.isCached(loreList)) {
+                loreList.clear()
+                if (loreCache.cachedLoreAfter.isNotEmpty()) {
+                    loreList.addAll(loreCache.cachedLoreAfter)
+                } else {
+                    loreList.addAll(loreCache.cachedLoreBefore)
+                }
+                // Need to still set replacement component even if its cached
+                if (chatComponent != null) editChatComponent(chatComponent, loreList)
+                return
             }
-            // Need to still set replacement component even if its cached
-            if (chatComponent != null) editChatComponent(chatComponent, loreList)
-            return
         }
         loreCache.updateBefore(loreList)
 
@@ -430,7 +436,7 @@ object EnchantParser {
             val notLastEnchantOnLine = (i % maxEnchantsPerLine != maxEnchantsPerLine - 1 && orderedEnchant != lastElement)
 
             component = component.append(
-                orderedEnchant.getComponent(currentItem, !notLastEnchantOnLine && fromChatComponent)
+                orderedEnchant.getComponent(currentItem, !notLastEnchantOnLine && fromChatComponent),
             )
 
             if (notLastEnchantOnLine) {
@@ -458,7 +464,7 @@ object EnchantParser {
             val notLastEnchantOnLine = (i % 3 != 2 && orderedEnchant != lastElement)
 
             component = component.append(
-                orderedEnchant.getComponent(currentItem, !notLastEnchantOnLine && fromChatComponent)
+                orderedEnchant.getComponent(currentItem, !notLastEnchantOnLine && fromChatComponent),
             )
 
             if (itemIsBook() && maxEnchantsPerLine == 1) {


### PR DESCRIPTION

## What
This PR adds a feature which shows the maximum enchantment level beside the enchantment level if the enchantment level is not the maximum enchantment level, its something which acts as a helper to the good/max enchantment color feature since the colors dont quite show how many levels behide you are from the maximum. 

Since fractions in the enchantment section would feel a little cloggy in compressed display, I've changed the maximum enchant number to show up grayed out so it highlights the enchantment level more than the max, which also looks decent in other views

<details>
<summary>Images</summary>

<img width="891" height="709" alt="image" src="https://github.com/user-attachments/assets/2660b5f5-3e0b-4749-aa1c-896ca726eece" />

<img width="562" height="924" alt="image" src="https://github.com/user-attachments/assets/1f8bbd99-698e-4d1a-8877-b7f629bc82c5" />

</details>

## Changelog New Features
+ Added maximum enchant level display in tooltip - Deprecatism