### PR TITLE
Backend: No double mutability for collections

### DIFF
--- a/detekt/baseline-main.xml
+++ b/detekt/baseline-main.xml
@@ -43,7 +43,6 @@
     <ID>Kdoc:CustomScoreboard.kt:/** * TODO LIST * - countdown events like fishing festival + fiesta when its not on tablist * - choose the amount of decimal places in shorten nums * - heavily optimize elements and events by only updating them when absolutely needed */</ID>
     <ID>Kdoc:ForagingTracker.kt:ForagingTracker$/** * this is a failsafe in the event of runes lacking sufficient NEU repo data to automagically * fetch their correct internal names, and thus translating their in-game names into internal * names literally */</ID>
     <ID>Kdoc:FossilExcavatorApi.kt:FossilExcavatorApi$/** * TODO fix the bug that readItemAmount produces two different outputs: * §r§fEnchanted Book -&gt; §fEnchanted * §fEnchanted Book §r§8x -&gt; §fEnchanted Book * * also maybe this is no bug, as enchanted book is no real item? */</ID>
-    <ID>Kdoc:RenderEntityOutlineEvent.kt:RenderEntityOutlineEvent$/** * Constructs the event, given the type and optional entities to outline. * * * This will modify {@param potentialEntities} internally, so make a copy before passing it if necessary. * * @param theType of the event (see [Type] */</ID>
     <ID>Kdoc:Renderable.kt:Renderable.Companion$/** Bottom Layer must be bigger then the top layer */</ID>
     <ID>Kdoc:RepoPatternGui.kt:RepoPatternGui.Companion$/** * Open the [RepoPatternGui] */</ID>
     <ID>Kdoc:ScoreboardPattern.kt:ScoreboardPattern$/** * Sometimes when the scoreboard updates, it only updates half way, * causing some lines to become mixed with other lines -&gt; broken. * This should already get handled fine but sometimes these errors still occur with some lines way too often. * This pattern is to catch those lines. */</ID>
@@ -3434,7 +3433,6 @@
     <ID>StatementWrapping:KuudraTier.kt:KuudraTier${ this.intTierNumber = tierNumber }</ID>
     <ID>StatementWrapping:PetData.kt:PetData${ specifiedRarity.oneAbove() ?: specifiedRarity }</ID>
     <ID>StatementWrapping:SkyHanniRealtimeItemSlot.kt:SkyHanniRealtimeItemSlot${ allocate(slotSize) }</ID>
-    <ID>StorageVarOrVal:ChatSoundResponseConfig.kt:ChatSoundResponseConfig$@Expose @ConfigOption(name = "Sound Responses", desc = "Add animal sounds to play when certain words are said in chat.") @ConfigEditorDraggableList var soundResponses = SoundResponseTypes.entries.toMutableList()</ID>
     <ID>StorageVarOrVal:GuiConfig.kt:GuiConfig$@Expose @ConfigOption(name = "Mayor Overlay", desc = "Settings for the mayor overlay.") @Accordion var mayorOverlay = MayorOverlayConfig()</ID>
     <ID>StorageVarOrVal:SpiritLeapConfig.kt:SpiritLeapConfig$@Expose @ConfigOption( name = "Spirit Leap Colors", desc = "Configure colors for each class and dead teammates.", ) @Accordion var colorConfig = SpiritLeapColorConfig()</ID>
     <ID>StorageVarOrVal:SpiritLeapConfig.kt:SpiritLeapConfig$@Expose @ConfigOption( name = "Spirit Leap Keybinds", desc = "Set keybinds and show keybind hints for Spirit Leap." ) @Accordion var spiritLeapKeybindConfig = SpiritLeapKeybindConfig()</ID>

--- a/detekt/detekt.yml
+++ b/detekt/detekt.yml
@@ -185,8 +185,8 @@ naming:
         active: false
 
 potential-bugs:
-    DoubleMutabilityForCollection: # went crazy about all the mutable collections
-        active: false
+    DoubleMutabilityForCollection:
+        active: true
     HasPlatformType: # false positives on config get() methods
         active: false
     StorageNeedsExpose:

--- a/src/main/java/at/hannibal2/skyhanni/api/SkillApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/SkillApi.kt
@@ -150,8 +150,8 @@ object SkillApi {
     )
 
     val skillMenuDetector = InventoryDetector { skillMenuNamePattern }
-    var skillXPInfoMap = mutableMapOf<SkillType, SkillXPInfo>()
-    var oldSkillInfoMap = mutableMapOf<SkillType?, SkillInfo?>()
+    val skillXPInfoMap = mutableMapOf<SkillType, SkillXPInfo>()
+    val oldSkillInfoMap = mutableMapOf<SkillType?, SkillInfo?>()
     private val skillStorage get() = ProfileStorageData.profileSpecific?.skills
     val storage get() = skillStorage?.skillData
     var exactLevelingMap = mapOf<Int, Int>()

