### PR TITLE
Fix: Sprayonator Spray Duration

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestApi.kt
@@ -33,15 +33,12 @@ import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.LocationUtils.distanceSqToPlayer
 import at.hannibal2.skyhanni.utils.LocationUtils.isInside
-import at.hannibal2.skyhanni.utils.NeuInternalName
-import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
 import at.hannibal2.skyhanni.utils.RegexUtils.firstMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
-import at.hannibal2.skyhanni.utils.collection.CollectionUtils.equalsOneOf
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -51,10 +48,6 @@ import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object PestApi {
-
-    private val SPRAYONATOR = "SPRAYONATOR".toInternalName()
-    private val JUICY_SPRAYONATOR = "JUICY_SPRAYONATOR".toInternalName()
-    private val SALTY_SPRAYONATOR = "SALTY_SPRAYONATOR".toInternalName()
 
     val config get() = GardenApi.config.pests
     val storage get() = GardenApi.storage
@@ -79,9 +72,7 @@ object PestApi {
     fun hasLassoInHand() = InventoryUtils.getItemInHand()?.getItemCategoryOrNull() == ItemCategory.LASSO
     fun hasVacuumOrLassoInHand() = hasVacuumInHand() || hasLassoInHand()
 
-    private fun NeuInternalName.isSprayonator() = equalsOneOf(SPRAYONATOR, JUICY_SPRAYONATOR, SALTY_SPRAYONATOR)
-
-    fun hasSprayonatorInHand(): Boolean = InventoryUtils.itemInHandId.isSprayonator()
+    fun hasSprayonatorInHand(): Boolean = SprayonatorType.getInHandOrNull() != null
 
     fun SprayType.getPests() = PestType.filterableEntries.filter { it.spray == this }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/SprayonatorType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/SprayonatorType.kt
@@ -1,0 +1,30 @@
+package at.hannibal2.skyhanni.features.garden.pests
+
+import at.hannibal2.skyhanni.utils.InventoryUtils
+import at.hannibal2.skyhanni.utils.NeuInternalName
+import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+
+enum class SprayonatorType(
+    rawName: String,
+    val duration: Duration,
+) {
+    BASIC("SPRAYONATOR", 30.minutes),
+    JUICY("JUICY_SPRAYONATOR", 45.minutes),
+    SALTY("SALTY_SPRAYONATOR", 60.minutes),
+    ;
+
+    val internalName: NeuInternalName = rawName.toInternalName()
+
+    companion object {
+        private fun getByInternalNameOrNull(internalName: NeuInternalName): SprayonatorType? =
+            entries.firstOrNull { it.internalName == internalName }
+
+        fun getInHandOrNull(): SprayonatorType? = getByInternalNameOrNull(InventoryUtils.itemInHandId)
+
+        /** Falls back to the last held Sprayonator, as chat messages can arrive after a slot change. */
+        fun getRecentlyHeldOrNull(): SprayonatorType? = getInHandOrNull()
+            ?: InventoryUtils.pastItemsInHand.asReversed().firstNotNullOfOrNull { getByInternalNameOrNull(it.second) }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/plot/GardenPlotApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/plot/GardenPlotApi.kt
@@ -11,6 +11,7 @@ import at.hannibal2.skyhanni.events.garden.PlotChangeEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.features.garden.pests.PestApi
 import at.hannibal2.skyhanni.features.garden.pests.SprayType
+import at.hannibal2.skyhanni.features.garden.pests.SprayonatorType
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.DelayedRun
@@ -252,8 +253,9 @@ object GardenPlotApi {
             val plot = getPlotByName(plotName)
             val spray = SprayType.getByNameOrNull(sprayName) ?: return
 
-            plot?.setSpray(spray, 30.minutes)
-
+            // estimate, the pests tab widget may replace this with the real remaining time
+            val type = SprayonatorType.getRecentlyHeldOrNull() ?: SprayonatorType.BASIC
+            plot?.setSpray(spray, type.duration)
         }
         cleanPlotChatPattern.matchMatcher(event.message) {
             val plotId = group("plot").toInt()


### PR DESCRIPTION
## What
The tier is read from the Sprayonator in hand, falling back to the last held one because the chat message can arrive after a slot change.

## Changelog Fixes
+ Fixed the Spray Display always showing 30 minutes for upgraded Sprayonators. - hannibal2
    * The Juicy Sprayonator lasts 45 minutes, the Salty Sprayonator 60 minutes.
+ Fixed the "New Spray Notice" showing up after spraying with an upgraded Sprayonator. - hannibal2
