### PR TITLE
Fix: Add new attribute shards to Pest Profit Tracker

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestType.kt
@@ -14,6 +14,7 @@ enum class PestType(
     val vinyl: VinylType?,
     val internalName: NeuInternalName,
     val crop: CropType?,
+    val attributeShard: NeuInternalName?,
     val pluralName: String? = "${displayName}s",
     val eliteLbName: String = displayName.lowercase(),
 ) {
@@ -24,6 +25,7 @@ enum class PestType(
         VinylType.NOT_JUST_A_PEST,
         "PEST_BEETLE_MONSTER".toInternalName(),
         CropType.NETHER_WART,
+        "ATTRIBUTE_SHARD_CROP_BUG;1".toInternalName(),
     ),
     CRICKET(
         "Cricket",
@@ -32,6 +34,7 @@ enum class PestType(
         VinylType.CRICKET_CHOIR,
         "PEST_CRICKET_MONSTER".toInternalName(),
         CropType.CARROT,
+        "ATTRIBUTE_SHARD_PEST_FORTUNE;1".toInternalName(),
     ),
     EARTHWORM(
         "Earthworm",
@@ -40,6 +43,7 @@ enum class PestType(
         VinylType.EARTHWORM_ENSEMBLE,
         "PEST_EARTHWORM_MONSTER".toInternalName(),
         CropType.MELON,
+        "ATTRIBUTE_SHARD_INFILTRATION;1".toInternalName(),
     ),
     FIELD_MOUSE(
         "Field Mouse",
@@ -48,6 +52,7 @@ enum class PestType(
         vinyl = null,
         "PEST_FIELD_MOUSE_MONSTER".toInternalName(),
         crop = null,
+        "ATTRIBUTE_SHARD_PEST_LUCK;1".toInternalName(),
         pluralName = "Field Mice",
         eliteLbName = "mouse",
     ),
@@ -58,6 +63,7 @@ enum class PestType(
         VinylType.PRETTY_FLY,
         "PEST_FLY_MONSTER".toInternalName(),
         CropType.WHEAT,
+        "ATTRIBUTE_SHARD_FORTUNATE_FARMER;1".toInternalName(),
         pluralName = "Flies",
     ),
     LOCUST(
@@ -67,6 +73,7 @@ enum class PestType(
         VinylType.CICADA_SYMPHONY,
         "PEST_LOCUST_MONSTER".toInternalName(),
         CropType.POTATO,
+        "ATTRIBUTE_SHARD_CROP_SPEED;1".toInternalName(),
     ),
     LUNAR_MOTH(
         "Lunar Moth",
@@ -75,6 +82,7 @@ enum class PestType(
         vinyl = null,
         "PEST_LUNAR_MOTH_MONSTER".toInternalName(),
         crop = null, // Always drops Sunflower, Moonflower, *and* Wild Rose
+        "ATTRIBUTE_SHARD_LUNAR_POWER;1".toInternalName(),
         eliteLbName = "lunar-moth",
     ),
     MITE(
@@ -84,6 +92,7 @@ enum class PestType(
         VinylType.DYNAMITES,
         "PEST_MITE_MONSTER".toInternalName(),
         CropType.CACTUS,
+        "ATTRIBUTE_SHARD_FILTER_UPGRADE;1".toInternalName(),
     ),
     MOSQUITO(
         "Mosquito",
@@ -92,6 +101,7 @@ enum class PestType(
         VinylType.BUZZIN_BEATS,
         "PEST_MOSQUITO_MONSTER".toInternalName(),
         CropType.SUGAR_CANE,
+        "ATTRIBUTE_SHARD_ENCHANTED_FARMER;1".toInternalName(),
         pluralName = "Mosquitoes",
     ),
     MOTH(
@@ -101,6 +111,7 @@ enum class PestType(
         VinylType.WINGS_OF_HARMONY,
         "PEST_MOTH_MONSTER".toInternalName(),
         CropType.COCOA_BEANS,
+        "ATTRIBUTE_SHARD_PEST_COOLDOWN;1".toInternalName(),
     ),
     RAT(
         "Rat",
@@ -109,6 +120,7 @@ enum class PestType(
         VinylType.RODENT_REVOLUTION,
         "PEST_RAT_MONSTER".toInternalName(),
         CropType.PUMPKIN,
+        "ATTRIBUTE_SHARD_SPRAYONATOR_SERENDIPITY;1".toInternalName(),
     ),
     SLUG(
         "Slug",
@@ -117,6 +129,7 @@ enum class PestType(
         VinylType.SLOW_AND_GROOVY,
         "PEST_SLUG_MONSTER".toInternalName(),
         CropType.MUSHROOM,
+        "ATTRIBUTE_SHARD_BONUS_PEST_CHANCE;1".toInternalName(),
     ),
     PRAYING_MANTIS(
         "Praying Mantis",
@@ -125,6 +138,7 @@ enum class PestType(
         VinylType.PRAY_FOR_ME,
         "PEST_PRAYING_MANTIS_MONSTER".toInternalName(),
         CropType.WILD_ROSE,
+        "ATTRIBUTE_SHARD_INSECT_POWER;1".toInternalName(),
         pluralName = "Praying Mantises",
         eliteLbName = "mantis",
     ),
@@ -135,6 +149,7 @@ enum class PestType(
         VinylType.FIREFLY_IN_THE_HOLE,
         "PEST_FIREFLY_MONSTER".toInternalName(),
         CropType.MOONFLOWER,
+        "ATTRIBUTE_SHARD_SOLAR_POWER;1".toInternalName(),
     ),
     DRAGONFLY(
         "Dragonfly",
@@ -143,6 +158,7 @@ enum class PestType(
         VinylType.IMAGINE_DRAGONFLIES,
         "PEST_DRAGONFLY_MONSTER".toInternalName(),
         CropType.SUNFLOWER,
+        "ATTRIBUTE_SHARD_GARDEN_WISDOM;1".toInternalName(),
     ),
 
     // TODO replace with null
@@ -154,6 +170,7 @@ enum class PestType(
         spray = null,
         vinyl = null,
         "DUMMY".toInternalName(),
+        attributeShard = null,
         crop = null,
     ),
     ;
@@ -284,6 +301,10 @@ enum class PestType(
             it.key.toInternalName() to it.value
         }.toMap()
 
-        fun getByItemInternalNameOrNull(internalName: NeuInternalName): PestType? = internalNameRareDropMap[internalName]
+        fun getByItemInternalNameOrNull(internalName: NeuInternalName): PestType? = when {
+            internalName.asString().startsWith("ATTRIBUTE_SHARD_") ->
+                PestType.entries.firstOrNull { it.attributeShard == internalName }
+            else -> internalNameRareDropMap[internalName]
+        }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/PestProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/tracker/PestProfitTracker.kt
@@ -32,6 +32,7 @@ import at.hannibal2.skyhanni.features.garden.tracker.PestProfitTracker.drawDispl
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ConditionalUtils
+import at.hannibal2.skyhanni.utils.EnumUtils.isAnyOf
 import at.hannibal2.skyhanni.utils.ItemPriceSource
 import at.hannibal2.skyhanni.utils.ItemUtils.itemNameWithoutColor
 import at.hannibal2.skyhanni.utils.NeuInternalName
@@ -88,8 +89,8 @@ object PestProfitTracker : SkyHanniBucketedItemTracker<PestType, PestProfitTrack
      * REGEX-TEST: §6§lRARE DROP! §r§aNot Just a Pest Vinyl §r§6(Cocoaleech)
      * REGEX-FAIL: §6§lRARE CROP! §aCane Knot §e(§e+139.5)
      */
-    // TODO consider if we want to add Harvest Feast drops to Pest Profit Tracker - we need a way to distinguish drops
-    //  from breaking crops vs. killing pests since they use the same message
+    // Harvest Feast drops are handled elsewhere; they're added here if determined to come from a pest.
+    // This pattern intentionally does not match them.
     @Suppress("MaxLineLength")
     private val pestRareDropPattern by patternGroup.pattern(
         "raredrop",
@@ -101,7 +102,6 @@ object PestProfitTracker : SkyHanniBucketedItemTracker<PestType, PestProfitTrack
     val OVERCLOCKER = "OVERCLOCKER_3000".toInternalName()
     val BITS = "SKYBLOCK_BIT".toInternalName()
     const val KILL_BITS = 5
-    private val PEST_SHARD = "ATTRIBUTE_SHARD_PEST_LUCK;1".toInternalName()
 
     private val noMessageDrops = setOf(
         "PESTERMINATOR;1",
@@ -253,8 +253,9 @@ object PestProfitTracker : SkyHanniBucketedItemTracker<PestType, PestProfitTrack
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     fun onShardGain(event: ShardGainEvent) {
-        if (event.shardInternalName != PEST_SHARD) return
-        addItem(PestType.UNKNOWN, PEST_SHARD, event.amount, command = false)
+        if (!event.source.isAnyOf(CHARM, HUNT)) return
+        val pestType = PestType.getByItemInternalNameOrNull(event.shardInternalName) ?: return
+        addItem(pestType, event.shardInternalName, event.amount, command = false)
     }
 
     private fun SkyHanniChatEvent.Allow.checkSprayChats() {


### PR DESCRIPTION
## What
Torrhus Canyon replaced the universal Pest Shard with an individual attribute shard for each pest. This PR adds support for those to the Pest Profit Tracker.

## Changelog Fixes
+ Fixed new Attribute Shards from Pests not being tracked by Pest Profit Tracker. - Luna