--- a/src/main/java/at/hannibal2/skyhanni/api/event/SkyHanniEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/event/SkyHanniEvents.kt
@@ -224,7 +224,7 @@ object SkyHanniEvents {
 
         var invokeCount: Long = 0L
 
-        var overTimeLog = mutableMapOf<Int, EventInvokeData>()
+        val overTimeLog = mutableMapOf<Int, EventInvokeData>()
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/config/SackData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/SackData.kt
@@ -7,11 +7,11 @@ import java.util.UUID
 
 class SackData {
     @Expose
-    var players: MutableMap<UUID, PlayerSpecific> = mutableMapOf()
+    val players: MutableMap<UUID, PlayerSpecific> = mutableMapOf()
 
     class PlayerSpecific {
         @Expose
-        var profiles: MutableMap<String, ProfileSpecific> = mutableMapOf()
+        val profiles: MutableMap<String, ProfileSpecific> = mutableMapOf()
     }
 
     class ProfileSpecific {

--- a/src/main/java/at/hannibal2/skyhanni/config/StorageData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/StorageData.kt
@@ -8,11 +8,11 @@ import java.util.UUID
 
 class StorageData {
     @Expose
-    var players: MutableMap<UUID, PlayerSpecific> = mutableMapOf()
+    val players: MutableMap<UUID, PlayerSpecific> = mutableMapOf()
 
     class PlayerSpecific {
         @Expose
-        var profiles: MutableMap<String, ProfileSpecific> = mutableMapOf()
+        val profiles: MutableMap<String, ProfileSpecific> = mutableMapOf()
     }
 
     class ProfileSpecific {

--- a/src/main/java/at/hannibal2/skyhanni/config/UpdateKeybinds.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/UpdateKeybinds.kt
@@ -13,8 +13,7 @@ import at.hannibal2.skyhanni.utils.system.PlatformUtils
 
 @SkyHanniModule
 object UpdateKeybinds {
-
-    var keybinds: MutableSet<String> = mutableSetOf()
+    val keybinds: MutableSet<String> = mutableSetOf()
 
     private val logger = SkyHanniLogger("keybind_upgrader")
 

--- a/src/main/java/at/hannibal2/skyhanni/config/features/chat/ChatSoundResponseConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/chat/ChatSoundResponseConfig.kt
@@ -20,5 +20,5 @@ class ChatSoundResponseConfig {
     @Expose
     @ConfigOption(name = "Sound Responses", desc = "Add animal sounds to play when certain words are said in chat.")
     @ConfigEditorDraggableList
-    var soundResponses = SoundResponseTypes.entries.toMutableList()
+    val soundResponses = SoundResponseTypes.entries.toMutableList()
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/CustomTodosStorage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/CustomTodosStorage.kt
@@ -5,5 +5,5 @@ import com.google.gson.annotations.Expose
 
 class CustomTodosStorage {
     @Expose
-    var customTodos: MutableList<CustomTodo> = ArrayList()
+    val customTodos: MutableList<CustomTodo> = ArrayList()
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/OrderedWaypointsRoutes.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/OrderedWaypointsRoutes.kt
@@ -6,5 +6,5 @@ import com.google.gson.annotations.Expose
 
 class OrderedWaypointsRoutes {
     @Expose
-    var routes: MutableMap<String, Waypoints<SkyHanniWaypoint>>? = null
+    val routes: MutableMap<String, Waypoints<SkyHanniWaypoint>> = mutableMapOf()
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/PlayerSpecificStorage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/PlayerSpecificStorage.kt
@@ -16,7 +16,7 @@ import kotlin.time.Duration
 
 class PlayerSpecificStorage {
     @Expose
-    var profiles: MutableMap<String, ProfileSpecificStorage> = mutableMapOf() // profile name
+    val profiles: MutableMap<String, ProfileSpecificStorage> = mutableMapOf() // profile name
 
     @Expose
     var multipleProfiles: Boolean = false
@@ -40,11 +40,11 @@ class PlayerSpecificStorage {
     var communityShopAccountUpgrade: CommunityShopUpgrade? = null
 
     @Expose
-    var guildMembers: MutableList<String> = mutableListOf()
+    val guildMembers: MutableList<String> = mutableListOf()
 
     /** Written and read by [at.hannibal2.skyhanni.data.CurrencyApi], for currencies shared by all profiles. */
     @Expose
-    var currencies: MutableMap<SkyblockCurrency, Long> = enumMapOf()
+    val currencies: MutableMap<SkyblockCurrency, Long> = enumMapOf()
 
     @Expose
     var bazaar: BazaarStorage = BazaarStorage()
@@ -65,7 +65,7 @@ class PlayerSpecificStorage {
 
     class WinterStorage {
         @Expose
-        var playersThatHaveBeenGifted: MutableSet<String> = mutableSetOf()
+        val playersThatHaveBeenGifted: MutableSet<String> = mutableSetOf()
 
         @Expose
         var amountGifted: Int = 0
@@ -75,14 +75,14 @@ class PlayerSpecificStorage {
     }
 
     @Expose
-    var bingoSessions: MutableMap<Long, BingoSession> = mutableMapOf()
+    val bingoSessions: MutableMap<Long, BingoSession> = mutableMapOf()
 
     class BingoSession {
         @Expose
-        var tierOneMinionsDone: MutableSet<NeuInternalName> = mutableSetOf()
+        val tierOneMinionsDone: MutableSet<NeuInternalName> = mutableSetOf()
 
         @Expose
-        var goals: MutableMap<Int, BingoGoal> = mutableMapOf()
+        val goals: MutableMap<Int, BingoGoal> = mutableMapOf()
     }
 
     @Expose
@@ -105,5 +105,5 @@ class PlayerSpecificStorage {
     }
 
     @Expose
-    var slayerPersonalBests: MutableMap<BossType, Duration> = mutableMapOf()
+    val slayerPersonalBests: MutableMap<BossType, Duration> = mutableMapOf()
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.kt
@@ -94,7 +94,7 @@ class ProfileSpecificStorage(
 
     class SkillStorage {
         @Expose
-        var skillData: MutableMap<SkillType, SkillApi.SkillInfo> = enumMapOf()
+        val skillData: MutableMap<SkillType, SkillApi.SkillInfo> = enumMapOf()
 
         @Expose
         var giftTalismanSkillXpBonus: Double = 0.0
@@ -108,11 +108,11 @@ class ProfileSpecificStorage(
 
     /** Written and read by [at.hannibal2.skyhanni.data.CurrencyApi]. */
     @Expose
-    var currencies: MutableMap<SkyblockCurrency, Long> = enumMapOf()
+    val currencies: MutableMap<SkyblockCurrency, Long> = enumMapOf()
 
     /** Written and read by [at.hannibal2.skyhanni.data.CurrencyApi]. */
     @Expose
-    var essences: MutableMap<NeuInternalName, Long> = mutableMapOf()
+    val essences: MutableMap<NeuInternalName, Long> = mutableMapOf()
 
     // features
     // - combat
@@ -131,7 +131,7 @@ class ProfileSpecificStorage(
     }
 
     @Expose
-    var instanceChestFavoriteItems: MutableList<NeuInternalName> = mutableListOf()
+    val instanceChestFavoriteItems: MutableList<NeuInternalName> = mutableListOf()
 
     // - commands
     @Expose
@@ -151,10 +151,10 @@ class ProfileSpecificStorage(
 
     class DungeonStorage {
         @Expose
-        var bosses: MutableMap<DungeonFloor, Int> = enumMapOf()
+        val bosses: MutableMap<DungeonFloor, Int> = enumMapOf()
 
         @Expose
-        var runs: MutableList<DungeonRunInfo> = generateMaxChestAsList()
+        val runs: MutableList<DungeonRunInfo> = generateMaxChestAsList()
 
         class DungeonRunInfo {
             constructor()
@@ -195,11 +195,11 @@ class ProfileSpecificStorage(
         var carnivalYear: Int = 0
 
         @Expose
-        var goals: MutableMap<CarnivalGoal, Boolean> = enumMapOf()
+        val goals: MutableMap<CarnivalGoal, Boolean> = enumMapOf()
 
         // - shop name -> (item name, tier)
         @Expose
-        var carnivalShopProgress: MutableMap<String, Map<String, Int>> = mutableMapOf()
+        val carnivalShopProgress: MutableMap<String, Map<String, Int>> = mutableMapOf()
     }
 
     // -- diana
@@ -211,13 +211,13 @@ class ProfileSpecificStorage(
         var profitTracker: DianaProfitTracker.Data = DianaProfitTracker.Data()
 
         @Expose
-        var profitTrackerPerElection: MutableMap<Int, DianaProfitTracker.Data> = mutableMapOf()
+        val profitTrackerPerElection: MutableMap<Int, DianaProfitTracker.Data> = mutableMapOf()
 
         @Expose
         var mythologicalMobTracker: MythologicalCreatureTracker.Data = MythologicalCreatureTracker.Data()
 
         @Expose
-        var mythologicalMobTrackerPerElection: MutableMap<Int, MythologicalCreatureTracker.Data> = mutableMapOf()
+        val mythologicalMobTrackerPerElection: MutableMap<Int, MythologicalCreatureTracker.Data> = mutableMapOf()
     }
 
     // -- winter
@@ -311,20 +311,20 @@ class ProfileSpecificStorage(
         var targetName: String? = null
 
         @Expose
-        var rabbitCounts: MutableMap<String, Int> = mutableMapOf()
+        val rabbitCounts: MutableMap<String, Int> = mutableMapOf()
 
         @Expose
-        var locationRabbitRequirements: MutableMap<String, LocationRabbit> = mutableMapOf()
+        val locationRabbitRequirements: MutableMap<String, LocationRabbit> = mutableMapOf()
 
         @Expose
-        var collectedEggLocations: MutableMap<IslandType, MutableSet<LorenzVec>> = enumMapOf()
+        val collectedEggLocations: MutableMap<IslandType, MutableSet<LorenzVec>> = enumMapOf()
 
         @Expose
-        var residentRabbits: MutableMap<IslandType, MutableMap<String, Boolean?>> = enumMapOf()
+        val residentRabbits: MutableMap<IslandType, MutableMap<String, Boolean?>> = enumMapOf()
 
         class HotspotRabbitStorage(@Expose var skyblockYear: Int?) {
             @Expose
-            var hotspotRabbits: MutableMap<IslandType, MutableMap<String, Boolean?>> = enumMapOf()
+            val hotspotRabbits: MutableMap<IslandType, MutableMap<String, Boolean?>> = enumMapOf()
         }
 
         @Expose
@@ -337,10 +337,10 @@ class ProfileSpecificStorage(
         var strayTracker: CFStrayTracker.Data = CFStrayTracker.Data()
 
         @Expose
-        var mealLastFound: MutableMap<HoppityEggType, SimpleTimeMark> = enumMapOf()
+        val mealLastFound: MutableMap<HoppityEggType, SimpleTimeMark> = enumMapOf()
 
         @Expose
-        var mealNextSpawn: MutableMap<HoppityEggType, SimpleTimeMark> = enumMapOf()
+        val mealNextSpawn: MutableMap<HoppityEggType, SimpleTimeMark> = enumMapOf()
 
         @Expose
         var hotChocolateMixinExpiry = farPast()
@@ -357,7 +357,7 @@ class ProfileSpecificStorage(
     }
 
     @Expose
-    var hoppityEventStats: MutableMap<Int, HoppityEventStats> = mutableMapOf()
+    val hoppityEventStats: MutableMap<Int, HoppityEventStats> = mutableMapOf()
 
     @Expose
     var hoppityStatLiveDisplayToggledOff: Boolean = false
@@ -379,14 +379,14 @@ class ProfileSpecificStorage(
         @Expose var typeCountsSince: RabbitData? = RabbitData(),
     ) {
         @Transient
-        var containingYears: MutableSet<Int> = mutableSetOf()
+        val containingYears: MutableSet<Int> = mutableSetOf()
 
         constructor(year: Int) : this() {
             containingYears.add(year)
         }
 
         constructor(years: Set<Int>) : this() {
-            containingYears = years.toMutableSet()
+            containingYears.addAll(years)
         }
 
         operator fun plusAssign(it: HoppityEventStats) {
@@ -464,28 +464,28 @@ class ProfileSpecificStorage(
         var lastGainedCropCollectionTime: SimpleTimeMark = farPast()
 
         @Expose
-        var cropCollectionCounter: MutableMap<CropType, CropCollectionApi.CropCollection> = enumMapOf()
+        val cropCollectionCounter: MutableMap<CropType, CropCollectionApi.CropCollection> = enumMapOf()
 
         @Expose
-        var cropMilestoneCounter: MutableMap<CropType, Long> = EnumMap(CropType::class.java)
+        val cropMilestoneCounter: MutableMap<CropType, Long> = EnumMap(CropType::class.java)
 
         @Expose
-        var toolCounterData: MutableMap<String, Long> = HashMap()
+        val toolCounterData: MutableMap<String, Long> = HashMap()
 
         @Expose
-        var cropUpgrades: MutableMap<CropType, Int> = enumMapOf()
+        val cropUpgrades: MutableMap<CropType, Int> = enumMapOf()
 
         @Expose
-        var cropsPerSecond: MutableMap<CropType, Int> = enumMapOf()
+        val cropsPerSecond: MutableMap<CropType, Int> = enumMapOf()
 
         @Expose
-        var latestBlocksPerSecond: MutableMap<CropType, Double> = enumMapOf()
+        val latestBlocksPerSecond: MutableMap<CropType, Double> = enumMapOf()
 
         @Expose
-        var latestTrueFarmingFortune: MutableMap<CropType, Double> = enumMapOf()
+        val latestTrueFarmingFortune: MutableMap<CropType, Double> = enumMapOf()
 
         @Expose
-        var personalBestFF: MutableMap<CropType, Double> = enumMapOf()
+        val personalBestFF: MutableMap<CropType, Double> = enumMapOf()
 
         @Expose
         var savedCropAccessory: CropAccessory? = CropAccessory.NONE
@@ -506,10 +506,10 @@ class ProfileSpecificStorage(
         var rareCropTracker: RareCropTracker.Data = RareCropTracker.Data()
 
         @Expose
-        var composterUpgrades: MutableMap<ComposterUpgrade, Int> = enumMapOf()
+        val composterUpgrades: MutableMap<ComposterUpgrade, Int> = enumMapOf()
 
         @Expose
-        var toolWithBountiful: MutableMap<CropType, Boolean> = enumMapOf()
+        val toolWithBountiful: MutableMap<CropType, Boolean> = enumMapOf()
 
         @Expose
         var composterCurrentOrganicMatterItem: NeuInternalName? = NONE
@@ -521,10 +521,10 @@ class ProfileSpecificStorage(
         var uniqueVisitors: Int = 0
 
         @Expose
-        var charmedVisitors: MutableSet<String> = mutableSetOf()
+        val charmedVisitors: MutableSet<String> = mutableSetOf()
 
         @Expose
-        var ignoredVisitors: MutableSet<String> = mutableSetOf()
+        val ignoredVisitors: MutableSet<String> = mutableSetOf()
 
         @Expose
         var visitorDrops: VisitorDrops = VisitorDrops()
@@ -540,7 +540,7 @@ class ProfileSpecificStorage(
             fun getTotalVisitors() = acceptedVisitors + deniedVisitors
 
             @Expose
-            var acceptedRarities: MutableMap<LorenzRarity, Long> = enumMapOf()
+            val acceptedRarities: MutableMap<LorenzRarity, Long> = enumMapOf()
 
             @Expose
             var copper: Int = 0
@@ -564,7 +564,7 @@ class ProfileSpecificStorage(
             var gemstonePowder: Long = 0
 
             @Expose
-            var rewardsCount: MutableMap<VisitorReward, Int> = enumMapOf()
+            val rewardsCount: MutableMap<VisitorReward, Int> = enumMapOf()
         }
 
         @Expose
@@ -572,23 +572,23 @@ class ProfileSpecificStorage(
 
         class PlotIcon {
             @Expose
-            var plotList: MutableMap<Int, NeuInternalName> = mutableMapOf()
+            val plotList: MutableMap<Int, NeuInternalName> = mutableMapOf()
         }
 
         @Expose
-        var plotData: MutableMap<Int, PlotData> = mutableMapOf()
+        val plotData: MutableMap<Int, PlotData> = mutableMapOf()
 
         @Expose
         var scoreboardPests: Int = 0
 
         @Expose
-        var cropStartLocations: MutableMap<CropType, LorenzVec> = enumMapOf()
+        val cropStartLocations: MutableMap<CropType, LorenzVec> = enumMapOf()
 
         @Expose
-        var cropLastFarmedLocations: MutableMap<CropType, LorenzVec> = enumMapOf()
+        val cropLastFarmedLocations: MutableMap<CropType, LorenzVec> = enumMapOf()
 
         @Expose
-        var farmingLanes: MutableMap<CropType, FarmingLane> = enumMapOf()
+        val farmingLanes: MutableMap<CropType, FarmingLane> = enumMapOf()
 
         @Expose
         var fortune: Fortune = Fortune()
@@ -619,7 +619,7 @@ class ProfileSpecificStorage(
             var cakeExpiring: SimpleTimeMark? = null
 
             @Expose
-            var carrolyn: MutableMap<CropType, Boolean> = enumMapOf()
+            val carrolyn: MutableMap<CropType, Boolean> = enumMapOf()
         }
 
         @Expose
@@ -633,10 +633,10 @@ class ProfileSpecificStorage(
 
         class FarmingWeightConfig {
             @Expose
-            var lastLeaderboardPosMap: MutableMap<EliteLeaderboardType, Int> = mutableMapOf()
+            val lastLeaderboardPosMap: MutableMap<EliteLeaderboardType, Int> = mutableMapOf()
 
             @Expose
-            var leaderboardAmountMap: MutableMap<EliteLeaderboardType, Double> = mutableMapOf()
+            val leaderboardAmountMap: MutableMap<EliteLeaderboardType, Double> = mutableMapOf()
 
             @Expose
             var cropDisplayType: CropLeaderboardStorage = CropLeaderboardStorage(null, EliteLeaderboardMode.ALL_TIME)
@@ -649,15 +649,15 @@ class ProfileSpecificStorage(
                 WeightLeaderboardStorage(FarmingWeight.FARMING_WEIGHT, EliteLeaderboardMode.ALL_TIME)
 
             @Expose
-            var minAmountMap: MutableMap<EliteLeaderboardType, Double> = mutableMapOf()
+            val minAmountMap: MutableMap<EliteLeaderboardType, Double> = mutableMapOf()
 
         }
 
         @Expose
-        var npcVisitorLocations: MutableMap<String, LorenzVec> = mutableMapOf()
+        val npcVisitorLocations: MutableMap<String, LorenzVec> = mutableMapOf()
 
         @Expose
-        var customGoalMilestone: MutableMap<CropType, Int> = enumMapOf()
+        val customGoalMilestone: MutableMap<CropType, Int> = enumMapOf()
 
         @Expose
         var pestProfitTracker: PestProfitTracker.BucketData = PestProfitTracker.BucketData()
@@ -669,7 +669,7 @@ class ProfileSpecificStorage(
         var gardenBpsTracker: GardenBpsTracker.TimedData = GardenBpsTracker.TimedData()
 
         @Expose
-        var overflowHoeLevels: MutableMap<String, Int> = mutableMapOf()
+        val overflowHoeLevels: MutableMap<String, Int> = mutableMapOf()
 
         @Expose
         var cropFeverTracker: CropFeverTracker.BucketData = CropFeverTracker.BucketData()
@@ -733,7 +733,7 @@ class ProfileSpecificStorage(
 
     class WardrobeStorage {
         @Expose
-        var data: MutableMap<Int, WardrobeData> = mutableMapOf()
+        val data: MutableMap<Int, WardrobeData> = mutableMapOf()
 
         @Expose
         var currentSlot: Int? = null
@@ -744,7 +744,7 @@ class ProfileSpecificStorage(
 
     class LoadoutStorage {
         @Expose
-        var data: MutableMap<Int, LoadoutData> = mutableMapOf()
+        val data: MutableMap<Int, LoadoutData> = mutableMapOf()
 
         @Expose
         var currentSlot: Int? = null
@@ -755,10 +755,10 @@ class ProfileSpecificStorage(
 
     class EquipmentStorage {
         @Expose
-        var slots: MutableList<SafeItemStack?> = CurrentEquipmentApi.getEmptyEquipment()
+        val slots: MutableList<SafeItemStack?> = CurrentEquipmentApi.getEmptyEquipment()
 
         @Expose
-        var riftSlots: MutableList<SafeItemStack?> = CurrentEquipmentApi.getEmptyEquipment()
+        val riftSlots: MutableList<SafeItemStack?> = CurrentEquipmentApi.getEmptyEquipment()
     }
 
     @Expose
@@ -766,10 +766,10 @@ class ProfileSpecificStorage(
 
     class BazaarOrdersStorage {
         @Expose
-        var buyOrders: MutableMap<NeuInternalName, Int> = mutableMapOf()
+        val buyOrders: MutableMap<NeuInternalName, Int> = mutableMapOf()
 
         @Expose
-        var sellOffers: MutableMap<NeuInternalName, Int> = mutableMapOf()
+        val sellOffers: MutableMap<NeuInternalName, Int> = mutableMapOf()
     }
 
     // - foraging
@@ -811,7 +811,7 @@ class ProfileSpecificStorage(
 
     class MiningStorage {
         @Expose
-        var kingsTalkedTo: MutableList<String> = mutableListOf()
+        val kingsTalkedTo: MutableList<String> = mutableListOf()
 
         @Expose
         var fossilExcavatorProfitTracker: ExcavatorProfitTracker.Data = ExcavatorProfitTracker.Data()
@@ -820,7 +820,7 @@ class ProfileSpecificStorage(
         var hotmTree: HotxTree = HotxTree()
 
         @Expose
-        var powder: MutableMap<PowderType, PowderStorage> = enumMapOf()
+        val powder: MutableMap<PowderType, PowderStorage> = enumMapOf()
 
         @Expose
         var tokens: Int = 0
@@ -839,16 +839,16 @@ class ProfileSpecificStorage(
             var mineshaftTotalCount: Int = 0
 
             @Expose
-            var blocksBroken: MutableList<PityData> = mutableListOf()
+            val blocksBroken: MutableList<PityData> = mutableListOf()
 
             @Expose
             var corpseProfitTracker: CorpseTracker.BucketData = CorpseTracker.BucketData()
 
             @Expose
-            var mineshaftsEnteredSinceNew: MutableMap<MineshaftDetection.MineshaftType, Int> = mutableMapOf()
+            val mineshaftsEnteredSinceNew: MutableMap<MineshaftDetection.MineshaftType, Int> = mutableMapOf()
 
             @Expose
-            var lastMineshaftTimeNew: MutableMap<MineshaftDetection.MineshaftType, SimpleTimeMark> = mutableMapOf()
+            val lastMineshaftTimeNew: MutableMap<MineshaftDetection.MineshaftType, SimpleTimeMark> = mutableMapOf()
         }
 
         @Expose
@@ -866,7 +866,7 @@ class ProfileSpecificStorage(
 
     // - minion
     @Expose
-    var minions: MutableMap<LorenzVec, MinionConfig>? = mutableMapOf()
+    val minions: MutableMap<LorenzVec, MinionConfig>? = mutableMapOf()
 
     class MinionConfig {
         @Expose
@@ -915,7 +915,7 @@ class ProfileSpecificStorage(
     var abiphoneContactAmount: Int? = null
 
     @Expose
-    var enchantedClockBoosts: MutableMap<EnchantedClockHelper.SimpleBoostType, EnchantedClockHelper.Status> = enumMapOf()
+    val enchantedClockBoosts: MutableMap<EnchantedClockHelper.SimpleBoostType, EnchantedClockHelper.Status> = enumMapOf()
 
     @Expose
     var npcDayLimit: NpcDayLimitStorage = NpcDayLimitStorage()
@@ -934,19 +934,19 @@ class ProfileSpecificStorage(
 
     class CrimsonIsleStorage {
         @Expose
-        var quests: MutableList<String> = mutableListOf()
+        val quests: MutableList<String> = mutableListOf()
 
         @Expose
-        var miniBossesDoneToday: MutableList<String> = mutableListOf()
+        val miniBossesDoneToday: MutableList<String> = mutableListOf()
 
         @Expose
-        var kuudraTiersDone: MutableList<String> = mutableListOf()
+        val kuudraTiersDone: MutableList<String> = mutableListOf()
 
         @Expose
-        var trophyFishes: MutableMap<String, MutableMap<TrophyRarity, Int>> = mutableMapOf()
+        val trophyFishes: MutableMap<String, MutableMap<TrophyRarity, Int>> = mutableMapOf()
 
         @Expose
-        var reputation: MutableMap<FactionType, Int> = mutableMapOf()
+        val reputation: MutableMap<FactionType, Int> = mutableMapOf()
     }
 
     // - rift
@@ -955,7 +955,7 @@ class ProfileSpecificStorage(
 
     class RiftStorage {
         @Expose
-        var completedKloonTerminals: MutableList<KloonTerminal> = mutableListOf()
+        val completedKloonTerminals: MutableList<KloonTerminal> = mutableListOf()
 
         @Expose
         var verminTracker: VerminTracker.Data = VerminTracker.Data()
@@ -969,10 +969,10 @@ class ProfileSpecificStorage(
 
     // - slayer
     @Expose
-    var slayerProfitData: MutableMap<String, SlayerProfitTracker.Data> = mutableMapOf()
+    val slayerProfitData: MutableMap<String, SlayerProfitTracker.Data> = mutableMapOf()
 
     @Expose
-    var slayerRngMeter: MutableMap<String, SlayerRngMeterStorage> = mutableMapOf()
+    val slayerRngMeter: MutableMap<String, SlayerRngMeterStorage> = mutableMapOf()
 
     data class SlayerRngMeterStorage(
         @Expose var currentMeter: Long = -1,
@@ -986,7 +986,7 @@ class ProfileSpecificStorage(
     var currentPetUuid: UUID? = null
 
     @Expose
-    var stats: MutableMap<SkyblockStat, Double?> = enumMapOf()
+    val stats: MutableMap<SkyblockStat, Double?> = enumMapOf()
 
     @Expose
     var maxwell: MaxwellPowerStorage = MaxwellPowerStorage()
@@ -1013,7 +1013,7 @@ class ProfileSpecificStorage(
         var currentArrow: String? = null
 
         @Expose
-        var arrowAmount: MutableMap<NeuInternalName, Int> = mutableMapOf()
+        val arrowAmount: MutableMap<NeuInternalName, Int> = mutableMapOf()
     }
 
     @Expose
@@ -1041,10 +1041,10 @@ class ProfileSpecificStorage(
 
     class FairySoulsStorage {
         @Expose
-        var totalFound: MutableMap<IslandType, Int> = mutableMapOf()
+        val totalFound: MutableMap<IslandType, Int> = mutableMapOf()
 
         @Expose
-        var found: MutableMap<IslandType, MutableSet<LorenzVec>> = mutableMapOf()
+        val found: MutableMap<IslandType, MutableSet<LorenzVec>> = mutableMapOf()
     }
 
     @Expose
@@ -1056,7 +1056,7 @@ class ProfileSpecificStorage(
 
         class SpiderRelicsStorage {
             @Expose
-            var found: MutableSet<LorenzVec> = mutableSetOf()
+            val found: MutableSet<LorenzVec> = mutableSetOf()
         }
     }
 
@@ -1069,7 +1069,7 @@ class ProfileSpecificStorage(
     )
 
     @Expose
-    var attributeShards: MutableMap<String, AttributeShardData> = mutableMapOf()
+    val attributeShards: MutableMap<String, AttributeShardData> = mutableMapOf()
 
     data class AttributeShardData(
         @Expose var amountSyphoned: Int = 0,
@@ -1083,12 +1083,12 @@ class ProfileSpecificStorage(
 
     class HuntingStorage {
         @Expose
-        var trackedAttributeShards: MutableMap<String, Int> = mutableMapOf()
+        val trackedAttributeShards: MutableMap<String, Int> = mutableMapOf()
 
         @Expose
         var huntingProfitTracker: HuntingProfitTracker.Data = HuntingProfitTracker.Data()
     }
 
     @Expose
-    var hiddenCoopMembers: MutableSet<String> = mutableSetOf()
+    val hiddenCoopMembers: MutableSet<String> = mutableSetOf()
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/SpecificSeaCreatureStorage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/SpecificSeaCreatureStorage.kt
@@ -5,5 +5,5 @@ import com.google.gson.annotations.Expose
 
 class SpecificSeaCreatureStorage {
     @Expose
-    var specificSeaCreatureConfigStorage: MutableMap<String, SpecificSeaCreatureSettings> = mutableMapOf()
+    val specificSeaCreatureConfigStorage: MutableMap<String, SpecificSeaCreatureSettings> = mutableMapOf()
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/Storage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/Storage.kt
@@ -24,20 +24,20 @@ class Storage {
     var harvestFeastStorage: HarvestFeastStorage = HarvestFeastStorage()
 
     @Expose
-    var trackerDisplayModes: MutableMap<String, SkyHanniTracker.DisplayMode> = mutableMapOf()
+    val trackerDisplayModes: MutableMap<String, SkyHanniTracker.DisplayMode> = mutableMapOf()
 
     @Expose
     var foundDianaBurrowLocations: List<LorenzVec> = emptyList()
 
     @Expose
-    var players: MutableMap<UUID, PlayerSpecificStorage> = mutableMapOf()
+    val players: MutableMap<UUID, PlayerSpecificStorage> = mutableMapOf()
 
     @Expose
-    var blacklistedUsers: MutableList<String> = mutableListOf()
+    val blacklistedUsers: MutableList<String> = mutableListOf()
 
     @Expose
-    var reminders: MutableMap<String, Reminder> = mutableMapOf()
+    val reminders: MutableMap<String, Reminder> = mutableMapOf()
 
     @Expose
-    var testRenderablePositions: MutableMap<String, Position> = mutableMapOf()
+    val testRenderablePositions: MutableMap<String, Position> = mutableMapOf()
 }

--- a/src/main/java/at/hannibal2/skyhanni/data/MaxwellApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MaxwellApi.kt
@@ -58,7 +58,7 @@ object MaxwellApi {
         }
 
     private val NO_POWER by lazy { getPowerByNameOrNull("No Power") }
-    private var powers = mutableListOf<String>()
+    private var powers: List<String> = emptyList()
 
     private val patternGroup = RepoPattern.group("data.maxwell")
 

--- a/src/main/java/at/hannibal2/skyhanni/data/garden/CropCollectionApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/garden/CropCollectionApi.kt
@@ -127,7 +127,7 @@ object CropCollectionApi {
         }
 
         @Expose
-        var cropCollectionType: MutableMap<CropCollectionType, Long> = EnumMap(CropCollectionType::class.java)
+        val cropCollectionType: MutableMap<CropCollectionType, Long> = EnumMap(CropCollectionType::class.java)
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/local/VisualWordsJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/local/VisualWordsJson.kt
@@ -5,5 +5,5 @@ import com.google.gson.annotations.Expose
 
 class VisualWordsJson {
     @Expose
-    var modifiedWords: MutableList<VisualWord> = ArrayList()
+    var modifiedWords: List<VisualWord> = emptyList()
 }

--- a/src/main/java/at/hannibal2/skyhanni/events/RenderEntityOutlineEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/RenderEntityOutlineEvent.kt
@@ -18,32 +18,22 @@ class RenderEntityOutlineEvent(theType: Type?, potentialEntities: HashSet<Entity
     /**
      * The entities to outline. This is progressively cumulated from [.entitiesToChooseFrom]
      */
-    var entitiesToOutline: HashMap<Entity, Color> = hashMapOf()
+    val entitiesToOutline: HashMap<Entity, Color> = hashMapOf()
 
     /**
      * The entities we can outline. Note that this set and [.entitiesToOutline] are disjoint at all times.
      */
-    var entitiesToChooseFrom: HashSet<Entity> = hashSetOf()
+    val entitiesToChooseFrom: HashSet<Entity> = hashSetOf()
 
     /**
      * Whether [.entitiesToChooseFrom] has been computed already.
      */
     private var computed: Boolean = false
 
-    /**
-     * Constructs the event, given the type and optional entities to outline.
-     *
-     *
-     * This will modify {@param potentialEntities} internally, so make a copy before passing it if necessary.
-     *
-     * @param theType of the event (see [Type]
-     */
+    // Constructs the event, given the type and optional entities to outline.
     init {
         type = theType
-        entitiesToChooseFrom = potentialEntities
-        if (!potentialEntities.isEmpty()) {
-            entitiesToOutline = HashMap(potentialEntities.size)
-        }
+        entitiesToChooseFrom.addAll(potentialEntities)
     }
 
     /**
@@ -83,14 +73,14 @@ class RenderEntityOutlineEvent(theType: Type?, potentialEntities: HashSet<Entity
         @OptIn(AllEntitiesGetter::class)
         val entities: List<Entity> = EntityUtils.getAllEntities().toList()
         // Only render outlines around non-null entities within the camera frustum
-        entitiesToChooseFrom = HashSet(entities.size)
+        entitiesToChooseFrom.clear()
         // Empty invisible armor stands are common and never render an outlineable model
         for (entity in entities) {
             if (!entity.isEmptyInvisibleArmorStand() && entity !is ItemFrame) {
                 entitiesToChooseFrom.add(entity)
             }
         }
-        entitiesToOutline = HashMap(entitiesToChooseFrom.size)
+        entitiesToOutline.clear()
     }
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/events/minecraft/ToolTipEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/minecraft/ToolTipEvent.kt
@@ -9,13 +9,7 @@ import net.minecraft.world.inventory.Slot
  */
 @Deprecated("Use ToolTipTextEvent instead", ReplaceWith("ToolTipTextEvent"))
 class ToolTipEvent(val slot: Slot, val itemStack: SafeItemStack, private val toolTip0: MutableList<String>) : CancellableSkyHanniEvent() {
-
-    var toolTip: MutableList<String>
-        set(value) {
-            toolTip0.clear()
-            toolTip0.addAll(value)
-        }
-        get() = toolTip0
+    val toolTip: MutableList<String> get() = toolTip0
 
     fun toolTipRemovedPrefix() = toolTip.map { it.removePrefix("§5§o") }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/InstanceChestProfit.kt
@@ -212,7 +212,6 @@ object InstanceChestProfit {
                 ChatUtils.chat("Added ${it.repoItemName}§e to Favorites List.")
             }
         }
-        profileStorage?.instanceChestFavoriteItems = favoriteItems
     }
 
     @HandleEvent(InventoryCloseEvent::class)

--- a/src/main/java/at/hannibal2/skyhanni/features/cosmetics/CosmeticFollowingLine.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/cosmetics/CosmeticFollowingLine.kt
@@ -24,14 +24,14 @@ object CosmeticFollowingLine {
 
     private val config get() = SkyHanniMod.feature.gui.cosmetic.followingLine
 
-    private var locations = LinkedHashMap<LorenzVec, LocationSpot>()
+    private val locations = LinkedHashMap<LorenzVec, LocationSpot>()
     private val latestLocations = LinkedHashMap<LorenzVec, LocationSpot>()
 
     class LocationSpot(val time: SimpleTimeMark, val onGround: Boolean)
 
     @HandleEvent
     fun onWorldChange() {
-        locations = LinkedHashMap()
+        locations.clear()
     }
 
     @HandleEvent(onlyOnSkyblockOrFeatures = [OutsideSBFeature.FOLLOWING_LINE])

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonLividFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonLividFinder.kt
@@ -59,7 +59,7 @@ object DungeonLividFinder {
     var livid: RemotePlayer? = null
         private set
 
-    private var fakeLivids = mutableSetOf<RemotePlayer>()
+    private val fakeLivids = mutableSetOf<RemotePlayer>()
 
     // This only happens when in f5/m5 bossfight, so the performance impact is minimal
     @OptIn(AllEntitiesGetter::class)

--- a/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalFruitDigging.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/carnival/CarnivalFruitDigging.kt
@@ -43,7 +43,7 @@ object CarnivalFruitDigging {
 
     private var isPlayingFruitDigging = false
     private var lastSquareDug: GamePos? = null
-    private var remainingFruit = Fruit.entries.associateWith { it.count }.toMutableMap()
+    private val remainingFruit = Fruit.entries.associateWith { it.count }.toMutableMap()
 
     private val solver = FruitDiggingSolver(GRID_LENGTH)
     private var recommendation: FruitDiggingSolver.Recommendation? = null
@@ -444,7 +444,8 @@ object CarnivalFruitDigging {
     fun resetData() {
         isPlayingFruitDigging = false
         gameGrid = GameGrid()
-        remainingFruit = Fruit.entries.associateWith { it.count }.toMutableMap()
+        remainingFruit.clear()
+        Fruit.entries.forEach { remainingFruit[it] = it.count }
         lastSquareDug = null
         recommendation = null
         solverDirty = false

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityTextureHandler.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityTextureHandler.kt
@@ -9,8 +9,7 @@ import at.hannibal2.skyhanni.utils.LorenzRarity
 
 @SkyHanniModule
 object HoppityTextureHandler {
-
-    private var hoppityRabbitTextures = mutableMapOf<LorenzRarity, List<HoppityRabbitTextureEntry>>()
+    private var hoppityRabbitTextures: Map<LorenzRarity, List<HoppityRabbitTextureEntry>> = emptyMap()
 
     @HandleEvent
     fun onRepoReload(event: RepositoryReloadEvent) {
@@ -18,7 +17,7 @@ object HoppityTextureHandler {
         hoppityRabbitTextures = data.textures.mapNotNull { (key, entries) ->
             val rarity = LorenzRarity.getByName(key) ?: return@mapNotNull null
             rarity to entries
-        }.toMap().toMutableMap()
+        }.toMap()
     }
 
     /**
@@ -53,5 +52,4 @@ object HoppityTextureHandler {
         hoppityRabbitTextures.values.flatten().firstOrNull {
             rabbit in it.rabbits
         }?.textureId
-
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/jerry/frozentreasure/FrozenTreasureTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/jerry/frozentreasure/FrozenTreasureTracker.kt
@@ -35,7 +35,7 @@ object FrozenTreasureTracker {
 
     private var estimatedIce = 0L
     private var lastEstimatedIce = 0L
-    private var icePerSecond = mutableListOf<Long>()
+    private val icePerSecond = mutableListOf<Long>()
     private var icePerHour = 0
     private var stoppedChecks = 0
     private val tracker = SkyHanniTracker(
@@ -61,7 +61,7 @@ object FrozenTreasureTracker {
     fun onWorldChange() {
         icePerHour = 0
         stoppedChecks = 0
-        icePerSecond = mutableListOf()
+        icePerSecond.clear()
         tracker.update()
     }
 
@@ -86,9 +86,7 @@ object FrozenTreasureTracker {
                 icePerSecond.add(0)
             }
             icePerSecond.add(difference)
-            val listCopy = icePerSecond
-            while (listCopy.size > 1200) listCopy.removeAt(0)
-            icePerSecond = listCopy
+            while (icePerSecond.size > 1200) icePerSecond.removeAt(0)
         }
         icePerHour = (icePerSecond.average() * 3600).toInt()
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorColorNames.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorColorNames.kt
@@ -11,7 +11,7 @@ import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 object GardenVisitorColorNames {
 
     private val visitorColors = mutableMapOf<String, String>() // name -> color code
-    var visitorMap = mutableMapOf<String, GardenVisitor>() // TODO why is this here
+    val visitorMap = mutableMapOf<String, GardenVisitor>() // TODO why is this here
 
     @HandleEvent
     fun onRepoReload(event: RepositoryReloadEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorCompactChat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/visitor/GardenVisitorCompactChat.kt
@@ -68,9 +68,9 @@ object GardenVisitorCompactChat {
         "^ {2}§a§lREWARDS",
     )
 
-    private var visitorAcceptedChat = mutableListOf<String>()
+    private val visitorAcceptedChat = mutableListOf<String>()
     private var visitorNameFormatted = ""
-    private var rewardsList = mutableListOf<String>()
+    private val rewardsList = mutableListOf<String>()
 
     @HandleEvent
     fun onChat(event: SkyHanniChatEvent.Allow) {
@@ -88,8 +88,8 @@ object GardenVisitorCompactChat {
         val transformedMessage = event.message.removeResets()
 
         fullyAcceptedPattern.matchMatcher(transformedMessage) {
-            visitorAcceptedChat = mutableListOf()
-            rewardsList = mutableListOf()
+            visitorAcceptedChat.clear()
+            rewardsList.clear()
             val visitorColor = groupOrNull("color") ?: "§7"
             val visitorName = group("name")
             visitorNameFormatted = "$visitorColor$visitorName"

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/BetterContainers.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/BetterContainers.kt
@@ -77,7 +77,7 @@ object BetterContainers {
     private var bufferedImageBase: BufferedImage? = null
     private var bufferedImageSlot: BufferedImage? = null
     private var bufferedImageButton: BufferedImage? = null
-    private var lastSlots: MutableList<Slot?>? = null
+    private var lastSlots: List<Slot?>? = null
 
     private var loaded = false
     private var gpuNative: NativeImage? = null

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/CarnivalShopHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/CarnivalShopHelper.kt
@@ -38,7 +38,7 @@ object CarnivalShopHelper {
      */
     private val SLOT_RANGE = 11..15
 
-    private var repoEventShops = mutableListOf<EventShop>()
+    private var repoEventShops: List<EventShop> = emptyList()
     private var currentProgress: EventShopProgress? = null
     private var currentEventType: String = ""
     private var tokensOwned: Int = 0
@@ -120,7 +120,7 @@ object CarnivalShopHelper {
         val repoTokenShops = event.getConstant<NeuMiscJson>("carnivalshops").carnivalTokenShops
         repoEventShops = repoTokenShops.map { (key, value) ->
             EventShop(key.replace("_", " "), value.values.toMutableList())
-        }.toMutableList()
+        }
         checkSavedProgress()
         regenerateOverviewItemStack()
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/EssenceShopHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/EssenceShopHelper.kt
@@ -57,7 +57,7 @@ object EssenceShopHelper {
      */
     private val SLOT_RANGE = 10..33
 
-    private var essenceShops = mutableListOf<EssenceShop>()
+    private var essenceShops: List<EssenceShop> = emptyList()
     private var currentProgress: EssenceShopProgress? = null
     private var currentEssenceType: String = ""
     private var currentEssenceItem: NeuInternalName? = null
@@ -151,7 +151,7 @@ object EssenceShopHelper {
         val repoEssenceShops = event.getConstant<Map<String, Map<String, NeuEssenceShopJson>>>("essenceshops")
         essenceShops = repoEssenceShops.map { (key, value) ->
             EssenceShop(key, value.values.toMutableList())
-        }.toMutableList()
+        }
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarOrderApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarOrderApi.kt
@@ -213,8 +213,14 @@ object BazaarOrderApi {
             }
         }
         val storage = storage ?: return
-        storage.buyOrders = buy
-        storage.sellOffers = sell
+        storage.buyOrders.apply {
+            clear()
+            putAll(buy)
+        }
+        storage.sellOffers.apply {
+            clear()
+            putAll(sell)
+        }
     }
 
     @HandleEvent(onlyOnSkyblock = true)

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFApi.kt
@@ -109,8 +109,8 @@ object CFApi {
     var maxRabbits = 503
     var hitmanCosts = TreeSet<Long>()
     private var chocolateMilestones = TreeSet<Long>()
-    private var chocolateFactoryMilestones: MutableList<MilestoneJson> = mutableListOf()
-    private var chocolateShopMilestones: MutableList<MilestoneJson> = mutableListOf()
+    private var chocolateFactoryMilestones: List<MilestoneJson> = emptyList()
+    private var chocolateShopMilestones: List<MilestoneJson> = emptyList()
     private var maxPrestige = 6
     var cfShortcutIndex = 16
 
@@ -179,8 +179,8 @@ object CFApi {
         cfShortcutIndex = data.cfShortcutIndex
         chocolateMilestones = data.chocolateMilestones
         hitmanCosts = data.hitmanCosts
-        chocolateFactoryMilestones = data.chocolateFactoryMilestones.toMutableList()
-        chocolateShopMilestones = data.chocolateShopMilestones.toMutableList()
+        chocolateFactoryMilestones = data.chocolateFactoryMilestones
+        chocolateShopMilestones = data.chocolateShopMilestones
         specialRabbitTextures = data.specialRabbits
 
         CFUpgrade.updateIgnoredSlots()

--- a/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbility.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/itemabilities/abilitycooldown/ItemAbility.kt
@@ -77,7 +77,7 @@ enum class ItemAbility(
     ECHO("Echo", 3, "Ancestral Spade");
 
     var newVariant = false
-    var internalNames = mutableListOf<NeuInternalName>()
+    val internalNames = mutableListOf<NeuInternalName>()
 
     constructor(
         cooldownInSeconds: Int,

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/KingTalismanHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/KingTalismanHelper.kt
@@ -45,7 +45,7 @@ object KingTalismanHelper {
     )
 
     private fun resetKings() {
-        storage?.kingsTalkedTo = mutableListOf<String>()
+        storage?.kingsTalkedTo?.clear()
         update()
     }
 
@@ -178,7 +178,10 @@ object KingTalismanHelper {
         if (!MiningApi.inDwarvenMines) return
 
         if (talismanPattern.matches(event.message)) {
-            storage?.kingsTalkedTo = kingCircles.toMutableList()
+            storage?.kingsTalkedTo?.apply {
+                clear()
+                addAll(kingCircles)
+            }
             update()
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/MineshaftPityDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/MineshaftPityDisplay.kt
@@ -57,11 +57,8 @@ object MineshaftPityDisplay {
 
     private val profileStorage get() = ProfileStorageData.profileSpecific?.mining?.mineshaft
 
-    private var minedBlocks: MutableList<PityData>
+    private val minedBlocks: MutableList<PityData>
         get() = profileStorage?.blocksBroken ?: mutableListOf()
-        set(value) {
-            profileStorage?.blocksBroken = value
-        }
 
     private var PityBlock.spreadBlocksBroken: Int
         get() = minedBlocks.firstOrNull { it.pityBlock == this }?.spreadBlocksBroken ?: 0
@@ -319,7 +316,7 @@ object MineshaftPityDisplay {
     }
 
     private fun resetCounter() {
-        minedBlocks = mutableListOf()
+        profileStorage?.blocksBroken?.clear()
         lastMineshaftSpawn = SimpleTimeMark.now()
         update()
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/MiningCommissionsBlocksColor.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/MiningCommissionsBlocksColor.kt
@@ -22,6 +22,7 @@ import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.world.item.DyeColor
 import net.minecraft.world.level.block.state.BlockState
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
@@ -57,7 +58,7 @@ object MiningCommissionsBlocksColor {
 
     private var oldSneakState = false
     private var dirty = false
-    private var replaceBlocksMapCache = mutableMapOf<BlockState, BlockState>()
+    private var replaceBlocksMapCache = ConcurrentHashMap<BlockState, BlockState>()
 
     // TODO Commission API
     @HandleEvent
@@ -117,7 +118,7 @@ object MiningCommissionsBlocksColor {
         }
 
         if (reload) {
-            replaceBlocksMapCache = mutableMapOf()
+            replaceBlocksMapCache = ConcurrentHashMap()
             MinecraftCompat.reloadChunks()
             dirty = false
         }
@@ -142,7 +143,7 @@ object MiningCommissionsBlocksColor {
     @HandleEvent
     fun onWorldChange() {
         enabled = false
-        replaceBlocksMapCache = mutableMapOf()
+        replaceBlocksMapCache = ConcurrentHashMap()
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/OrderedWaypoints.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/OrderedWaypoints.kt
@@ -13,7 +13,6 @@ import at.hannibal2.skyhanni.data.model.waypoints.SkyHanniWaypoint
 import at.hannibal2.skyhanni.data.model.waypoints.WaypointFormat
 import at.hannibal2.skyhanni.data.model.waypoints.Waypoints
 import at.hannibal2.skyhanni.events.IslandChangeEvent
-import at.hannibal2.skyhanni.events.hypixel.HypixelJoinEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
 import at.hannibal2.skyhanni.events.mining.GlaciteMineshaftDetectEvent
@@ -48,14 +47,6 @@ object OrderedWaypoints {
     private var currentOrderedWaypointIndex = 0
     private var lastCloser = 0
     private var loadJob: Job? = null
-
-    @HandleEvent(HypixelJoinEvent::class)
-    fun onHypixelJoin() {
-        if (SkyHanniMod.orderedWaypointsRoutesData.routes == null) {
-            SkyHanniMod.orderedWaypointsRoutesData.routes = mutableMapOf()
-            saveConfig()
-        }
-    }
 
     fun saveConfig() {
         SkyHanniMod.configManager.saveConfig(ConfigFileType.ROUTES, "Save file")

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/TabWidgetSettings.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/TabWidgetSettings.kt
@@ -72,7 +72,7 @@ object TabWidgetSettings {
     )
 
     var inInventory = false
-    var highlights = mutableMapOf<Int, LorenzColor>()
+    val highlights = mutableMapOf<Int, LorenzColor>()
 
     @HandleEvent
     fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/AdvancedPlayerList.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/AdvancedPlayerList.kt
@@ -49,7 +49,7 @@ object AdvancedPlayerList {
         "^(?!SB Level).*\\[(?<level>(?:§.)*[\\d,]+)(?:§.)*] (?<name>.*)",
     )
 
-    private var playerData = mutableMapOf<Component, PlayerData>()
+    private var playerData: Map<Component, PlayerData> = emptyMap()
 
     fun createTabLine(component: Component, type: TabStringType) = playerData[component]?.let {
         TabLine(component, type, it.createCustomName())
@@ -119,9 +119,9 @@ object AdvancedPlayerList {
             else -> prepare
         }
 
-        var newPlayerList = sorted.map { it.key }.toMutableList()
+        val newPlayerList = sorted.map { it.key }.toMutableList()
         if (config.reverseSort) {
-            newPlayerList = newPlayerList.reversed().toMutableList()
+            newPlayerList.reverse()
         }
         if (extraTitles > 0 && newPlayerList.size >= 19) {
             newPlayerList.add(19, original.first())

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabListReader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabListReader.kt
@@ -24,7 +24,7 @@ object TabListReader {
     private val patternGroup = RepoPattern.group("misc.compacttablist")
 
     var hypixelAdvertisingString = "HYPIXEL.NET"
-    var renderColumns = mutableListOf<RenderColumn>()
+    var renderColumns: List<RenderColumn> = emptyList()
         private set
 
     private var lastTab: List<Component>? = null
@@ -151,8 +151,9 @@ object TabListReader {
         parseSections(columns)
 
         val renderColumn = RenderColumn()
-        renderColumns = mutableListOf(renderColumn)
-        combineColumnsToRender(columns, renderColumn)
+        val columnsToRender = mutableListOf(renderColumn)
+        combineColumnsToRender(columns, renderColumn, columnsToRender)
+        renderColumns = columnsToRender
     }
 
     private fun rebuildColumns(tabList: List<Component>): List<TabColumn> = buildList {
@@ -310,13 +311,17 @@ object TabListReader {
         }
     }
 
-    private fun combineColumnsToRender(columns: List<TabColumn>, firstColumn: RenderColumn) {
+    private fun combineColumnsToRender(
+        columns: List<TabColumn>,
+        firstColumn: RenderColumn,
+        columnsToRender: MutableList<RenderColumn>,
+    ) {
         var currentColumn = firstColumn
         var lastTitleComponent: Component? = null
 
         fun newColumnOrSpacer(required: Boolean) {
             if (required || currentColumn.size() >= TabListRenderer.MAX_LINES) {
-                renderColumns.add(RenderColumn().also { currentColumn = it })
+                columnsToRender.add(RenderColumn().also { currentColumn = it })
             } else if (currentColumn.size() > 0) {
                 currentColumn.addLine(AdvancedPlayerList.createTabLine(Component.literal(""), TabStringType.TEXT))
             }
@@ -324,7 +329,7 @@ object TabListReader {
 
         fun addLine(line: Component) {
             if (currentColumn.size() >= TabListRenderer.MAX_LINES) {
-                renderColumns.add(RenderColumn().also { currentColumn = it })
+                columnsToRender.add(RenderColumn().also { currentColumn = it })
             }
             currentColumn.addLine(AdvancedPlayerList.createTabLine(line, TabStringType.fromComponent(line)))
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/customtodos/CustomTodos.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/customtodos/CustomTodos.kt
@@ -73,7 +73,11 @@ class CustomTodos(
     }
 
     fun save() {
-        SkyHanniMod.customTodos.customTodos = todos.map { it.into() }.toMutableList()
+        val mapped = todos.map { it.into() }
+        SkyHanniMod.customTodos.customTodos.apply {
+            clear()
+            addAll(mapped)
+        }
         SkyHanniMod.configManager.saveConfig(ConfigFileType.CUSTOM_TODOS, "Save file")
     }
 
@@ -94,5 +98,4 @@ class CustomTodos(
         )
         save()
     }
-
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
@@ -51,7 +51,7 @@ object EstimatedItemValue {
     private var display = emptyList<Renderable>()
     private val cache = mutableMapOf<SafeItemStack, List<Renderable>>()
     private var lastToolTipTime = 0L
-    var gemstoneUnlockCosts = NeuGemstoneCostJson()
+    var gemstoneUnlockCosts: Map<NeuInternalName, Map<String, List<String>>> = emptyMap()
     var hasLegacyGemstoneSlots = emptyList<NeuInternalName>()
     var bookBundleAmount = mapOf<String, Int>()
     var crimsonPrestigeCosts = mapOf<String, Map<NeuInternalName, Int>>()

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantParser.kt
@@ -91,7 +91,7 @@ object EnchantParser {
     // Used to determine how many enchants are used on each line
     // for this particular item, since consistency is not Hypixel's strong point
     private var maxEnchantsPerLine = 0
-    private var loreLines: MutableList<Component> = mutableListOf()
+    private val loreLines: MutableList<Component> = mutableListOf()
     private var orderedEnchants: TreeSet<FormattedEnchant> = TreeSet()
 
     private val loreCache: EnchantCache = EnchantCache()
@@ -231,7 +231,7 @@ object EnchantParser {
 
         stackingEnchants.clear()
         shouldBeSingleColumn = false
-        loreLines = mutableListOf()
+        loreLines.clear()
         orderedEnchants = TreeSet()
         maxEnchantsPerLine = 0
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantsJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/enchants/EnchantsJson.kt
@@ -6,15 +6,15 @@ import com.google.gson.annotations.SerializedName
 class EnchantsJson {
     @Expose
     @SerializedName("NORMAL")
-    var normal: HashMap<String, Enchant.Normal> = hashMapOf()
+    var normal: Map<String, Enchant.Normal> = emptyMap()
 
     @Expose
     @SerializedName("ULTIMATE")
-    var ultimate: HashMap<String, Enchant.Ultimate> = hashMapOf()
+    var ultimate: Map<String, Enchant.Ultimate> = emptyMap()
 
     @Expose
     @SerializedName("STACKING")
-    var stacking: HashMap<String, Enchant.Stacking> = hashMapOf()
+    var stacking: Map<String, Enchant.Stacking> = emptyMap()
 
     fun getFromLore(passedLoreName: String): Enchant {
         val loreName = passedLoreName.lowercase()

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/limbo/LimboPlaytime.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/limbo/LimboPlaytime.kt
@@ -15,9 +15,11 @@ import at.hannibal2.skyhanni.utils.NeuItems.getItemStack
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.formatDoubleOrNull
 import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
+import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.itemType
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.network.chat.Component
@@ -26,7 +28,7 @@ import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object LimboPlaytime {
-    private lateinit var modifiedList: MutableList<Component>
+    private var modifiedList = listOf<Component>()
     private var setMinutes = false
     private val patternGroup = RepoPattern.group("misc.limbo.tooltip")
 
@@ -49,7 +51,7 @@ object LimboPlaytime {
         "(?<hours>[\\d.,]+) hours.*$",
     )
 
-    private var tooltipPlaytime = mutableListOf<Component>()
+    private var tooltipPlaytime = listOf<Component>()
 
     private var wholeMinutes = 0
     private var hoursString: String = ""
@@ -59,11 +61,11 @@ object LimboPlaytime {
 
     private val itemID = "ENDER_PEARL".toInternalName()
     private const val ITEM_NAME = "§aLimbo"
-    private lateinit var limboItem: SafeItemStack
+    private var limboItem: SafeItemStack? = null
     private var lastCreateCooldown = SimpleTimeMark.farPast()
 
     @HandleEvent
-    fun replaceItem(event: ReplaceItemEvent) {
+    private fun replaceItem(event: ReplaceItemEvent) {
         if (!enabled) return
         if (event.inventory !is SimpleContainer) return
         // TODO replace with InventoryDetector
@@ -72,15 +74,16 @@ object LimboPlaytime {
         val playtime = storage?.playtime ?: 0
         if (playtime < 60) return
 
-        if (lastCreateCooldown.passedSince() > 3.seconds) {
+        val item = limboItem?.takeIf { lastCreateCooldown.passedSince() > 3.seconds } ?: run {
             lastCreateCooldown = SimpleTimeMark.now()
-            limboItem = ItemUtils.createItemStack(
+            ItemUtils.createItemStack(
                 itemID.getItemStack().itemType,
                 ITEM_NAME,
                 createItemLore(),
             )
         }
-        event.replace(limboItem)
+        limboItem = item
+        event.replace(item)
     }
 
     private fun createItemLore(): Array<String> = when {
@@ -95,7 +98,7 @@ object LimboPlaytime {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onToolTip(event: ToolTipTextEvent) {
+    private fun onToolTip(event: ToolTipTextEvent) {
         if (!enabled) return
         // TODO replace with InventoryDetector
         if (!InventoryUtils.openInventoryName().startsWith("Detailed /playtime")) return
@@ -112,7 +115,7 @@ object LimboPlaytime {
     }
 
     @HandleEvent
-    fun onInventoryOpen(event: InventoryOpenEvent) {
+    private fun onInventoryOpen(event: InventoryOpenEvent) {
         if (event.inventoryName != "Detailed /playtime") return
         val playtime = (storage?.playtime ?: 0).seconds
         if (playtime < 60.seconds) return
@@ -130,28 +133,28 @@ object LimboPlaytime {
         }
     }
 
-    private fun addLimbo(hoursList: MutableList<Component>, minutesList: MutableList<Component>) {
+    private fun addLimbo(hoursList: List<Component>, minutesList: List<Component>) {
         val storedPlaytime = storage?.playtime ?: 0
         if (wholeMinutes >= 60) {
-            modifiedList = hoursList
-            modifiedList.add("§5§o§b$hoursString hours §7on Limbo")
-            modifiedList = modifiedList.sortedByDescending {
-                val matcher = hoursPattern.matcher(it.string)
-                if (matcher.find()) {
-                    matcher.group("hours").formatDoubleOrNull() ?: 0.0
-                } else 0.0
-            }.toMutableList()
+            modifiedList = buildList {
+                addAll(hoursList)
+                add("§5§o§b$hoursString hours §7on Limbo".asComponent())
+            }.sortedByDescending {
+                hoursPattern.matchMatcher(it.string) {
+                    group("hours").formatDoubleOrNull() ?: 0.0
+                } ?: 0.0
+            }
             setMinutes = false
         } else {
             val minutes = storedPlaytime.seconds.inWholeMinutes
-            modifiedList = minutesList
-            modifiedList.add("§5§o§a$minutes minutes §7on Limbo")
-            modifiedList = modifiedList.sortedByDescending {
-                val matcher = minutesPattern.matcher(it.string)
-                if (matcher.find()) {
-                    matcher.group("minutes").toDoubleOrNull() ?: 0.0
-                } else 0.0
-            }.toMutableList()
+            modifiedList = buildList {
+                addAll(minutesList)
+                add("§5§o§a$minutes minutes §7on Limbo".asComponent())
+            }.sortedByDescending {
+                minutesPattern.matchMatcher(it.string) {
+                    group("minutes").toDoubleOrNull() ?: 0.0
+                } ?: 0.0
+            }
             setMinutes = true
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/visualwords/ModifyVisualWords.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/visualwords/ModifyVisualWords.kt
@@ -22,7 +22,7 @@ object ModifyVisualWords {
     val componentCache = TimeAndSizeLimitedCache<Component, Component>(65565, 5.minutes)
 
     /** Replacements added manually by the user via /shwords. */
-    var userModifiedWords = mutableListOf<VisualWordText>()
+    var userModifiedWords: List<VisualWordText> = emptyList()
 
     /** Replacements added automatically by the mod for features, april fools, etc. */
     private val modModifiedWords = mutableListOf<VisualWordText>()
@@ -32,8 +32,7 @@ object ModifyVisualWords {
         finalWordsList = modModifiedWords + userModifiedWords
         textCache.clear()
         componentCache.clear()
-        SkyHanniMod.visualWordsData.modifiedWords =
-            userModifiedWords.map { it.toVisualWord() }.toMutableList()
+        SkyHanniMod.visualWordsData.modifiedWords = userModifiedWords.map { it.toVisualWord() }
         MinecraftCompat.hud.chat.refreshTrimmedMessages()
     }
 
@@ -42,7 +41,7 @@ object ModifyVisualWords {
     private fun modifyVisualWordsEnabled(): Boolean {
         if (!config.enabled || !changeWords) return false
         if (userModifiedWords.isEmpty() && SkyHanniMod.visualWordsData.modifiedWords.isNotEmpty()) {
-            userModifiedWords.addAll(SkyHanniMod.visualWordsData.modifiedWords.map { VisualWordText.fromVisualWord(it) })
+            userModifiedWords = SkyHanniMod.visualWordsData.modifiedWords.map { VisualWordText.fromVisualWord(it) }
             update()
         }
         return userModifiedWords.isNotEmpty()
@@ -102,8 +101,8 @@ object ModifyVisualWords {
         return componentCache.getOrPut(component) { visitAndReplace(component) }
     }
 
-    private fun doReplacements(characters: MutableList<StyledCharacter>): MutableList<StyledCharacter> {
-        var workingCharacters = characters
+    private fun doReplacements(characters: List<StyledCharacter>): List<StyledCharacter> {
+        var workingCharacters: List<StyledCharacter> = characters
 
         for (word in finalWordsList) {
             if (!word.enabled) continue

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/visualwords/VisualWordScreen.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/visualwords/VisualWordScreen.kt
@@ -27,7 +27,7 @@ class VisualWordScreen : SkyHanniBaseScreen() {
     var currentlyEditing = false
     var currentIndex = -1
     var activeInput: TextInput? = null
-    var modifiedWords: MutableList<VisualWord> = ModifyVisualWords.userModifiedWords
+    val modifiedWords: MutableList<VisualWord> = ModifyVisualWords.userModifiedWords
         .map { it.toVisualWord() }.toMutableList()
 
     /**
@@ -149,8 +149,7 @@ class VisualWordScreen : SkyHanniBaseScreen() {
     }
 
     fun saveChanges() {
-        ModifyVisualWords.userModifiedWords = modifiedWords
-            .map { VisualWordText.fromVisualWord(it) }.toMutableList()
+        ModifyVisualWords.userModifiedWords = modifiedWords.map { VisualWordText.fromVisualWord(it) }
         ModifyVisualWords.update()
         SkyHanniMod.configManager.saveConfig(ConfigFileType.VISUAL_WORDS, "Updated visual words")
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/dreadfarm/WoodenButtonsHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/dreadfarm/WoodenButtonsHelper.kt
@@ -47,7 +47,7 @@ object WoodenButtonsHelper {
     )
 
     private var buttonLocations = mapOf<String, List<LorenzVec>>()
-    private var hitButtons = mutableSetOf<LorenzVec>()
+    private val hitButtons = mutableSetOf<LorenzVec>()
     private var lastHitButton: LorenzVec? = null
     private var currentSpot: GraphNode? = null
     private var lastBlowgunFire = SimpleTimeMark.farPast()
@@ -150,7 +150,8 @@ object WoodenButtonsHelper {
 
         if (event.message != "§eYou've hit all §r§b56 §r§ewooden buttons!") return
         RiftApi.allButtonsHit = true
-        hitButtons = buttonLocations.values.flatten().toMutableSet()
+        hitButtons.clear()
+        hitButtons.addAll(buttonLocations.values.flatten())
         soulLocations["Dreadfarm"]?.get("Buttons")?.let {
             IslandGraphs.pathFind(
                 it,

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerMiniBossFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerMiniBossFeatures.kt
@@ -19,8 +19,8 @@ import net.minecraft.world.entity.Entity
 object SlayerMiniBossFeatures {
 
     private val config get() = SlayerApi.config
-    private var miniBosses = mutableSetOf<Mob>()
-    private var cocoons = mutableSetOf<Entity>()
+    private val miniBosses = mutableSetOf<Mob>()
+    private val cocoons = mutableSetOf<Entity>()
 
     @HandleEvent
     fun onMobSpawn(event: MobEvent.Spawn.SkyblockMob) {

--- a/src/main/java/at/hannibal2/skyhanni/features/summonings/SummoningMobManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/summonings/SummoningMobManager.kt
@@ -36,7 +36,7 @@ import kotlin.time.Duration.Companion.seconds
 object SummoningMobManager {
 
     private val config get() = SkyHanniMod.feature.combat.summonings
-    private var mobs = mutableSetOf<Mob>()
+    private val mobs = mutableSetOf<Mob>()
 
     private var lastChatTime: SimpleTimeMark = SimpleTimeMark.farPast()
     private val timeOut = 2.seconds

--- a/src/main/java/at/hannibal2/skyhanni/test/ParkourWaypointSaver.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/ParkourWaypointSaver.kt
@@ -26,7 +26,7 @@ object ParkourWaypointSaver {
 
     private val config get() = DevApi.config.waypoint
     private var timeLastSaved = SimpleTimeMark.farPast()
-    private var locations = mutableListOf<LorenzVec>()
+    private var locations: List<LorenzVec> = emptyList()
     private var parkourHelper: ParkourHelper? = null
 
     @HandleEvent
@@ -43,9 +43,9 @@ object ParkourWaypointSaver {
                     loadClipboard()
                 } else {
                     if (PlayerUtils.isSneaking()) {
-                        locations.clear()
+                        locations = emptyList()
                     } else {
-                        locations = locations.dropLast(1).toMutableList()
+                        locations = locations.dropLast(1)
                     }
 //                     update()
                 }
@@ -54,7 +54,7 @@ object ParkourWaypointSaver {
             config.saveKey -> {
                 val newLocation = LocationUtils.getBlockBelowPlayer()
                 if (locations.isNotEmpty() && newLocation == locations.last()) return
-                locations.add(newLocation)
+                locations = locations + newLocation
                 update()
             }
         }
@@ -73,7 +73,7 @@ object ParkourWaypointSaver {
                 locations = clipboard.split("\n").map { line ->
                     val raw = line.replace("\"", "").replace(",", "")
                     raw.split(":").map { it.toDouble() }.toLorenzVec()
-                }.toMutableList()
+                }
             } catch (e: NumberFormatException) {
                 ErrorManager.logErrorWithData(
                     e,
@@ -93,7 +93,7 @@ object ParkourWaypointSaver {
         }
     }
 
-    private fun MutableList<LorenzVec>.copyLocations() {
+    private fun List<LorenzVec>.copyLocations() {
         val resultList = mutableListOf<String>()
         timeLastSaved = SimpleTimeMark.now()
         for (location in this) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/PetUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/PetUtils.kt
@@ -32,7 +32,7 @@ import kotlin.time.Duration.Companion.minutes
 @SkyHanniModule
 object PetUtils {
     // Late load from NEU repo
-    private var petSkins = mutableMapOf<String, MutableList<NeuItemJson>>()
+    private var petSkins: Map<String, List<NeuItemJson>> = emptyMap()
     private var basePetLeveling: List<Int> = listOf()
     private var customPetLeveling: Map<String, NeuPetData> = mapOf()
     private var petTypes: Map<String, String> = mapOf()

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkullTextureHolder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkullTextureHolder.kt
@@ -12,12 +12,12 @@ object SkullTextureHolder {
     @Suppress("MaxLineLength", "SkullTexturesUseRepo")
     private const val ALEX_SKIN_TEXTURE = "ewogICJ0aW1lc3RhbXAiIDogMTcxMTY1OTI2NDg1NSwKICAicHJvZmlsZUlkIiA6ICI2YWI0MzE3ODg5ZmQ0OTA1OTdmNjBmNjdkOWQ3NmZkOSIsCiAgInByb2ZpbGVOYW1lIiA6ICJNSEZfQWxleCIsCiAgInNpZ25hdHVyZVJlcXVpcmVkIiA6IHRydWUsCiAgInRleHR1cmVzIiA6IHsKICAgICJTS0lOIiA6IHsKICAgICAgInVybCIgOiAiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS84M2NlZTVjYTZhZmNkYjE3MTI4NWFhMDBlODA0OWMyOTdiMmRiZWJhMGVmYjhmZjk3MGE1Njc3YTFiNjQ0MDMyIiwKICAgICAgIm1ldGFkYXRhIiA6IHsKICAgICAgICAibW9kZWwiIDogInNsaW0iCiAgICAgIH0KICAgIH0KICB9Cn0="
 
-    private var skullTextures = mutableMapOf<String, String>()
+    private var skullTextures: Map<String, String> = emptyMap()
     private val cachedTextures = mutableListOf<StableOrTransientValue<*>>()
 
     @HandleEvent
     fun onRepoReload(event: RepositoryReloadEvent) {
-        skullTextures = event.getConstant<Map<String, String>>("Skulls").toMutableMap()
+        skullTextures = event.getConstant<Map<String, String>>("Skulls")
         cachedTextures.forEach { it.reset() }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
@@ -357,7 +357,7 @@ object StringUtils {
 
     fun doLookTheSame(left: Component, right: Component): Boolean {
         class ChatIterator(var component: Component) {
-            var queue = mutableListOf<Component>()
+            val queue = mutableListOf<Component>()
             var idx = 0
             var colorOverride = defaultStyleConstructor
             fun next(): Pair<Char, Style>? {

--- a/src/main/java/at/hannibal2/skyhanni/utils/tracker/ItemTrackerData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/tracker/ItemTrackerData.kt
@@ -51,7 +51,7 @@ abstract class ItemTrackerData<T : SessionUptime>(clazz: KClass<T>) : TrackerDat
     }
 
     @Expose
-    var items: MutableMap<NeuInternalName, TrackedItem> = HashMap()
+    val items: MutableMap<NeuInternalName, TrackedItem> = HashMap()
 
     data class TrackedItem(
         @Expose var timesGained: Long = 0,


### PR DESCRIPTION
## Dependencies
- #6379
- #6381

## What
This Detekt rule was previously disabled due to the sheer number of existing flags, but it's not just a pedantic rule. Declaring something as both a `var` and a `Mutable*` is a footgun and makes it easy to accidentally mess things up. This PR enables the rule and fixes all existing violations. #6379 and #6381 were a byproduct of this cleanup.

## Changelog Technical Details
+ Disallowed double mutability for collections via a Detekt rule and fixed all existing violations. - Luna