### PR TITLE
Backend: No unnecessary fully qualified names

### DIFF
--- a/detekt/baseline-main.xml
+++ b/detekt/baseline-main.xml
@@ -586,9 +586,6 @@
     <ID>PrivateEventListener:ComposterOverlay.kt:ComposterOverlay$@HandleEvent(onlyOnIsland = IslandType.GARDEN) fun onToolTip</ID>
     <ID>PrivateEventListener:ComposterOverlay.kt:ComposterOverlay$@HandleEvent(onlyOnIsland = IslandType.GARDEN) fun onWidgetUpdate</ID>
     <ID>PrivateEventListener:ComposterUpgradesData.kt:ComposterUpgradesData$@HandleEvent(onlyOnIsland = IslandType.GARDEN) fun onInventoryFullyOpened</ID>
-    <ID>PrivateEventListener:ComputerEnvDebug.kt:ComputerEnvDebug$@HandleEvent fun onCommandRegistration</ID>
-    <ID>PrivateEventListener:ComputerEnvDebug.kt:ComputerEnvDebug$@HandleEvent fun onDebugDataCollect</ID>
-    <ID>PrivateEventListener:ComputerEnvDebug.kt:ComputerEnvDebug$@HandleEvent fun onRepoReload</ID>
     <ID>PrivateEventListener:ComputerTimeOffset.kt:ComputerTimeOffset$@HandleEvent fun onDebugDataCollect</ID>
     <ID>PrivateEventListener:ComputerTimeOffset.kt:ComputerTimeOffset$@HandleEvent(ProfileJoinEvent::class) fun onProfileJoin</ID>
     <ID>PrivateEventListener:ConfigGuiManager.kt:ConfigGuiManager$@HandleEvent(ConfigLoadEvent::class) fun onConfigLoad</ID>
@@ -885,12 +882,6 @@
     <ID>PrivateEventListener:DraconicSacrificeTracker.kt:DraconicSacrificeTracker$@HandleEvent fun onCommandRegistration</ID>
     <ID>PrivateEventListener:DragNDrop.kt:DragNDrop$@HandleEvent fun onGuiContainerAfterDraw</ID>
     <ID>PrivateEventListener:DragNDrop.kt:DragNDrop$@HandleEvent fun onGuiContainerBeforeDraw</ID>
-    <ID>PrivateEventListener:DragonFeatures.kt:DragonFeatures$@HandleEvent fun onConfigFix</ID>
-    <ID>PrivateEventListener:DragonFeatures.kt:DragonFeatures$@HandleEvent fun onIslandChange</ID>
-    <ID>PrivateEventListener:DragonFeatures.kt:DragonFeatures$@HandleEvent(onlyOnIsland = IslandType.THE_END) fun onChat</ID>
-    <ID>PrivateEventListener:DragonFeatures.kt:DragonFeatures$@HandleEvent(onlyOnIsland = IslandType.THE_END) fun onRender</ID>
-    <ID>PrivateEventListener:DragonFeatures.kt:DragonFeatures$@HandleEvent(onlyOnIsland = IslandType.THE_END) fun onScoreBoard</ID>
-    <ID>PrivateEventListener:DragonFeatures.kt:DragonFeatures$@HandleEvent(onlyOnIsland = IslandType.THE_END) fun onTabList</ID>
     <ID>PrivateEventListener:DragonFightAPI.kt:DragonFightAPI$@HandleEvent fun onChat</ID>
     <ID>PrivateEventListener:DragonFightAPI.kt:DragonFightAPI$@HandleEvent fun onScoreboardChange</ID>
     <ID>PrivateEventListener:DragonFightAPI.kt:DragonFightAPI$@HandleEvent fun onWorldChange</ID>
@@ -1015,11 +1006,6 @@
     <ID>PrivateEventListener:ElectionApi.kt:ElectionApi$@HandleEvent(onlyOnSkyblock = true) fun onChat</ID>
     <ID>PrivateEventListener:ElectionApi.kt:ElectionApi$@HandleEvent(onlyOnSkyblock = true) fun onInventoryFullyOpened</ID>
     <ID>PrivateEventListener:EliteDevApi.kt:EliteDevApi$@HandleEvent fun onCommandRegistration</ID>
-    <ID>PrivateEventListener:EliteFarmersLeaderboard.kt:EliteFarmersLeaderboard$@HandleEvent fun onAchievementRegistration</ID>
-    <ID>PrivateEventListener:EliteFarmersLeaderboard.kt:EliteFarmersLeaderboard$@HandleEvent fun onCropCollectionAdd</ID>
-    <ID>PrivateEventListener:EliteFarmersLeaderboard.kt:EliteFarmersLeaderboard$@HandleEvent fun onDebugDataCollect</ID>
-    <ID>PrivateEventListener:EliteFarmersLeaderboard.kt:EliteFarmersLeaderboard$@HandleEvent fun onPestKill</ID>
-    <ID>PrivateEventListener:EliteFarmersLeaderboard.kt:EliteFarmersLeaderboard$@HandleEvent(onlyOnIsland = IslandType.GARDEN) fun onSecondPassed</ID>
     <ID>PrivateEventListener:EliteLeaderboards.kt:EliteLeaderboards.EliteLeaderboardDisplayManager$@HandleEvent fun onConfigFix</ID>
     <ID>PrivateEventListener:EliteLeaderboards.kt:EliteLeaderboards.EliteLeaderboardDisplayManager$@HandleEvent fun onConfigLoad</ID>
     <ID>PrivateEventListener:EliteLeaderboards.kt:EliteLeaderboards.EliteLeaderboardDisplayManager$@HandleEvent fun onGuiRenderTop</ID>
@@ -1950,9 +1936,6 @@
     <ID>PrivateEventListener:KuudraApi.kt:KuudraApi$@HandleEvent(onlyOnSkyblock = true) fun onChat</ID>
     <ID>PrivateEventListener:KuudraApi.kt:KuudraApi$@HandleEvent(onlyOnSkyblock = true) fun onScoreboardChange</ID>
     <ID>PrivateEventListener:KuudraProfileViewerBlocker.kt:KuudraProfileViewerBlocker$@HandleEvent(onlyOnIsland = IslandType.KUUDRA_ARENA) fun onClickEntity</ID>
