### PR TITLE
Backend: Print logger errors to the console in the dev environment

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigManager.kt
@@ -168,10 +168,11 @@ class ConfigManager {
                         try {
                             run()
                         } catch (e: Throwable) {
-                            logger.log(e.stackTraceToString())
+                            logger.logError("Failed to read $fileName from $file", e)
                             PlatformUtils.shutdownMinecraft(
                                 "Config is corrupt inside development environment. " +
-                                    "Maybe you forgot to implement a config migration, or the migration failed."
+                                    "Maybe you forgot to implement a config migration, or the migration failed. " +
+                                    "Cause: ${e.message}",
                             )
                         }
                     } else {
@@ -183,21 +184,17 @@ class ConfigManager {
 
                 logger.log("Loaded $fileName from file")
             } catch (e: Exception) {
-                logger.log(e.stackTraceToString())
                 val backupFile = file.resolveSibling("$fileName-${SimpleTimeMark.now().toMillis()}-backup.json")
-                logger.log("Exception while reading $file. Will load blank $fileName and save backup to $backupFile")
-                logger.log("Exception was $e")
+                logger.logError(
+                    "Exception while reading $file. Will load blank $fileName and save backup to $backupFile",
+                    e,
+                )
                 try {
                     file.copyTo(backupFile)
                 } catch (e: Exception) {
-                    logger.log("Could not create backup for $fileName file")
-                    logger.log(e.stackTraceToString())
+                    logger.logError("Could not create backup for $fileName file", e)
                 }
             }
-        }
-
-        if (output == defaultValue) {
-            logger.log("Setting $fileName to be blank as it did not exist. It will be saved once something is written to it")
         }
         if (output == null) {
             logger.log("Setting $fileName to be blank as it was null. It will be saved once something is written to it")
@@ -232,8 +229,7 @@ class ConfigManager {
                 "fileName" to fileName,
             )
         } catch (e: IOException) {
-            logger.log("Could not save $fileName file to $file")
-            logger.log(e.stackTraceToString())
+            logger.logError("Could not save $fileName file to $file", e)
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/data/OtherInventoryData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/OtherInventoryData.kt
@@ -9,6 +9,7 @@ import at.hannibal2.skyhanni.events.minecraft.packet.PacketReceivedEvent
 import at.hannibal2.skyhanni.events.minecraft.packet.PacketSentEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.compat.InventoryCompat.isNotEmpty
 import at.hannibal2.skyhanni.utils.compat.unformattedTextCompat
@@ -41,13 +42,23 @@ object OtherInventoryData {
         }
     }
 
