### PR TITLE
Fix + Improvement: Safari Ticket costs in NPC trades

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/CurrencyApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/CurrencyApi.kt
@@ -68,6 +68,24 @@ object CurrencyApi {
     )
 
     /**
+     * REGEX-TEST: Premium Safari Tickets: 0
+     * REGEX-TEST: First-Class Safari Tickets: 1,024
+     */
+    private val safariTicketItemPattern by patternGroup.pattern(
+        "safariticket.item",
+        "(?<type>[\\w-]+) Safari Tickets: (?<amount>[\\d,]+)",
+    )
+
+    /**
+     * REGEX-TEST: - Basic: 1
+     * REGEX-TEST: - First-Class: 0
+     */
+    private val safariTicketSignPattern by patternGroup.pattern(
+        "safariticket.sign",
+        "- (?<type>Basic|Economy|Premium|First-Class): (?<amount>[\\d,]+)",
+    )
+
+    /**
      * The type is read as written, so a new kind of essence needs no code change.
      *
      * REGEX-TEST: Your Undead Essence: 28,439
@@ -227,6 +245,7 @@ object CurrencyApi {
         medalAmountPattern.matchMatcher(line) {
             medalCurrencyOrNull(group("type"))?.setAmount(group("amount").formatLong())
         }
+        readSafariTicketLine(line)
         // every essence shop menu holds an item that states how much of it the player owns
         essenceAmountPattern.matchMatcher(line) {
             val type = group("type")
@@ -244,6 +263,30 @@ object CurrencyApi {
 
             essenceStorage?.put(internalName, group("amount").formatLong())
         }
+    }
+
+    private fun readSafariTicketLine(line: String) {
+        safariTicketItemPattern.matchMatcher(line) {
+            setSafariTicketAmount(group("type"), group("amount"), line)
+        }
+        safariTicketSignPattern.matchMatcher(line) {
+            setSafariTicketAmount(group("type"), group("amount"), line)
+        }
+    }
+
+    private fun setSafariTicketAmount(type: String, amount: String, line: String) {
+        val currency = SkyblockCurrency.getByLoreNameOrNull("$type Safari Ticket") ?: run {
+            ErrorManager.logErrorStateWithData(
+                "Could not read how many Safari Tickets you own",
+                "Unknown Safari Ticket type in an item lore",
+                "type" to type,
+                "line" to line,
+                "inventoryName" to InventoryUtils.openInventoryName(),
+                betaOnly = true,
+            )
+            return
+        }
+        currency.setAmount(amount.formatLong())
     }
 
     private fun essenceInternalNameOrNull(type: String): NeuInternalName? =

--- a/src/main/java/at/hannibal2/skyhanni/data/NpcTradeApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/NpcTradeApi.kt
@@ -1,6 +1,8 @@
 package at.hannibal2.skyhanni.data
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.hotx.HotfData
+import at.hannibal2.skyhanni.data.hotx.HotmData
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.InventoryUpdatedEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
@@ -72,6 +74,9 @@ object NpcTradeApi {
 
     // a menu without trades leaves the previous ones alone, they are still needed after it closed
     private fun readTrades(items: Collection<SafeItemStack>) {
+        // the perk trees unlock with their own currencies and have a display of their own
+        if (HotmData.inInventory || HotfData.inInventory) return
+
         // the same item can sit in several slots, the costs are the same in all of them
         val newTrades = items.mapNotNull { readTrade(it) }.associateBy { it.name }
         if (newTrades.isEmpty()) return

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/NpcTradeHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/NpcTradeHelper.kt
@@ -43,7 +43,8 @@ object NpcTradeHelper {
 
     /**
      * [evaluable] is false when the owned amount is unknown, for example a currency SkyHanni
-     * does not track. Such an item is never marked as affordable.
+     * does not track. Such an item is never marked as affordable and shows a question mark
+     * instead of an amount.
      */
     private class CostLine(val rawLine: String, val text: String, val covered: Boolean, val evaluable: Boolean) {
         /** The tooltip adds color codes of its own to the lore line, so the lookup ignores them. */
@@ -113,7 +114,8 @@ object NpcTradeHelper {
         val covered = owned != null && owned >= amount
 
         val suffix = when {
-            owned == null -> ""
+            internalName == NeuInternalName.MISSING_ITEM -> "§c!"
+            owned == null -> " §8?§7/§8${amount.addSeparators()}"
             covered -> " §a✔"
             else -> " §8${owned.addSeparators()}§7/§8${amount.addSeparators()}"
         }

--- a/src/main/java/at/hannibal2/skyhanni/utils/LoreCostUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LoreCostUtils.kt
@@ -96,10 +96,13 @@ object LoreCostUtils {
             return LoreCostEntry(NeuInternalName.MISSING_ITEM, 1, rawLine)
         }
 
-        val internalName = NeuInternalName.fromItemNameOrNull(name) ?: run {
-            logCostLineError("Unknown item in a cost line", rawLine, itemName)
-            NeuInternalName.MISSING_ITEM
-        }
+        // currencies without a repo item only arrive here, their amount is written behind the name or not at all
+        val internalName = NeuInternalName.fromItemNameOrNull(name)
+            ?: SkyblockCurrency.getByLoreNameOrNull(name)?.internalName
+            ?: run {
+                logCostLineError("Unknown item in a cost line", rawLine, itemName)
+                NeuInternalName.MISSING_ITEM
+            }
         return LoreCostEntry(internalName, amount.toLong(), rawLine)
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyblockCurrency.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyblockCurrency.kt
@@ -130,6 +130,29 @@ enum class SkyblockCurrency(
         ownedAmount = { getFromStorage() },
     ),
 
+    // Ticket Exchange from the Safari Manager, a ticket starts one Critter Safari
+    // and the lower tiers are spent to upgrade into the higher ones
+    SAFARI_TICKET_BASIC(
+        "SAFARI_TICKET_BASIC".toInternalName(), "Basic Safari Ticket", DARK_GREEN,
+        loreNames = setOf("basic safari ticket", "basic safari tickets"),
+        ownedAmount = { getFromStorage() },
+    ),
+    SAFARI_TICKET_ECONOMY(
+        "SAFARI_TICKET_ECONOMY".toInternalName(), "Economy Safari Ticket", BLUE,
+        loreNames = setOf("economy safari ticket", "economy safari tickets"),
+        ownedAmount = { getFromStorage() },
+    ),
+    SAFARI_TICKET_PREMIUM(
+        "SAFARI_TICKET_PREMIUM".toInternalName(), "Premium Safari Ticket", DARK_PURPLE,
+        loreNames = setOf("premium safari ticket", "premium safari tickets"),
+        ownedAmount = { getFromStorage() },
+    ),
+    SAFARI_TICKET_FIRST_CLASS(
+        "SAFARI_TICKET_FIRST_CLASS".toInternalName(), "First-Class Safari Ticket", GOLD,
+        loreNames = setOf("first-class safari ticket", "first-class safari tickets"),
+        ownedAmount = { getFromStorage() },
+    ),
+
     // TODO add these currencies, each one needs a real cost line from its shop first
     //  - North Stars, waiting on the winter event
     //  - Carnival Tokens, waiting on the carnival event, the item is SKYBLOCK_CARNIVAL_POINT


### PR DESCRIPTION
## What
Added Safari Tickets to `SkyblockCurrency`.

Reported on Discord: https://discord.com/channels/997079228510117908/1538620033402409031

## Changelog Fixes
+ Fixed Safari Ticket costs not being read in the Ticket Exchange. - hannibal2
+ Fixed an error when opening Heart of the Mountain or Heart of the Forest. - hannibal2

## Changelog Improvements
+ Improved NPC trade cost lines to show a question mark instead of the owned number when SkyHanni does not track that currency. - hannibal2