-    <ID>PrivateEventListener:LassoDisplay.kt:LassoDisplay$@HandleEvent fun onConfigFixEvent</ID>
-    <ID>PrivateEventListener:LassoDisplay.kt:LassoDisplay$@HandleEvent(onlyOnSkyblock = true) fun onGuiRenderOverlay</ID>
-    <ID>PrivateEventListener:LassoDisplay.kt:LassoDisplay$@OptIn(AllEntitiesGetter::class) @HandleEvent(SkyHanniTickEvent::class, onlyOnSkyblock = true) fun onTick</ID>
     <ID>PrivateEventListener:LastServers.kt:LastServers$@HandleEvent fun onSecondPassed</ID>
     <ID>PrivateEventListener:LavaReplacement.kt:LavaReplacement$@HandleEvent fun onConfigFix</ID>
     <ID>PrivateEventListener:LavaReplacement.kt:LavaReplacement$@HandleEvent fun onConfigLoad</ID>
@@ -2296,9 +2279,6 @@
     <ID>PrivateEventListener:OwnInventoryData.kt:OwnInventoryData$@HandleEvent(onlyOnSkyblock = true) fun onTick</ID>
     <ID>PrivateEventListener:OwnInventoryData.kt:OwnInventoryData$@HandleEvent(priority = HandleEvent.LOW, receiveCancelled = true, onlyOnSkyblock = true) fun onItemPickupReceivePacket</ID>
     <ID>PrivateEventListener:PabloHelper.kt:PabloHelper$@HandleEvent fun onChat</ID>
-    <ID>PrivateEventListener:PacketTest.kt:PacketTest$@HandleEvent fun onCommandRegistration</ID>
-    <ID>PrivateEventListener:PacketTest.kt:PacketTest$@HandleEvent fun onSendPacket</ID>
-    <ID>PrivateEventListener:PacketTest.kt:PacketTest$@HandleEvent(priority = HandleEvent.LOW, receiveCancelled = true) fun onPacketReceive</ID>
     <ID>PrivateEventListener:PageScrolling.kt:PageScrolling$@HandleEvent fun onInventoryOpen</ID>
     <ID>PrivateEventListener:PageScrolling.kt:PageScrolling$@HandleEvent fun onTick</ID>
     <ID>PrivateEventListener:ParkourWaypointSaver.kt:ParkourWaypointSaver$@HandleEvent fun onKeyPress</ID>
@@ -2414,8 +2394,6 @@
     <ID>PrivateEventListener:PigFeaturesApi.kt:PigFeaturesApi$@HandleEvent fun onWorldChange</ID>
     <ID>PrivateEventListener:PigFeaturesApi.kt:PigFeaturesApi$@HandleEvent(onlyOnIsland = IslandType.HUB) fun onChat</ID>
     <ID>PrivateEventListener:PigFeaturesApi.kt:PigFeaturesApi$@HandleEvent(onlyOnIsland = IslandType.HUB) fun onEntityClick</ID>
-    <ID>PrivateEventListener:PlatformUtils.kt:PlatformUtils$@HandleEvent fun onCommandRegistration</ID>
-    <ID>PrivateEventListener:PlatformUtils.kt:PlatformUtils$@HandleEvent fun onDebugDataCollect</ID>
     <ID>PrivateEventListener:PlayerChatFilter.kt:PlayerChatFilter$@HandleEvent fun onRepoReload</ID>
     <ID>PrivateEventListener:PlayerChatManager.kt:PlayerChatManager$@HandleEvent fun onChat</ID>
     <ID>PrivateEventListener:PlayerChatModifier.kt:PlayerChatModifier$@HandleEvent fun onChat</ID>
@@ -2991,7 +2969,6 @@
     <ID>PrivateEventListener:TabWidgetSettings.kt:TabWidgetSettings$@HandleEvent fun onBackgroundDrawn</ID>
     <ID>PrivateEventListener:TabWidgetSettings.kt:TabWidgetSettings$@HandleEvent fun onInventoryClose</ID>
     <ID>PrivateEventListener:TabWidgetSettings.kt:TabWidgetSettings$@HandleEvent fun onInventoryFullyOpened</ID>
-    <ID>PrivateEventListener:TeleportPadCompactName.kt:TeleportPadCompactName$@HandleEvent(priority = HandleEvent.HIGH, onlyOnIsland = IslandType.PRIVATE_ISLAND) fun onRenderLiving</ID>
     <ID>PrivateEventListener:TeleportPadInventoryNumber.kt:TeleportPadInventoryNumber$@HandleEvent fun onInventoryFullyOpened</ID>
     <ID>PrivateEventListener:TeleportPadInventoryNumber.kt:TeleportPadInventoryNumber$@HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND) fun onRenderItemTip</ID>
     <ID>PrivateEventListener:TentacleWaypoint.kt:TentacleWaypoint$@HandleEvent fun onWorldSwitch</ID>
@@ -3023,8 +3000,6 @@
     <ID>PrivateEventListener:TestExportTools.kt:TestExportTools$@HandleEvent fun onConfigFix</ID>
     <ID>PrivateEventListener:TestExportTools.kt:TestExportTools$@HandleEvent fun onGuiKeyPress</ID>
     <ID>PrivateEventListener:TestShowSlotNumber.kt:TestShowSlotNumber$@HandleEvent fun onRenderItemTip</ID>
-    <ID>PrivateEventListener:TextInput.kt:TextInput.Companion$@HandleEvent fun onChar</ID>
-    <ID>PrivateEventListener:TextInput.kt:TextInput.Companion$@HandleEvent fun onInventoryClose</ID>
     <ID>PrivateEventListener:TheGreatSpook.kt:TheGreatSpook$@HandleEvent fun onConfigLoad</ID>
     <ID>PrivateEventListener:TheGreatSpook.kt:TheGreatSpook$@HandleEvent fun onDebugDataCollect</ID>
     <ID>PrivateEventListener:TheGreatSpook.kt:TheGreatSpook$@HandleEvent fun onIslandChange</ID>

--- a/detekt/detekt.yml
+++ b/detekt/detekt.yml
@@ -91,6 +91,12 @@ style:
         maxDestructuringEntries: 5
     AbstractClassCanBeConcreteClass: # this is usually intentional
         active: false
+    UnnecessaryFullyQualifiedName:
+        active: true
+        # The Kotlin compiler will yell at you if you try to import these, but sometimes you need to use them
+        ignoredFullyQualifiedNames:
+            - 'java.lang.Boolean'
+            - 'java.lang.Enum'
 
 ktlint:
     MaximumLineLength: # ktlint - handled by detekt