+    // TEMP DEBUG, remove before committing
+    private var debugTick = 0
+
     fun close(title: String = currentInventoryName, reopenSameName: Boolean = false) {
+        // TEMP DEBUG, remove before committing
+        println(
+            "SH-INV-ORDER | CLOSE | tick $debugTick | window ${currentInventory?.windowId} " +
+                "| title '$title' | reopen $reopenSameName | thread ${Thread.currentThread().name}",
+        )
         InventoryCloseEvent(title, reopenSameName).post()
         currentInventory = null
     }
 
     @HandleEvent
     fun onTick() {
+        // TEMP DEBUG, remove before committing
+        debugTick++
         lateEvent?.let {
             it.post()
             lateEvent = null
@@ -163,6 +174,19 @@ object OtherInventoryData {
     }
 
     private fun done(inventory: Inventory) {
+        // TEMP DEBUG, remove before committing
+        val debugWindowId = inventory.windowId
+        println(
+            "SH-INV-ORDER | OPEN  | tick $debugTick | window $debugWindowId " +
+                "| title '${inventory.title}' | thread ${Thread.currentThread().name}",
+        )
+        DelayedRun.runOrNextTick {
+            println(
+                "SH-INV-ORDER | BLOCK | tick $debugTick | window $debugWindowId " +
+                    "| current window ${currentInventory?.windowId} | thread ${Thread.currentThread().name}",
+            )
+        }
+
         InventoryFullyOpenedEvent(inventory).post()
         inventory.fullyOpenedOnce = true
         InventoryUpdatedEvent(inventory).post()

--- a/src/main/java/at/hannibal2/skyhanni/data/OtherInventoryData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/OtherInventoryData.kt
@@ -9,7 +9,6 @@ import at.hannibal2.skyhanni.events.minecraft.packet.PacketReceivedEvent
 import at.hannibal2.skyhanni.events.minecraft.packet.PacketSentEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
-import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.compat.InventoryCompat.isNotEmpty
 import at.hannibal2.skyhanni.utils.compat.unformattedTextCompat
@@ -42,23 +41,13 @@ object OtherInventoryData {
         }
     }
 
-    // TEMP DEBUG, remove before committing
-    private var debugTick = 0
-
     fun close(title: String = currentInventoryName, reopenSameName: Boolean = false) {
-        // TEMP DEBUG, remove before committing
-        println(
-            "SH-INV-ORDER | CLOSE | tick $debugTick | window ${currentInventory?.windowId} " +
-                "| title '$title' | reopen $reopenSameName | thread ${Thread.currentThread().name}",
-        )
         InventoryCloseEvent(title, reopenSameName).post()
         currentInventory = null
     }
 
     @HandleEvent
     fun onTick() {
-        // TEMP DEBUG, remove before committing
-        debugTick++
         lateEvent?.let {
             it.post()
             lateEvent = null
@@ -174,19 +163,6 @@ object OtherInventoryData {
     }
 
     private fun done(inventory: Inventory) {
-        // TEMP DEBUG, remove before committing
-        val debugWindowId = inventory.windowId
-        println(
-            "SH-INV-ORDER | OPEN  | tick $debugTick | window $debugWindowId " +
-                "| title '${inventory.title}' | thread ${Thread.currentThread().name}",
-        )
-        DelayedRun.runOrNextTick {
-            println(
-                "SH-INV-ORDER | BLOCK | tick $debugTick | window $debugWindowId " +
-                    "| current window ${currentInventory?.windowId} | thread ${Thread.currentThread().name}",
-            )
-        }
-
         InventoryFullyOpenedEvent(inventory).post()
         inventory.fullyOpenedOnce = true
         InventoryUpdatedEvent(inventory).post()

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyHanniLogger.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyHanniLogger.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.utils
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.utils.TimeUtils.formatCurrentTime
+import at.hannibal2.skyhanni.utils.system.PlatformUtils
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.logging.FileHandler
@@ -10,7 +11,7 @@ import java.util.logging.LogRecord
 import java.util.logging.Logger
 import kotlin.time.Duration.Companion.days
 
-open class SkyHanniLogger(filePath: String) {
+open class SkyHanniLogger(private val filePath: String) {
 
     private val format = SimpleDateFormat("HH:mm:ss")
     internal open val logsDir = File("config/skyhanni/logs")
@@ -48,4 +49,17 @@ open class SkyHanniLogger(filePath: String) {
     }
 
     fun log(text: String?) = logger.info(text)
+
+    /**
+     * Logs [message] and the stack trace of [error] to the log file.
+     * In a development environment the same text also goes to the console,
+     * so a failure is visible without opening the log file first.
+     */
+    fun logError(message: String, error: Throwable) {
+        val text = "$message\n${error.stackTraceToString()}"
+        log(text)
+        if (PlatformUtils.isDevEnvironment) {
+            System.err.println("SkyHanni logger '$filePath': $text")
+        }
+    }
 }


### PR DESCRIPTION
## What
This used to work and got lost at some point, the stack trace only reached the log file since then.

`SkyHanniLogger.logError(message, error)` writes the message and stack trace to the log file, and in a development environment also to the console. `ConfigManager` uses it and appends the exception message to the shutdown reason, so a corrupt config names the failing json path right in the console instead of only in `config_manager.log`.

Console output stays limited to the development environment, since `ErrorManager` is the way to reach the user in production.

## Changelog Technical Details
+ Restored console output for SkyHanni logger errors in the development environment. - hannibal2
    * Config load failures now name the failing JSON path in the shutdown message.