--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
@@ -29,6 +29,7 @@ import at.hannibal2.skyhanni.utils.collection.CollectionUtils.enumMapOf
 import at.hannibal2.skyhanni.utils.json.BaseGsonBuilder
 import at.hannibal2.skyhanni.utils.system.PlatformUtils
 import com.google.gson.Gson
+import com.google.gson.JsonObject
 import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 import io.github.notenoughupdates.moulconfig.gui.GuiOptionEditor
@@ -72,7 +73,6 @@ class ConfigManager {
             logger.log("Loading config despite config being already loaded?")
         }
         configDirectory.mkdirs()
-
 
         for (fileType in ConfigFileType.entries) {
             val clazzInstance = fileType.clazz.getDeclaredConstructor().newInstance()
@@ -161,7 +161,7 @@ class ConfigManager {
                 logger.log("load-$fileName-now")
 
                 output = if (fileType == ConfigFileType.FEATURES) {
-                    val jsonObject = lenientGson.fromJson(text, com.google.gson.JsonObject::class.java)
+                    val jsonObject = lenientGson.fromJson(text, JsonObject::class.java)
                     val newJsonObject = ConfigUpdaterMigrator.fixConfig(jsonObject)
                     val run = { lenientGson.fromJson(newJsonObject, defaultValue.javaClass) }
                     if (PlatformUtils.isDevEnvironment) {

--- a/src/main/java/at/hannibal2/skyhanni/data/garden/EliteFarmersLeaderboard.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/garden/EliteFarmersLeaderboard.kt
@@ -8,7 +8,6 @@ import at.hannibal2.skyhanni.config.features.garden.leaderboards.EliteLeaderboar
 import at.hannibal2.skyhanni.config.features.garden.leaderboards.EliteLeaderboardConfigApi.getRankConfig
 import at.hannibal2.skyhanni.config.features.garden.leaderboards.EliteLeaderboardConfigApi.getRankGoalIfValid
 import at.hannibal2.skyhanni.config.features.garden.leaderboards.generics.EliteDisplayGenericConfig.LeaderboardTextEntry
-import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.achievements.Achievement
 import at.hannibal2.skyhanni.data.garden.CropCollectionApi.getCollection
 import at.hannibal2.skyhanni.data.garden.CropCollectionApi.setCollectionCounter
@@ -48,6 +47,7 @@ import kotlin.math.abs
 import kotlin.reflect.KClass
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -97,7 +97,7 @@ object EliteFarmersLeaderboard {
     }
 
     @HandleEvent
-    fun onCropCollectionAdd(event: CropCollectionAddEvent) {
+    private fun onCropCollectionAdd(event: CropCollectionAddEvent) {
         if (event.cropCollectionType == CropCollectionType.UNKNOWN) return
         val leaderboardType = EliteLeaderboardType.Crop(event.crop, EliteLeaderboardMode.MONTHLY)
         val currentAmount = leaderboardAmountMap?.get(leaderboardType) ?: event.amount.toDouble()
@@ -105,15 +105,15 @@ object EliteFarmersLeaderboard {
     }
 
     @HandleEvent
-    fun onPestKill(event: PestKillEvent) {
+    private fun onPestKill(event: PestKillEvent) {
         addPestKill(EliteLeaderboardType.Pest(event.pestType, EliteLeaderboardMode.ALL_TIME))
         addPestKill(EliteLeaderboardType.Pest(event.pestType, EliteLeaderboardMode.MONTHLY))
         addPestKill(EliteLeaderboardType.Pest(null, EliteLeaderboardMode.MONTHLY))
         addPestKill(EliteLeaderboardType.Pest(null, EliteLeaderboardMode.ALL_TIME))
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
-    fun onSecondPassed() {
+    @HandleEvent(onlyOnIsland = GARDEN)
+    private fun onSecondPassed() {
         if (lastPassedMessage.passedSince() < 30.seconds) return
         eliteLeaderboardData.forEach { lbType ->
             if (!getLeaderboardConfig(lbType.key).showLbChange) return@forEach
@@ -299,7 +299,7 @@ object EliteFarmersLeaderboard {
                         eliteLeaderboardData.getOrPut(leaderboardType) { EliteLeaderboardData() }.lastUpdate = SimpleTimeMark.now()
                     }
                 }
-            } catch (e: kotlinx.coroutines.TimeoutCancellationException) {
+            } catch (e: TimeoutCancellationException) {
                 apiUnavailable = true
                 throw e
             }
@@ -322,7 +322,6 @@ object EliteFarmersLeaderboard {
                 "§7(§e#${oldPosition.addSeparators()} §7-> §e#${currentPosition.addSeparators()}§7)",
         )
     }
-
 
     private suspend fun loadLeaderboardPosition(leaderboardType: EliteLeaderboardType): Int? {
         val lbData = eliteLeaderboardData.getOrPut(leaderboardType) { EliteLeaderboardData() }
@@ -527,7 +526,7 @@ object EliteFarmersLeaderboard {
     }
 
     @HandleEvent
-    fun onDebugDataCollect(event: DebugDataCollectEvent) {
+    private fun onDebugDataCollect(event: DebugDataCollectEvent) {
         event.title("elite leaderboard")
         event.addIrrelevant {
             eliteLeaderboardData.forEach {
@@ -539,7 +538,7 @@ object EliteFarmersLeaderboard {
     private const val BETTER_THAN_DEV_ACHIEVEMENT = "Better Than Dev Achievement"
 
     @HandleEvent
-    fun onAchievementRegistration(event: AchievementRegistrationEvent) {
+    private fun onAchievementRegistration(event: AchievementRegistrationEvent) {
         val achievement = Achievement(
             name = "Better than the devs".asComponent(),
             description = componentBuilder {

--- a/src/main/java/at/hannibal2/skyhanni/data/model/TextInput.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/model/TextInput.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.data.model
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.InventoryCloseEvent
+import at.hannibal2.skyhanni.events.minecraft.CharEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.KeyboardManager
 import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyClicked
@@ -17,7 +18,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable
 import kotlinx.coroutines.runBlocking
 
 open class TextInput {
-
     var textBox: String = ""
     private var carriage: Int? = null
 
@@ -77,7 +77,7 @@ open class TextInput {
         }
 
         @HandleEvent
-        fun onInventoryClose(event: InventoryCloseEvent) {
+        private fun onInventoryClose(event: InventoryCloseEvent) {
             disable()
         }
 
@@ -120,7 +120,7 @@ open class TextInput {
         }
 
         @HandleEvent
-        fun onChar(event: at.hannibal2.skyhanni.events.minecraft.CharEvent) {
+        private fun onChar(event: CharEvent) {
             handleTextInput(event.keyCode.toChar())
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/events/minecraft/packet/PacketSentEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/minecraft/packet/PacketSentEvent.kt
@@ -2,11 +2,11 @@ package at.hannibal2.skyhanni.events.minecraft.packet
 
 import at.hannibal2.skyhanni.api.event.CancellableSkyHanniEvent
 import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
+import net.minecraft.client.multiplayer.ClientPacketListener
 import net.minecraft.network.protocol.Packet
 
 @PrimaryFunction("onPacketSent")
 class PacketSentEvent(val packet: Packet<*>) : CancellableSkyHanniEvent() {
-
     fun findOriginatingModCall(skipSkyhanni: Boolean = false): StackTraceElement? {
         return Thread.currentThread().stackTrace
             // Skip calls before the event is being called
@@ -21,7 +21,7 @@ class PacketSentEvent(val packet: Packet<*>) : CancellableSkyHanniEvent() {
     }
 
     companion object {
-        private val networkClassName = net.minecraft.client.multiplayer.ClientPacketListener::class.java.name
+        private val networkClassName = ClientPacketListener::class.java.name
         private fun isNetworkHandlerClass(className: String) = className == networkClassName
 
         private fun startsWithMinecraft(string: String): Boolean {

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/end/DragonFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/end/DragonFeatures.kt
@@ -3,12 +3,9 @@ package at.hannibal2.skyhanni.features.combat.end
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
-import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.model.SkyblockStat
 import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.data.title.TitleManager
-import at.hannibal2.skyhanni.events.GuiRenderEvent
-import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.ScoreboardUpdateEvent
 import at.hannibal2.skyhanni.events.WidgetUpdateEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
@@ -31,11 +28,11 @@ import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import kotlin.properties.Delegates
+import kotlin.properties.ReadWriteProperty
 import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object DragonFeatures {
-
     private val config get() = SkyHanniMod.feature.combat.endIsland.dragon
     private val trackerConfig get() = SkyHanniMod.feature.combat.endIsland.dragon.dragonProfitTracker
     private val configProtector get() = SkyHanniMod.feature.combat.endIsland.endstoneProtectorChat
@@ -169,7 +166,7 @@ object DragonFeatures {
 
     private var dirty = false
 
-    private fun <T> dirtyTracking(initial: T): kotlin.properties.ReadWriteProperty<Any?, T> =
+    private fun <T> dirtyTracking(initial: T): ReadWriteProperty<Any?, T> =
         Delegates.observable(initial) { _, old, new ->
             if (old != new) dirty = true
         }
@@ -231,8 +228,8 @@ object DragonFeatures {
 
     private fun displayIsEnabled() = config.display && dragonSpawned
 
-    @HandleEvent(onlyOnIsland = IslandType.THE_END)
-    fun onChat(event: SkyHanniChatEvent.Allow) {
+    @HandleEvent(onlyOnIsland = THE_END)
+    private fun onChat(event: SkyHanniChatEvent.Allow) {
         val message = event.message
 
         if (!config.chat && !config.display && !config.superiorNotify && !configProtector) return
@@ -386,8 +383,8 @@ object DragonFeatures {
         )
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.THE_END)
-    fun onScoreBoard(event: ScoreboardUpdateEvent) {
+    @HandleEvent(onlyOnIsland = THE_END)
+    private fun onScoreboardUpdate(event: ScoreboardUpdateEvent) {
         val index = event.new.indexOfFirstOrNull { scoreDragonPattern.matches(it) } ?: return
         if (eggSpawned) {
             dragonSpawned = true
@@ -397,8 +394,8 @@ object DragonFeatures {
         }
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.THE_END)
-    fun onTabList(event: WidgetUpdateEvent) {
+    @HandleEvent(onlyOnIsland = THE_END)
+    private fun onTabList(event: WidgetUpdateEvent) {
         if (!event.isWidget(TabWidget.DRAGON)) return
         if (!displayIsEnabled()) return
         widgetActive = true
@@ -418,8 +415,8 @@ object DragonFeatures {
 
     private var display = listOf<Renderable>()
 
-    @HandleEvent(onlyOnIsland = IslandType.THE_END)
-    fun onRender(event: GuiRenderEvent) {
+    @HandleEvent(onlyOnIsland = THE_END)
+    private fun onGuiRender() {
         if (!displayIsEnabled()) return
         if (dirty) {
             display = if (widgetActive) display() else widgetErrorMessage
@@ -442,13 +439,13 @@ object DragonFeatures {
     )
 
     @HandleEvent
-    fun onIslandChange(event: IslandChangeEvent) {
+    private fun onWorldChange() {
         reset()
         eggSpawned = true
     }
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(78, "combat.dragon", "combat.endIsland.dragon")
         event.move(78, "combat.endstoneProtectorChat", "combat.endIsland.endstoneProtectorChat")
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/hunting/LassoDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/hunting/LassoDisplay.kt
@@ -3,8 +3,6 @@ package at.hannibal2.skyhanni.features.hunting
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
-import at.hannibal2.skyhanni.events.GuiRenderEvent
-import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.AllEntitiesGetter
 import at.hannibal2.skyhanni.utils.EntityUtils
@@ -18,16 +16,16 @@ import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
 import at.hannibal2.skyhanni.utils.toLorenzVec
+import net.minecraft.world.entity.Leashable
 import net.minecraft.world.entity.decoration.ArmorStand
 
 @SkyHanniModule
 object LassoDisplay {
-
     private val config get() = SkyHanniMod.feature.hunting
     private var display: Renderable? = null
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onGuiRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
+    private fun onGuiRenderOverlay() {
         if (!config.lassoDisplay) return
         display?.let {
             config.lassoDisplayPosition.renderRenderable(it, posLabel = "Lasso Display")
@@ -36,8 +34,8 @@ object LassoDisplay {
 
     // TODO: use entity events
     @OptIn(AllEntitiesGetter::class)
-    @HandleEvent(SkyHanniTickEvent::class, onlyOnSkyblock = true)
-    fun onTick() {
+    @HandleEvent(onlyOnSkyblock = true)
+    private fun onTick() {
         if (!config.lassoDisplay) return
         var isReel = false
         var progressBar = ""
@@ -46,7 +44,7 @@ object LassoDisplay {
             return
         }
         for (entity in EntityUtils.getAllEntities()) {
-            if (entity !is net.minecraft.world.entity.Leashable) continue
+            if (entity !is Leashable) continue
             val leashEntity = entity.leashHolder ?: continue
             if (!leashEntity.isLocalPlayer) continue
             val entitiesNearby = entity.blockPosition().toLorenzVec().up(2).getEntitiesNearby<ArmorStand>(2.0)
@@ -69,7 +67,7 @@ object LassoDisplay {
     }
 
     @HandleEvent
-    fun onConfigFixEvent(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(100, "foraging.lassoDisplay", "hunting.lassoDisplay")
         event.move(100, "foraging.lassoDisplayPosition", "hunting.lassoDisplayPosition")
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordIPC.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordIPC.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.features.misc.discordrpc
 
 import at.hannibal2.skyhanni.utils.ChatUtils
+import com.google.gson.GsonBuilder
 import com.google.gson.JsonObject
 import java.io.Closeable
 import java.io.IOException
@@ -30,7 +31,7 @@ class DiscordIPC(
 
     // We need to use our own GSON here, rather than the ConfigManager one,
     // as we need NON-null serialization, as discord does not play nice with nulls.
-    private val gson = com.google.gson.GsonBuilder().create()
+    private val gson = GsonBuilder().create()
 
     /** Whether this client is currently connected and ready for Discord IPC. */
     val isConnected: Boolean get() = _connected

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordIPCPipeManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordIPCPipeManager.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.features.misc.discordrpc
 
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.associateNotNull
+import java.io.File
 import java.nio.file.Files
 import kotlin.io.path.Path
 
@@ -15,7 +16,6 @@ import kotlin.io.path.Path
  * and surfaces an actionable message and the [DiscordIPCException.isSandboxIssue] flag.
  */
 object DiscordIPCPipeManager {
-
     private val isWindows = System.getProperty("os.name").lowercase().contains("win")
 
     /**
@@ -102,7 +102,7 @@ object DiscordIPCPipeManager {
                 isSandboxIssue = true,
             )
         }
-        if (baseDirs.none { java.io.File(it).canRead() }) return Diagnosis(
+        if (baseDirs.none { File(it).canRead() }) return Diagnosis(
             message = "No candidate runtime directories are accessible from this process. Is Discord running?",
             isSandboxIssue = false,
         )
@@ -116,7 +116,7 @@ object DiscordIPCPipeManager {
      * Returns null when not running inside a Flatpak sandbox.
      */
     private fun readFlatpakInfo(): Map<String, String>? {
-        val file = java.io.File("/.flatpak-info")
+        val file = File("/.flatpak-info")
         if (!file.exists()) return null
         return file.readLines()
             .filter { '=' in it && !it.startsWith('[') }
@@ -127,15 +127,15 @@ object DiscordIPCPipeManager {
 
     private fun resolveUid(): String? =
         System.getenv("XDG_RUNTIME_DIR")?.substringAfterLast('/')?.takeIf { it.isNotEmpty() && it.all(Char::isDigit) }
-            ?: runCatching { java.io.File("/proc/self/loginuid").readText().trim() }.getOrNull()
+            ?: runCatching { File("/proc/self/loginuid").readText().trim() }.getOrNull()
             ?: runCatching {
-                java.io.File("/proc/self/status").useLines { lines ->
+                File("/proc/self/status").useLines { lines ->
                     lines.firstOrNull { it.startsWith("Uid:") }?.split("\t")?.getOrNull(1)
                 }
             }.getOrNull()
 
     private fun readProcEnviron(): Map<String, String> = runCatching {
-        java.io.File("/proc/self/environ").readBytes()
+        File("/proc/self/environ").readBytes()
             .toString(Charsets.UTF_8)
             .split('\u0000')
             .associateNotNull { entry ->

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordStatus.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/discordrpc/DiscordStatus.kt
@@ -40,6 +40,7 @@ import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.TimeUtils.formatted
 import at.hannibal2.skyhanni.utils.compat.getCompoundOrDefault
 import at.hannibal2.skyhanni.utils.compat.getIntOrDefault
+import java.util.Locale
 import kotlin.time.Duration.Companion.minutes
 
 // There is no consistent way to get the full username of the owner of an island you are visiting (as far as I know)
@@ -160,7 +161,7 @@ enum class DiscordStatus(private val displayMessageSupplier: DiscordStatus.() ->
             val heldItemName = heldItem?.cleanName
 
             if (heldItem == null || heldItemName == "Air") "No item in hand"
-            else String.format(java.util.Locale.US, "Holding $heldItemName")
+            else String.format(Locale.US, "Holding $heldItemName")
         },
     ),
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/teleportpad/TeleportPadCompactName.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/teleportpad/TeleportPadCompactName.kt
@@ -2,12 +2,12 @@ package at.hannibal2.skyhanni.features.misc.teleportpad
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.SkyHanniRenderEntityEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import net.minecraft.network.chat.Component
 import net.minecraft.world.entity.decoration.ArmorStand
 
 @SkyHanniModule
@@ -30,8 +30,8 @@ object TeleportPadCompactName {
         "§.✦ §cNo Destination",
     )
 
-    @HandleEvent(priority = HandleEvent.HIGH, onlyOnIsland = IslandType.PRIVATE_ISLAND)
-    fun onRenderLiving(event: SkyHanniRenderEntityEvent.Specials.Pre<ArmorStand>) {
+    @HandleEvent(onlyOnIsland = PRIVATE_ISLAND, priority = HandleEvent.HIGH)
+    private fun onRenderLiving(event: SkyHanniRenderEntityEvent.Specials.Pre<ArmorStand>) {
         if (!SkyHanniMod.feature.misc.teleportPad.compactName) return
         val entity = event.entity
 
@@ -42,7 +42,7 @@ object TeleportPadCompactName {
         }
 
         namePattern.matchMatcher(name) {
-            entity.customName = net.minecraft.network.chat.Component.literal(group("name"))
+            entity.customName = Component.literal(group("name"))
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/init/SkyHanniMixinPlugin.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/init/SkyHanniMixinPlugin.java
@@ -1,9 +1,9 @@
 package at.hannibal2.skyhanni.mixins.init;
 
+import org.objectweb.asm.tree.ClassNode;
 import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
 import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
 import org.spongepowered.asm.mixin.injection.InjectionPoint;
-
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -43,7 +43,6 @@ public class SkyHanniMixinPlugin implements IMixinConfigPlugin {
 
     @Override
     public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
-
     }
 
     public URL baseUrl(URL classUrl) {
@@ -136,11 +135,11 @@ public class SkyHanniMixinPlugin implements IMixinConfigPlugin {
     }
 
     @Override
-    public void preApply(String targetClassName, org.objectweb.asm.tree.ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
     }
 
     @Override
-    public void postApply(String targetClassName, org.objectweb.asm.tree.ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
         appliedMixins.add(mixinClassName);
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/test/PacketTest.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/PacketTest.kt
@@ -19,20 +19,29 @@ import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.toLorenzVec
 import net.minecraft.network.protocol.Packet
 import net.minecraft.network.protocol.common.ClientboundKeepAlivePacket
+import net.minecraft.network.protocol.common.ClientboundPingPacket
 import net.minecraft.network.protocol.common.ServerboundKeepAlivePacket
+import net.minecraft.network.protocol.common.ServerboundPongPacket
 import net.minecraft.network.protocol.game.ClientboundAddEntityPacket
 import net.minecraft.network.protocol.game.ClientboundAnimatePacket
+import net.minecraft.network.protocol.game.ClientboundBlockEventPacket
 import net.minecraft.network.protocol.game.ClientboundBlockUpdatePacket
+import net.minecraft.network.protocol.game.ClientboundBossEventPacket
+import net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket
 import net.minecraft.network.protocol.game.ClientboundEntityEventPacket
+import net.minecraft.network.protocol.game.ClientboundEntityPositionSyncPacket
+import net.minecraft.network.protocol.game.ClientboundForgetLevelChunkPacket
 import net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket
 import net.minecraft.network.protocol.game.ClientboundLevelEventPacket
 import net.minecraft.network.protocol.game.ClientboundLevelParticlesPacket
 import net.minecraft.network.protocol.game.ClientboundMoveEntityPacket
 import net.minecraft.network.protocol.game.ClientboundOpenSignEditorPacket
+import net.minecraft.network.protocol.game.ClientboundPlayerInfoRemovePacket
 import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket
 import net.minecraft.network.protocol.game.ClientboundRemoveEntitiesPacket
 import net.minecraft.network.protocol.game.ClientboundRotateHeadPacket
 import net.minecraft.network.protocol.game.ClientboundSectionBlocksUpdatePacket
+import net.minecraft.network.protocol.game.ClientboundSetChunkCacheCenterPacket
 import net.minecraft.network.protocol.game.ClientboundSetEntityDataPacket
 import net.minecraft.network.protocol.game.ClientboundSetEntityLinkPacket
 import net.minecraft.network.protocol.game.ClientboundSetEntityMotionPacket
@@ -48,6 +57,7 @@ import net.minecraft.network.protocol.game.ClientboundSystemChatPacket
 import net.minecraft.network.protocol.game.ClientboundTeleportEntityPacket
 import net.minecraft.network.protocol.game.ClientboundUpdateAttributesPacket
 import net.minecraft.network.protocol.game.ClientboundUpdateMobEffectPacket
+import net.minecraft.network.protocol.game.ServerboundClientTickEndPacket
 import net.minecraft.network.protocol.game.ServerboundMovePlayerPacket
 import net.minecraft.network.protocol.game.ServerboundMovePlayerPacket.Pos
 import net.minecraft.network.protocol.game.ServerboundMovePlayerPacket.PosRot
@@ -61,7 +71,6 @@ import net.minecraft.network.protocol.game.ClientboundMoveEntityPacket.Rot as En
 
 @SkyHanniModule
 object PacketTest {
-
     private var enabled = false
     private var full = false
 
@@ -79,7 +88,7 @@ object PacketTest {
     }
 
     @HandleEvent
-    fun onSendPacket(event: PacketSentEvent) {
+    private fun onPacketSent(event: PacketSentEvent) {
         if (!enabled) return
 
         val packet = event.packet
@@ -92,15 +101,15 @@ object PacketTest {
         if (packetName == PosRot::class.simpleName) return
         if (packetName == ServerboundPlayerCommandPacket::class.simpleName) return
         if (packetName == Rot::class.simpleName) return
-        if (packetName == net.minecraft.network.protocol.common.ServerboundPongPacket::class.simpleName) return
-        if (packetName == net.minecraft.network.protocol.game.ServerboundClientTickEndPacket::class.simpleName) return
+        if (packetName == ServerboundPongPacket::class.simpleName) return
+        if (packetName == ServerboundClientTickEndPacket::class.simpleName) return
         if (packetName == ServerboundMovePlayerPacket::class.simpleName) return
 
         println("Send: [$packetName]")
     }
 
     @HandleEvent(priority = HandleEvent.LOW, receiveCancelled = true)
-    fun onPacketReceive(event: PacketReceivedEvent) {
+    private fun onPacketReceived(event: PacketReceivedEvent) {
         if (!enabled) return
         val packet = event.packet
         packet.print()
@@ -120,8 +129,8 @@ object PacketTest {
         // Keep alive
         if (packetName == ClientboundKeepAlivePacket::class.simpleName) return
         if (packetName == ServerboundKeepAlivePacket::class.simpleName) return
-        if (packetName == net.minecraft.network.protocol.common.ClientboundPingPacket::class.simpleName) return
-        if (packetName == net.minecraft.network.protocol.game.ClientboundPlayerInfoRemovePacket::class.simpleName) return
+        if (packetName == ClientboundPingPacket::class.simpleName) return
+        if (packetName == ClientboundPlayerInfoRemovePacket::class.simpleName) return
 
         // Gui
         if (packetName == ClientboundSetObjectivePacket::class.simpleName) return
@@ -137,9 +146,9 @@ object PacketTest {
         if (packetName == ClientboundLevelChunkWithLightPacket::class.simpleName) return
         if (packetName == ClientboundSectionBlocksUpdatePacket::class.simpleName) return
         if (packetName == ClientboundBlockUpdatePacket::class.simpleName) return
-        if (packetName == net.minecraft.network.protocol.game.ClientboundBlockEventPacket::class.simpleName) return
-        if (packetName == net.minecraft.network.protocol.game.ClientboundForgetLevelChunkPacket::class.simpleName) return
-        if (packetName == net.minecraft.network.protocol.game.ClientboundSetChunkCacheCenterPacket::class.simpleName) return
+        if (packetName == ClientboundBlockEventPacket::class.simpleName) return
+        if (packetName == ClientboundForgetLevelChunkPacket::class.simpleName) return
+        if (packetName == ClientboundSetChunkCacheCenterPacket::class.simpleName) return
 
         // Chat
         if (packetName == ClientboundSystemChatPacket::class.simpleName) return
@@ -147,7 +156,7 @@ object PacketTest {
         // Others
         if (packetName == ClientboundSoundPacket::class.simpleName) return
         if (!full && packetName == ClientboundLevelParticlesPacket::class.simpleName) return
-        if (packetName == net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket::class.simpleName) return
+        if (packetName == ClientboundContainerSetSlotPacket::class.simpleName) return
 
         // Entity
         if (this is ClientboundRemoveEntitiesPacket) {
@@ -162,8 +171,8 @@ object PacketTest {
             if (packetName == EntityLookMove::class.simpleName) return
             if (packetName == ClientboundRotateHeadPacket::class.simpleName) return
             if (packetName == EntityLook::class.simpleName) return
-            if (packetName == net.minecraft.network.protocol.game.ClientboundBossEventPacket::class.simpleName) return
-            if (packetName == net.minecraft.network.protocol.game.ClientboundEntityPositionSyncPacket::class.simpleName) return
+            if (packetName == ClientboundBossEventPacket::class.simpleName) return
+            if (packetName == ClientboundEntityPositionSyncPacket::class.simpleName) return
             if (packetName == ClientboundSetEntityMotionPacket::class.simpleName) return
             if (packetName == ClientboundSetEntityDataPacket::class.simpleName) return
             if (packetName == ClientboundUpdateAttributesPacket::class.simpleName) return
@@ -270,7 +279,7 @@ object PacketTest {
     }
 
     @HandleEvent
-    fun onCommandRegistration(event: CommandRegistrationEvent) {
+    private fun onCommandRegistration(event: CommandRegistrationEvent) {
         event.registerBrigadier("shtestpacket") {
             description = "Logs incoming and outgoing packets to the console"
             category = CommandCategory.DEVELOPER_TEST

--- a/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditorHistory.kt
+++ b/src/main/java/at/hannibal2/skyhanni/test/graph/GraphEditorHistory.kt
@@ -10,9 +10,10 @@ import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.chat.TextHelper.send
 import org.lwjgl.glfw.GLFW
+import java.awt.Color
+import java.util.Stack
 
 object GraphEditorHistory {
-
     private val undoRedoMessageId = ChatUtils.getUniqueMessageId()
 
     private data class HistoryEntry(
@@ -21,8 +22,8 @@ object GraphEditorHistory {
         val playerPos: LorenzVec,
     )
 
-    private val undoStack = java.util.Stack<HistoryEntry>()
-    private val redoStack = java.util.Stack<HistoryEntry>()
+    private val undoStack = Stack<HistoryEntry>()
+    private val redoStack = Stack<HistoryEntry>()
 
     fun save(label: String) {
         val currentPos = GraphUtils.playerPosition
@@ -90,7 +91,7 @@ object GraphEditorHistory {
         IslandGraphs.pathFind(
             entry.playerPos,
             "$type: ${entry.label}",
-            java.awt.Color.ORANGE,
+            Color.ORANGE,
             condition = { isEnabled() },
         )
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/ComputerEnvDebug.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ComputerEnvDebug.kt
@@ -13,6 +13,8 @@ import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.system.PlatformUtils
+import com.sun.management.OperatingSystemMXBean
+import net.fabricmc.loader.api.FabricLoader
 import java.lang.management.ManagementFactory
 import kotlin.math.roundToInt
 import kotlin.time.Duration.Companion.hours
@@ -20,7 +22,6 @@ import kotlin.time.Duration.Companion.milliseconds
 
 @SkyHanniModule
 object ComputerEnvDebug {
-
     private var launchers: List<LauncherEntry> = listOf()
     private var genericStacks: List<String> = listOf()
 
@@ -83,7 +84,7 @@ object ComputerEnvDebug {
         }
     }
 
-    private fun getFirstStack(): String? = kotlin.runCatching {
+    private fun getFirstStack(): String? = runCatching {
         Thread.currentThread().stackTrace.last().toString()
     }.onFailure { e ->
         ErrorManager.logErrorWithData(e, "Failed loading current thread stack trace info")
@@ -129,7 +130,7 @@ object ComputerEnvDebug {
         text.add("Minecraft Allocated: $allocatedPercentage% ${totalMemoryGB.formatGB()} GB")
 
         // Get total system memory using OS-specific APIs
-        val osBean = ManagementFactory.getOperatingSystemMXBean() as com.sun.management.OperatingSystemMXBean
+        val osBean = ManagementFactory.getOperatingSystemMXBean() as OperatingSystemMXBean
         val totalPhysicalMemory = osBean.totalMemorySize
         val freePhysicalMemory = osBean.freeMemorySize
         val usedPhysicalMemory = totalPhysicalMemory - freePhysicalMemory
@@ -197,7 +198,7 @@ object ComputerEnvDebug {
     private fun DebugDataCollectEvent.performanceMods() {
         if (PlatformUtils.isDevEnvironment) return
         title("Performance Mods")
-        val hasSodium = net.fabricmc.loader.api.FabricLoader.getInstance().isModLoaded("sodium")
+        val hasSodium = FabricLoader.getInstance().isModLoaded("sodium")
         if (!hasSodium) {
             addData {
                 add("Sodium is not installed")

--- a/src/main/java/at/hannibal2/skyhanni/utils/KSerializable.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/KSerializable.kt
@@ -32,7 +32,6 @@ annotation class KSerializable
 annotation class ExtraData
 
 class KotlinTypeAdapterFactory : TypeAdapterFactory {
-
     internal data class ParameterInfo(
         val param: KParameter,
         val adapter: TypeAdapter<Any?>,
@@ -57,7 +56,7 @@ class KotlinTypeAdapterFactory : TypeAdapterFactory {
             }
         val parameterInfos = params.mapNotNull { param ->
             val field = kotlinClass.memberProperties.single { it.name == param.name } as KProperty1<Any, Any?>
-            kotlin.runCatching {
+            runCatching {
                 field.isAccessible = true
             }.getOrNull() ?: return@mapNotNull null
             val kType = field.returnType

--- a/src/main/java/at/hannibal2/skyhanni/utils/NumberUtil.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NumberUtil.kt
@@ -9,9 +9,9 @@ import java.util.Locale
 import java.util.TreeMap
 import kotlin.math.absoluteValue
 import kotlin.math.pow
+import kotlin.math.round
 
 object NumberUtil {
-
     private val config get() = SkyHanniMod.feature
 
     private val suffixes = TreeMap<Long, String>().apply {
@@ -90,7 +90,7 @@ object NumberUtil {
      */
     fun Double.roundTo(precision: Int): Double {
         val scale = 10.0.pow(precision)
-        return kotlin.math.round(this * scale) / scale
+        return round(this * scale) / scale
     }
 
     fun Float.roundTo(precision: Int): Float = toDouble().roundTo(precision).toFloat()

--- a/src/main/java/at/hannibal2/skyhanni/utils/compat/TextCompat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/compat/TextCompat.kt
@@ -10,12 +10,14 @@ import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
+import com.mojang.serialization.JsonOps
 import net.minecraft.ChatFormatting
 import net.minecraft.client.Minecraft
 import net.minecraft.client.multiplayer.chat.GuiMessageSource
 import net.minecraft.client.multiplayer.chat.GuiMessageTag
 import net.minecraft.network.chat.ClickEvent
 import net.minecraft.network.chat.Component
+import net.minecraft.network.chat.ComponentSerialization
 import net.minecraft.network.chat.HoverEvent
 import net.minecraft.network.chat.MessageSignature
 import net.minecraft.network.chat.MutableComponent
@@ -314,7 +316,6 @@ fun ClickEvent.value(): String {
         // todo use error manager here probably, not doing it now because it doesn't compile on 1.21
         else -> ""
     }
-
 }
 
 fun HoverEvent.value(): Component = when (action()) {
@@ -344,8 +345,8 @@ fun Component.changeColor(color: LorenzColor): Component {
 }
 
 fun Component.convertToJsonString(): String {
-    return net.minecraft.network.chat.ComponentSerialization.CODEC.encodeStart(
-        com.mojang.serialization.JsonOps.INSTANCE,
+    return ComponentSerialization.CODEC.encodeStart(
+        JsonOps.INSTANCE,
         this,
     ).orThrow.toString()
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/SkyHanniRenderLayers.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/SkyHanniRenderLayers.kt
@@ -1,17 +1,18 @@
 package at.hannibal2.skyhanni.utils.render
 
+import com.mojang.blaze3d.pipeline.RenderPipeline
 import net.minecraft.client.renderer.rendertype.LayeringTransform
 import net.minecraft.client.renderer.rendertype.RenderSetup
 import net.minecraft.client.renderer.rendertype.RenderType
 import net.minecraft.resources.Identifier
 import net.minecraft.util.Util
+import java.util.function.Function
 
 //? if < 26.2 {
 /*import at.hannibal2.skyhanni.utils.render.layers.ChromaRenderLayer
 *///?}
 
 object SkyHanniRenderLayers {
-
     private val FILLED: RenderType = RenderType.create(
         "skyhanni_filled",
         RenderSetup.builder(SkyHanniRenderPipeline.FILLED()).createRenderSetup(),
@@ -52,7 +53,7 @@ object SkyHanniRenderLayers {
         RenderSetup.builder(SkyHanniRenderPipeline.QUADS_XRAY()).createRenderSetup(),
     )
 
-    private val CHROMA_TEXTURED: java.util.function.Function<Identifier, RenderType> = Util.memoize { texture ->
+    private val CHROMA_TEXTURED: Function<Identifier, RenderType> = Util.memoize { texture ->
         //~ if < 26.2 'RenderType.create' -> 'ChromaRenderLayer'
         RenderType.create(
             "skyhanni_text_chroma",
@@ -101,7 +102,6 @@ object SkyHanniRenderLayers {
 
     fun getChromaTexturedWithIdentifier(identifier: Identifier) = CHROMA_TEXTURED.apply(identifier)
 
-    fun getChromaStandard(): com.mojang.blaze3d.pipeline.RenderPipeline = SkyHanniRenderPipeline.CHROMA_STANDARD()
-    fun getChromaTextured(): com.mojang.blaze3d.pipeline.RenderPipeline = SkyHanniRenderPipeline.CHROMA_TEXT()
-
+    fun getChromaStandard(): RenderPipeline = SkyHanniRenderPipeline.CHROMA_STANDARD()
+    fun getChromaTextured(): RenderPipeline = SkyHanniRenderPipeline.CHROMA_TEXT()
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/system/PlatformUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/system/PlatformUtils.kt
@@ -10,6 +10,7 @@ import at.hannibal2.skyhanni.utils.MarkdownBuilder
 import at.hannibal2.skyhanni.utils.OSUtils
 import at.hannibal2.skyhanni.utils.VersionConstants
 import net.fabricmc.loader.api.FabricLoader
+import net.minecraft.SharedConstants
 import kotlin.system.exitProcess
 
 /**
@@ -18,8 +19,7 @@ import kotlin.system.exitProcess
  */
 @SkyHanniModule
 object PlatformUtils {
-
-    val MC_VERSION: String = net.minecraft.SharedConstants.getCurrentVersion().name()
+    val MC_VERSION: String = SharedConstants.getCurrentVersion().name()
 
     @JvmStatic
     @get:JvmName("isDevEnvironment")
@@ -33,7 +33,7 @@ object PlatformUtils {
     )
 
     @HandleEvent
-    fun onCommandRegistration(event: CommandRegistrationEvent) {
+    private fun onCommandRegistration(event: CommandRegistrationEvent) {
         event.registerBrigadier("shmodlist") {
             description = "Get a Discord-formatted list of all loaded mods"
             category = CommandCategory.USERS_ACTIVE
@@ -52,7 +52,7 @@ object PlatformUtils {
     }
 
     @HandleEvent
-    fun onDebugDataCollect(event: DebugDataCollectEvent) {
+    private fun onDebugDataCollect(event: DebugDataCollectEvent) {
         event.title("Loaded Mods")
         event.addIrrelevant {
             getLoadedMods().forEach { (_, name, version, origin) ->


### PR DESCRIPTION
## Dependencies
- #6289

## What
This PR enables the Detekt rule to forbid unnecessary use of fully qualified names and fixes all existing violations (including the one I found via grepping in a Java file, since we don't have Java linting yet).

## Changelog Technical Details
+ Banned unnecessary use of fully qualified names in favor of importing them. - Luna