### PR TITLE
Backend: Reduce unnecessary formattedText comparisons

### DIFF
--- a/detekt/baseline-main.xml
+++ b/detekt/baseline-main.xml
@@ -248,13 +248,6 @@
     <ID>PrivateEventListener:BarnFishingTimer.kt:BarnFishingTimer$@HandleEvent(onlyOnSkyblock = true) fun onGuiRenderOverlay</ID>
     <ID>PrivateEventListener:BarnFishingTimer.kt:BarnFishingTimer$@HandleEvent(onlyOnSkyblock = true) fun onSecondPassed</ID>
     <ID>PrivateEventListener:BarnFishingTimer.kt:BarnFishingTimer$@Suppress("UNUSED_PARAMETER") @HandleEvent(onlyOnIsland = IslandType.HUB) fun onPlayerMove</ID>
-    <ID>PrivateEventListener:BazaarApi.kt:BazaarApi$@HandleEvent fun onConfigFix</ID>
-    <ID>PrivateEventListener:BazaarApi.kt:BazaarApi$@HandleEvent fun onInventoryClose</ID>
-    <ID>PrivateEventListener:BazaarApi.kt:BazaarApi$@HandleEvent fun onSlotClick</ID>
-    <ID>PrivateEventListener:BazaarApi.kt:BazaarApi$@HandleEvent fun onTick</ID>
-    <ID>PrivateEventListener:BazaarApi.kt:BazaarApi$@HandleEvent(onlyOnSkyblock = true) fun onBackgroundDrawn</ID>
-    <ID>PrivateEventListener:BazaarApi.kt:BazaarApi$@HandleEvent(onlyOnSkyblock = true) fun onChat</ID>
-    <ID>PrivateEventListener:BazaarApi.kt:BazaarApi$@HandleEvent(priority = HandleEvent.HIGHEST) fun onInventoryFullyOpened</ID>
     <ID>PrivateEventListener:BazaarBestSellMethod.kt:BazaarBestSellMethod$@HandleEvent fun onBazaarOpenedProduct</ID>
     <ID>PrivateEventListener:BazaarBestSellMethod.kt:BazaarBestSellMethod$@HandleEvent fun onChestGuiRender</ID>
     <ID>PrivateEventListener:BazaarBestSellMethod.kt:BazaarBestSellMethod$@HandleEvent fun onInventoryClose</ID>
@@ -920,13 +913,6 @@
     <ID>PrivateEventListener:DungeonCleanEnd.kt:DungeonCleanEnd$@HandleEvent(onlyOnIsland = IslandType.CATACOMBS) fun onEntityHealthUpdate</ID>
     <ID>PrivateEventListener:DungeonCleanEnd.kt:DungeonCleanEnd$@HandleEvent(onlyOnIsland = IslandType.CATACOMBS) fun onParticle</ID>
     <ID>PrivateEventListener:DungeonCleanEnd.kt:DungeonCleanEnd$@HandleEvent(onlyOnIsland = IslandType.CATACOMBS) fun onPlaySound</ID>
-    <ID>PrivateEventListener:DungeonCopilot.kt:DungeonCopilot$@HandleEvent fun onConfigFix</ID>
-    <ID>PrivateEventListener:DungeonCopilot.kt:DungeonCopilot$@HandleEvent fun onDungeonBossRoomEnter</ID>
-    <ID>PrivateEventListener:DungeonCopilot.kt:DungeonCopilot$@HandleEvent fun onDungeonStart</ID>
-    <ID>PrivateEventListener:DungeonCopilot.kt:DungeonCopilot$@HandleEvent fun onWorldChange</ID>
-    <ID>PrivateEventListener:DungeonCopilot.kt:DungeonCopilot$@HandleEvent(onlyOnIsland = IslandType.CATACOMBS) fun onChat</ID>
-    <ID>PrivateEventListener:DungeonCopilot.kt:DungeonCopilot$@HandleEvent(onlyOnIsland = IslandType.CATACOMBS) fun onCheckRender</ID>
-    <ID>PrivateEventListener:DungeonCopilot.kt:DungeonCopilot$@HandleEvent(onlyOnIsland = IslandType.CATACOMBS) fun onGuiRenderOverlay</ID>
     <ID>PrivateEventListener:DungeonCreationCooldown.kt:DungeonCreationCooldown$@HandleEvent fun onChat</ID>
     <ID>PrivateEventListener:DungeonCreationCooldown.kt:DungeonCreationCooldown$@HandleEvent fun onCommand</ID>
     <ID>PrivateEventListener:DungeonCreationCooldown.kt:DungeonCreationCooldown$@HandleEvent fun onGuiRenderOverlay</ID>
@@ -950,16 +936,6 @@
     <ID>PrivateEventListener:DungeonHighlightClickedBlocks.kt:DungeonHighlightClickedBlocks$@HandleEvent fun onConfigFix</ID>
     <ID>PrivateEventListener:DungeonHighlightClickedBlocks.kt:DungeonHighlightClickedBlocks$@HandleEvent fun onDungeonClickedBlock</ID>
     <ID>PrivateEventListener:DungeonHighlightClickedBlocks.kt:DungeonHighlightClickedBlocks$@HandleEvent fun onRenderWorld</ID>
-    <ID>PrivateEventListener:DungeonLividFinder.kt:DungeonLividFinder$@HandleEvent fun onBlockChange</ID>
-    <ID>PrivateEventListener:DungeonLividFinder.kt:DungeonLividFinder$@HandleEvent fun onDebugDataCollect</ID>
-    <ID>PrivateEventListener:DungeonLividFinder.kt:DungeonLividFinder$@HandleEvent fun onRenderWorld</ID>
-    <ID>PrivateEventListener:DungeonLividFinder.kt:DungeonLividFinder$@HandleEvent fun onRepoReload</ID>
-    <ID>PrivateEventListener:DungeonLividFinder.kt:DungeonLividFinder$@HandleEvent fun onWorldChange</ID>
-    <ID>PrivateEventListener:DungeonLividFinder.kt:DungeonLividFinder$@HandleEvent(ConfigLoadEvent::class) fun onConfigLoad</ID>
-    <ID>PrivateEventListener:DungeonLividFinder.kt:DungeonLividFinder$@HandleEvent(DungeonBossRoomEnterEvent::class) fun onBossStart</ID>
-    <ID>PrivateEventListener:DungeonLividFinder.kt:DungeonLividFinder$@HandleEvent(DungeonCompleteEvent::class) fun onBossEnd</ID>
-    <ID>PrivateEventListener:DungeonLividFinder.kt:DungeonLividFinder$@HandleEvent(SecondPassedEvent::class) fun onSecondPassed</ID>
-    <ID>PrivateEventListener:DungeonLividFinder.kt:DungeonLividFinder$@HandleEvent(onlyOnIsland = IslandType.CATACOMBS) fun onCheckRender</ID>
     <ID>PrivateEventListener:DungeonMilestonesDisplay.kt:DungeonMilestonesDisplay$@HandleEvent fun onChat</ID>
     <ID>PrivateEventListener:DungeonMilestonesDisplay.kt:DungeonMilestonesDisplay$@HandleEvent fun onDungeonStart</ID>
     <ID>PrivateEventListener:DungeonMilestonesDisplay.kt:DungeonMilestonesDisplay$@HandleEvent fun onTick</ID>
@@ -1301,8 +1277,6 @@
     <ID>PrivateEventListener:FossilSolverDisplay.kt:FossilSolverDisplay$@HandleEvent(onlyOnIsland = IslandType.DWARVEN_MINES) fun onRenderItemTip</ID>
     <ID>PrivateEventListener:FossilSolverDisplay.kt:FossilSolverDisplay$@HandleEvent(onlyOnIsland = IslandType.DWARVEN_MINES) fun onSlotClick</ID>
     <ID>PrivateEventListener:FossilSolverDisplay.kt:FossilSolverDisplay$@HandleEvent(onlyOnIsland = IslandType.DWARVEN_MINES) fun onTick</ID>
-    <ID>PrivateEventListener:FriendApi.kt:FriendApi$@HandleEvent fun onChat</ID>
-    <ID>PrivateEventListener:FriendApi.kt:FriendApi$@HandleEvent fun onHypixelJoin</ID>
     <ID>PrivateEventListener:FrogMaskFeatures.kt:FrogMaskFeatures$@HandleEvent fun onConfigFix</ID>
     <ID>PrivateEventListener:FrogMaskFeatures.kt:FrogMaskFeatures$@HandleEvent(GuiRenderEvent.GuiOverlayRenderEvent::class, onlyOnSkyblock = true) fun onGuiRenderOverlay</ID>
     <ID>PrivateEventListener:FrogMaskFeatures.kt:FrogMaskFeatures$@HandleEvent(SecondPassedEvent::class, onlyOnSkyblock = true) fun onSecondPassed</ID>
@@ -2974,9 +2948,6 @@
     <ID>PrivateEventListener:TabListData.kt:TabListData$@HandleEvent fun onCommandRegistration</ID>
     <ID>PrivateEventListener:TabListData.kt:TabListData$@HandleEvent fun onTick</ID>
     <ID>PrivateEventListener:TabListData.kt:TabListData$@HandleEvent(receiveCancelled = true) fun onPacketReceive</ID>
-    <ID>PrivateEventListener:TabListReader.kt:TabListReader$@HandleEvent fun onConfigLoad</ID>
-    <ID>PrivateEventListener:TabListReader.kt:TabListReader$@HandleEvent(onlyOnSkyblock = true) fun onTabListFooterUpdate</ID>
-    <ID>PrivateEventListener:TabListReader.kt:TabListReader$@HandleEvent(onlyOnSkyblock = true) fun onTabListUpdate</ID>
     <ID>PrivateEventListener:TabListRenderer.kt:TabListRenderer$@HandleEvent fun onConfigFix</ID>
     <ID>PrivateEventListener:TabListRenderer.kt:TabListRenderer$@HandleEvent fun onSkipTablistLine</ID>
     <ID>PrivateEventListener:TabListRenderer.kt:TabListRenderer$@HandleEvent(onlyOnSkyblock = true) fun onRenderOverlayPre</ID>

--- a/src/main/java/at/hannibal2/skyhanni/data/FriendApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/FriendApi.kt
@@ -13,6 +13,7 @@ import at.hannibal2.skyhanni.events.FriendRequestSentEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.utils.ComponentMatcherUtils.intoSpan
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.PlayerUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
@@ -191,7 +192,7 @@ object FriendApi {
                     }
                 }
             }
-            val bestFriend = sibling.unformattedTextCompat().split(" ").firstOrNull()?.contains("§l") ?: false
+            val bestFriend = sibling.intoSpan().sampleStyleAtStart().isBold
             val name = readName(sibling)
             if (uuid != null && name != null) {
                 getFriends()[uuid] = Friend(

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/IslandExceptions.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/IslandExceptions.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.data.mob
 
 import at.hannibal2.skyhanni.data.ElectionApi.derpy
 import at.hannibal2.skyhanni.data.mob.MobFilter.makeMobResult
+import at.hannibal2.skyhanni.utils.ComponentMatcherUtils.intoSpan
 import at.hannibal2.skyhanni.utils.EntityUtils.baseMaxHealth
 import at.hannibal2.skyhanni.utils.EntityUtils.cleanName
 import at.hannibal2.skyhanni.utils.EntityUtils.isNpc
@@ -15,10 +16,11 @@ import at.hannibal2.skyhanni.utils.MobUtils.takeNonDefault
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
+import at.hannibal2.skyhanni.utils.collection.CollectionUtils.equalsOneOf
 import at.hannibal2.skyhanni.utils.compat.EntityCompat.getEntityHelmet
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import net.minecraft.client.player.RemotePlayer
+import net.minecraft.network.chat.TextColor
 import net.minecraft.world.entity.LivingEntity
 import net.minecraft.world.entity.animal.feline.Ocelot
 import net.minecraft.world.entity.animal.golem.IronGolem
@@ -60,36 +62,41 @@ object IslandExceptions {
         baseEntity: LivingEntity,
         armorStand: ArmorStand?,
         nextEntity: LivingEntity?,
-    ) = when {
-        baseEntity is Zombie &&
-            armorStand != null &&
-            (armorStand.name.formattedTextCompatLessResets() == "§e﴾ §5♃ §c§lThe Watcher§r§r §e﴿" || armorStand.name.formattedTextCompatLessResets() == "§3§lWatchful Eye§r") ->
-            MobData.MobResult.found(
-                MobFactories.special(baseEntity, armorStand.cleanName, armorStand),
-            )
+    ): MobData.MobResult? {
+        val entityCleanName by lazy { baseEntity.cleanName }
+        val standCleanName by lazy { armorStand?.cleanName.orEmpty() }
 
-        baseEntity is CaveSpider -> MobUtils.getClosestArmorStand(baseEntity, 2.0).takeNonDefault()
-            .makeMobResult { MobFactories.dungeon(baseEntity, it) }
+        return when {
+            baseEntity is Zombie &&
+                armorStand != null &&
+                standCleanName.equalsOneOf("﴾ ♃ The Watcher ﴿", "Watchful Eye") ->
+                MobData.MobResult.found(
+                    MobFactories.special(baseEntity, standCleanName, armorStand),
+                )
 
-        baseEntity is RemotePlayer && baseEntity.isNpc() && baseEntity.name.formattedTextCompatLessResets() == "Shadow Assassin" ->
-            MobUtils.getClosestArmorStandWithName(baseEntity, 3.0, "Shadow Assassin")
+            baseEntity is CaveSpider -> MobUtils.getClosestArmorStand(baseEntity, 2.0).takeNonDefault()
                 .makeMobResult { MobFactories.dungeon(baseEntity, it) }
 
-        baseEntity is RemotePlayer && baseEntity.isNpc() && baseEntity.name.formattedTextCompatLessResets() == "The Professor" ->
-            MobUtils.getArmorStand(baseEntity, 9)
-                .makeMobResult { MobFactories.boss(baseEntity, it) }
+            baseEntity is RemotePlayer && baseEntity.isNpc() && entityCleanName == "Shadow Assassin" ->
+                MobUtils.getClosestArmorStandWithName(baseEntity, 3.0, "Shadow Assassin")
+                    .makeMobResult { MobFactories.dungeon(baseEntity, it) }
 
-        baseEntity is RemotePlayer &&
-            baseEntity.isNpc() &&
-            (nextEntity is Giant || nextEntity == null) &&
-            baseEntity.name.formattedTextCompatLessResets().contains("Livid") -> MobUtils.getArmorStand(baseEntity, 10)
-            ?.takeIf { getNextEntity(it, -1)?.takeIf { entity -> entity.name.formattedTextCompatLessResets().contains("Livid") } == null }
-            .makeMobResult { MobFactories.boss(baseEntity, it, overriddenName = "Real Livid") }
+            baseEntity is RemotePlayer && baseEntity.isNpc() && entityCleanName == "The Professor" ->
+                MobUtils.getArmorStand(baseEntity, 9)
+                    .makeMobResult { MobFactories.boss(baseEntity, it) }
 
-        baseEntity is IronGolem && MobFilter.wokeSleepingGolemPattern.matches(armorStand?.name.formattedTextCompatLessResets().orEmpty()) ->
-            MobData.MobResult.found(Mob(baseEntity, MobCategory.DUNGEON, armorStand, "Sleeping Golem")) // Consistency fix
+            baseEntity is RemotePlayer &&
+                baseEntity.isNpc() &&
+                (nextEntity is Giant || nextEntity == null) &&
+                entityCleanName.contains("Livid") -> MobUtils.getArmorStand(baseEntity, 10)
+                ?.takeIf { getNextEntity(it, -1)?.takeIf { entity -> entity.cleanName.contains("Livid") } == null }
+                .makeMobResult { MobFactories.boss(baseEntity, it, overriddenName = "Real Livid") }
 
-        else -> null
+            baseEntity is IronGolem && MobFilter.wokeSleepingGolemPattern.matches(standCleanName) ->
+                MobData.MobResult.found(Mob(baseEntity, MobCategory.DUNGEON, armorStand, "Sleeping Golem")) // Consistency fix
+
+            else -> null
+        }
     }
 
     private fun privateIsland(
@@ -116,7 +123,7 @@ object IslandExceptions {
         baseEntity is Slime && armorStand != null && armorStand.cleanName.startsWith("﴾ [Lv10] B") ->
             MobData.MobResult.found(Mob(baseEntity, MobCategory.BOSS, armorStand, name = "Bacte"))
 
-        baseEntity is RemotePlayer && baseEntity.isNpc() && baseEntity.name.formattedTextCompatLessResets() == "Branchstrutter " ->
+        baseEntity is RemotePlayer && baseEntity.isNpc() && baseEntity.cleanName == "Branchstrutter " ->
             MobData.MobResult.found(Mob(baseEntity, MobCategory.DISPLAY_NPC, name = "Branchstrutter"))
 
         else -> null
@@ -126,30 +133,34 @@ object IslandExceptions {
         baseEntity: LivingEntity,
         armorStand: ArmorStand?,
         nextEntity: LivingEntity?,
-    ) = when {
-        baseEntity is Pig && nextEntity is Pig -> MobData.MobResult.illegal // Matriarch Tongue
-        baseEntity is RemotePlayer && baseEntity.isNpc() && baseEntity.name.string == "BarbarianGuard " ->
-            MobData.MobResult.found(Mob(baseEntity, MobCategory.DISPLAY_NPC, name = "Barbarian Guard"))
+    ): MobData.MobResult? {
+        val entityCleanName by lazy { baseEntity.cleanName }
 
-        baseEntity is RemotePlayer && baseEntity.isNpc() && baseEntity.name.string == "MageGuard " ->
-            MobData.MobResult.found(Mob(baseEntity, MobCategory.DISPLAY_NPC, name = "Mage Guard"))
+        return when {
+            baseEntity is Pig && nextEntity is Pig -> MobData.MobResult.illegal // Matriarch Tongue
+            baseEntity is RemotePlayer && baseEntity.isNpc() && entityCleanName == "BarbarianGuard " ->
+                MobData.MobResult.found(Mob(baseEntity, MobCategory.DISPLAY_NPC, name = "Barbarian Guard"))
 
-        baseEntity is RemotePlayer && baseEntity.isNpc() && baseEntity.name.string == "Mage Outlaw" ->
-            // fix for wierd name
-            MobData.MobResult.found(Mob(baseEntity, MobCategory.BOSS, armorStand, name = "Mage Outlaw"))
+            baseEntity is RemotePlayer && baseEntity.isNpc() && entityCleanName == "MageGuard " ->
+                MobData.MobResult.found(Mob(baseEntity, MobCategory.DISPLAY_NPC, name = "Mage Guard"))
 
-        baseEntity is ZombifiedPiglin &&
-            MobFilter.NPC_TURD_SKULL != null &&
-            baseEntity.getEntityHelmet()?.getSkullTexture() == MobFilter.NPC_TURD_SKULL ->
-            MobData.MobResult.found(Mob(baseEntity, MobCategory.DISPLAY_NPC, name = "Turd"))
+            baseEntity is RemotePlayer && baseEntity.isNpc() && entityCleanName == "Mage Outlaw" ->
+                // fix for wierd name
+                MobData.MobResult.found(Mob(baseEntity, MobCategory.BOSS, armorStand, name = "Mage Outlaw"))
 
-        baseEntity is Ocelot -> if (MobFilter.createDisplayNpc(baseEntity)) {
-            MobData.MobResult.illegal
-        } else {
-            MobData.MobResult.notYetFound // Maybe a problem in the future
+            baseEntity is ZombifiedPiglin &&
+                MobFilter.NPC_TURD_SKULL != null &&
+                baseEntity.getEntityHelmet()?.getSkullTexture() == MobFilter.NPC_TURD_SKULL ->
+                MobData.MobResult.found(Mob(baseEntity, MobCategory.DISPLAY_NPC, name = "Turd"))
+
+            baseEntity is Ocelot -> if (MobFilter.createDisplayNpc(baseEntity)) {
+                MobData.MobResult.illegal
+            } else {
+                MobData.MobResult.notYetFound // Maybe a problem in the future
+            }
+
+            else -> null
         }
-
-        else -> null
     }
 
     private fun deepCaverns(baseEntity: LivingEntity) = when {
@@ -186,42 +197,47 @@ object IslandExceptions {
         baseEntity: LivingEntity,
         armorStand: ArmorStand?,
         nextEntity: LivingEntity?,
-    ) = when {
-        baseEntity is Ocelot &&
-            armorStand?.isDefaultValue() == false &&
-            // TODO fix pattern
-            armorStand.name.formattedTextCompatLessResets().startsWith("§8[§7Lv155§8] §cAzrael§r") ->
-            MobUtils.getArmorStand(baseEntity, 1)
-                .makeMobResult { MobFactories.basic(baseEntity, it) }
+    ): MobData.MobResult? {
+        val standCleanName by lazy { armorStand?.cleanName.orEmpty() }
 
-        baseEntity is Ocelot && (nextEntity is Ocelot || nextEntity == null) ->
-            MobUtils.getArmorStand(baseEntity, 3)
-                .makeMobResult { MobFactories.basic(baseEntity, it) }
+        return when {
+            baseEntity is Ocelot &&
+                armorStand?.isDefaultValue() == false &&
+                // TODO fix pattern
+                standCleanName.startsWith("[Lv155] Azrael") ->
+                MobUtils.getArmorStand(baseEntity, 1)
+                    .makeMobResult { MobFactories.basic(baseEntity, it) }
 
-        baseEntity is RemotePlayer &&
-            baseEntity.name.formattedTextCompatLessResets()
-                .let { it == "Minos Champion" || it == "Minos Inquisitor" || it == "Minotaur " } &&
-            armorStand != null ->
-            MobUtils.getArmorStand(baseEntity, 2)
-                .makeMobResult { MobFactories.basic(baseEntity, it, listOf(armorStand)) }
+            baseEntity is Ocelot && (nextEntity is Ocelot || nextEntity == null) ->
+                MobUtils.getArmorStand(baseEntity, 3)
+                    .makeMobResult { MobFactories.basic(baseEntity, it) }
 
-        baseEntity is Zombie &&
-            armorStand?.isDefaultValue() == true &&
-            MobUtils.getNextEntity(baseEntity, 4)?.name.formattedTextCompatLessResets().startsWith("§e") ->
-            petCareHandler(baseEntity)
+            baseEntity is RemotePlayer &&
+                standCleanName.equalsOneOf("Minos Champion", "Minos Inquisitor", "Minotaur ") &&
+                armorStand != null ->
+                MobUtils.getArmorStand(baseEntity, 2)
+                    .makeMobResult { MobFactories.basic(baseEntity, it, listOf(armorStand)) }
 
-        baseEntity is Zombie && armorStand != null && !armorStand.isDefaultValue() -> null // Impossible Rat
-        baseEntity is Zombie -> ratHandler(baseEntity, nextEntity) // Possible Rat
-        baseEntity is Pig && MobFilter.shinyPig.matches(armorStand?.cleanName) -> MobData.MobResult.found(
-            Mob(
-                baseEntity,
-                MobCategory.SPECIAL,
-                armorStand,
-                "SHINY PIG",
-            ),
-        )
+            baseEntity is Zombie &&
+                armorStand?.isDefaultValue() == true &&
+                MobUtils.getNextEntity(baseEntity, 4).let {
+                    it?.name?.intoSpan()?.sampleStyleAtStart()?.color == TextColor.fromLegacyFormat(YELLOW)
+                } ->
+                petCareHandler(baseEntity)
 
-        else -> null
+            baseEntity is Zombie && armorStand != null && !armorStand.isDefaultValue() -> null // Impossible Rat
+            baseEntity is Zombie -> ratHandler(baseEntity, nextEntity) // Possible Rat
+            baseEntity is Pig && MobFilter.shinyPig.matches(standCleanName) -> MobData.MobResult.found(
+                Mob(
+                    baseEntity,
+                    MobCategory.SPECIAL,
+                    armorStand,
+                    "SHINY PIG",
+                ),
+            )
+
+            else -> null
+        }
     }
 
     private fun garden(baseEntity: LivingEntity) = when {
@@ -246,7 +262,7 @@ object IslandExceptions {
         val armorStand = MobUtils.getArmorStand(baseEntity, 2)
         return when {
             baseEntity is MagmaCube &&
-                MobFilter.jerryMagmaCubePattern.matches(armorStand?.name.formattedTextCompatLessResets()) ->
+                MobFilter.jerryMagmaCubePattern.matches(armorStand?.cleanName) ->
                 MobData.MobResult.found(Mob(baseEntity, MobCategory.BOSS, armorStand, "Jerry Magma Cube"))
 
             else -> null

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/Mob.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/Mob.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.features.rift.RiftApi
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper
 import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
 import at.hannibal2.skyhanni.utils.ColorUtils.toColor
+import at.hannibal2.skyhanni.utils.ComponentMatcherUtils.intoSpan
 import at.hannibal2.skyhanni.utils.EntityUtils.baseMaxHealth
 import at.hannibal2.skyhanni.utils.EntityUtils.canBeSeen
 import at.hannibal2.skyhanni.utils.EntityUtils.cleanName
@@ -20,10 +21,10 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.toSingletonListOrEmpty
 import at.hannibal2.skyhanni.utils.compat.EntityCompat.findHealthReal
 import at.hannibal2.skyhanni.utils.compat.EntityCompat.getAllEquipment
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import io.github.notenoughupdates.moulconfig.ChromaColour
 import io.github.notenoughupdates.moulconfig.observer.Property
+import net.minecraft.network.chat.TextColor
 import net.minecraft.world.entity.Entity
 import net.minecraft.world.entity.LivingEntity
 import net.minecraft.world.entity.decoration.ArmorStand
@@ -85,7 +86,6 @@ class Mob(
     val levelOrTier: Int = -1,
     val hypixelTypes: String = "",
 ) {
-
     private val uniqueId: UUID = UUID.randomUUID()
     val id = baseEntity.id
 
@@ -94,7 +94,6 @@ class Mob(
     val ownerNameOrEmpty: String get() = owner?.ownerName.orEmpty()
 
     companion object {
-
         fun Entity?.belongsToPlayer(): Boolean = this?.mob.belongsToPlayer()
         fun Mob?.belongsToPlayer(): Boolean = this?.owner?.equals(PlayerUtils.getName()) ?: false
     }
@@ -115,13 +114,12 @@ class Mob(
      */
     val isCorrupted get() = !RiftApi.inRift() && baseEntity.isCorrupted()
 
-    // TODO use component style
     /**
      * @property isRunic does not change.
      */
     val isRunic = !RiftApi.inRift() &&
-        armorStand?.name.formattedTextCompatLessResets().startsWith("§5") &&
-        category == MobCategory.BASIC
+        armorStand?.name?.intoSpan()?.sampleStyleAtStart()?.color == TextColor.fromLegacyFormat(DARK_PURPLE) &&
+        category == BASIC
 
     fun isInRender() = baseEntity.distanceToPlayer() < MobData.ENTITY_RENDER_RANGE_IN_BLOCKS
 
@@ -196,7 +194,7 @@ class Mob(
         // Inlined updateBoundingBox()
         relativeBoundingBox = if (extraEntities.isNotEmpty()) makeRelativeBoundingBox() else null
 
-        if (ownerName == null && category == MobCategory.SLAYER) {
+        if (ownerName == null && category == SLAYER) {
             hologram2?.let {
                 summonOwnerPattern.matchMatcher(it.cleanName) {
                     ownerName = group("name")

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/MobFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/MobFilter.kt
@@ -125,14 +125,18 @@ object MobFilter {
         "^\\[\\w+ (?<level>\\d+)\\] (?<name>.*)",
     )
 
-    // TODO fix pattern
+    // TODO check if pattern is correct
+    /**
+     * REGEX-TEST: Woke Golem
+     * REGEX-TEST: Sleeping Golem
+     */
     val wokeSleepingGolemPattern by patternGroup.pattern(
-        "pattern.dungeon.woke.golem",
-        "(?:§c§lWoke|§5§lSleeping) Golem§r",
+        "pattern.dungeon.woke.golem.colorless",
+        "(?:Woke|Sleeping) Golem",
     )
     val jerryMagmaCubePattern by patternGroup.pattern(
-        "pattern.jerry.magma.cube",
-        "§c(?:Cubie|Maggie|Cubert|Cübe|Cubette|Magmalene|Lucky 7|8ball|Mega Cube|Super Cube)(?: ᛤ)? §a\\d+§8\\/§a\\d+§c${SkyblockStat.HEALTH.hypixelIcon}",
+        "pattern.jerry.magma.cube.colorless",
+        """(?:Cubie|Maggie|Cubert|Cübe|Cubette|Magmalene|Lucky 7|8ball|Mega Cube|Super Cube)(?: ᛤ)? \d+/\d+${SkyblockStat.HEALTH.hypixelIcon}""",
     )
     val summonOwnerPattern by patternGroup.pattern(
         "pattern.summon.owner",
@@ -179,7 +183,6 @@ object MobFilter {
         ;
 
         companion object {
-
             val toRegexLine = DungeonAttribute.entries.joinToString("|") { it.name }
         }
     }
@@ -362,7 +365,7 @@ object MobFilter {
         if (DungeonApi.inDungeon()) {
             when {
                 (baseEntity is EnderMan || baseEntity is Giant) &&
-                    extraEntityList.lastOrNull()?.name.formattedTextCompatLessResets() == "§e﴾ §c§lLivid§r§r §a7M§c❤ §e﴿" -> MobResult.illegal // Livid Start Animation
+                    extraEntityList.lastOrNull()?.cleanName == "﴾ Livid 7M❤ ﴿" -> MobResult.illegal // Livid Start Animation
                 else -> null
             }
         } else when (SkyBlockUtils.currentIsland) {

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonCopilot.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonCopilot.kt
@@ -3,7 +3,6 @@ package at.hannibal2.skyhanni.features.dungeon
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
-import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
@@ -11,10 +10,11 @@ import at.hannibal2.skyhanni.events.dungeon.DungeonBossRoomEnterEvent
 import at.hannibal2.skyhanni.events.dungeon.DungeonEnterEvent
 import at.hannibal2.skyhanni.events.dungeon.DungeonStartEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.EntityUtils.cleanName
 import at.hannibal2.skyhanni.utils.PlayerUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLessResets
+import at.hannibal2.skyhanni.utils.collection.CollectionUtils.equalsOneOf
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -22,7 +22,6 @@ import net.minecraft.world.entity.decoration.ArmorStand
 
 @SkyHanniModule
 object DungeonCopilot {
-
     private val config get() = SkyHanniMod.feature.dungeon.dungeonCopilot
 
     private val patternGroup = RepoPattern.group("dungeon.copilot")
@@ -51,8 +50,8 @@ object DungeonCopilot {
     private var nextStep: Renderable? = null
     private var searchForKey = false
 
-    @HandleEvent(onlyOnIsland = IslandType.CATACOMBS)
-    fun onChat(event: SkyHanniChatEvent.Allow) {
+    @HandleEvent(onlyOnIsland = CATACOMBS)
+    private fun onChat(event: SkyHanniChatEvent.Allow) {
         if (!config.enabled) return
 
         handleChatMessage(event.message)?.let {
@@ -109,53 +108,50 @@ object DungeonCopilot {
         nextStep = step?.let { Renderable.text(it) }
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.CATACOMBS)
-    fun onCheckRender(event: CheckRenderEntityEvent<ArmorStand>) {
+    @HandleEvent(onlyOnIsland = CATACOMBS)
+    private fun onCheckRender(event: CheckRenderEntityEvent<ArmorStand>) {
         val entity = event.entity
 
         if (!searchForKey) return
 
-        if (entity.name.formattedTextCompatLessResets() == "§6§8Wither Key") {
-            changeNextStep("Pick up Wither Key")
-            searchForKey = false
-        }
-        if (entity.name.formattedTextCompatLessResets() == "§c§cBlood Key") {
-            changeNextStep("Pick up Blood Key")
+        val name = entity.cleanName
+        if (name.equalsOneOf("Wither Key", "Blood Key")) {
+            changeNextStep("Pick up $name")
             searchForKey = false
         }
     }
 
     @HandleEvent
-    fun onDungeonStart(event: DungeonStartEvent) {
+    private fun onDungeonStart(event: DungeonStartEvent) {
         changeNextStep("Clear first room")
         searchForKey = true
     }
 
     @HandleEvent
-    fun onDungeonStart(event: DungeonEnterEvent) {
+    private fun onDungeonStart(event: DungeonEnterEvent) {
         changeNextStep("Talk to Mort")
         searchForKey = true
     }
 
     @HandleEvent
-    fun onDungeonBossRoomEnter(event: DungeonBossRoomEnterEvent) {
+    private fun onDungeonBossRoomEnter(event: DungeonBossRoomEnterEvent) {
         changeNextStep("Defeat the boss! Good luck :)")
     }
 
     @HandleEvent
-    fun onWorldChange() {
+    private fun onWorldChange() {
         changeNextStep()
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.CATACOMBS)
-    fun onGuiRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
+    @HandleEvent(onlyOnIsland = CATACOMBS)
+    private fun onGuiRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
         if (!config.enabled) return
         val nextStep = nextStep ?: return
         config.pos.renderRenderable(nextStep, posLabel = "Dungeon Copilot")
     }
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(3, "dungeon.messageFilterKeysAndDoors", "dungeon.messageFilter.keysAndDoors")
         event.move(3, "dungeon.copilotEnabled", "dungeon.dungeonCopilot.enabled")
         event.move(3, "dungeon.copilotPos", "dungeon.dungeonCopilot.pos")

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonLividFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonLividFinder.kt
@@ -2,13 +2,10 @@ package at.hannibal2.skyhanni.features.dungeon
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.jsonobjects.repo.LividSolverJson
 import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
-import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
-import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.ServerBlockChangeEvent
 import at.hannibal2.skyhanni.events.dungeon.DungeonBossRoomEnterEvent
 import at.hannibal2.skyhanni.events.dungeon.DungeonCompleteEvent
@@ -18,9 +15,11 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.AllEntitiesGetter
 import at.hannibal2.skyhanni.utils.BlockUtils.getBlockStateAt
 import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.ComponentMatcherUtils.intoSpan
 import at.hannibal2.skyhanni.utils.ConditionalUtils.onToggle
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.canBeSeen
+import at.hannibal2.skyhanni.utils.EntityUtils.cleanName
 import at.hannibal2.skyhanni.utils.EntityUtils.getSkinTexture
 import at.hannibal2.skyhanni.utils.EntityUtils.isNpc
 import at.hannibal2.skyhanni.utils.LorenzColor
@@ -76,16 +75,16 @@ object DungeonLividFinder {
     private var color: LorenzColor? = null
 
     private val lividTextureToColor = mutableMapOf<String, LorenzColor>()
-    private var lividNameToColor = mapOf(
-        "Vendetta" to LorenzColor.WHITE,
-        "Doctor" to LorenzColor.GRAY,
-        "Crossed" to LorenzColor.LIGHT_PURPLE,
-        "Purple" to LorenzColor.DARK_PURPLE,
-        "Scream" to LorenzColor.BLUE,
-        "Hockey" to LorenzColor.RED,
-        "Arcade" to LorenzColor.YELLOW,
-        "Smile" to LorenzColor.GREEN,
-        "Frog" to LorenzColor.DARK_GREEN,
+    private var lividNameToColor = mapOf<String, LorenzColor>(
+        "Vendetta" to WHITE,
+        "Doctor" to GRAY,
+        "Crossed" to LIGHT_PURPLE,
+        "Purple" to DARK_PURPLE,
+        "Scream" to BLUE,
+        "Hockey" to RED,
+        "Arcade" to YELLOW,
+        "Smile" to GREEN,
+        "Frog" to DARK_GREEN,
     )
 
     /**
@@ -107,7 +106,7 @@ object DungeonLividFinder {
     )
 
     @HandleEvent
-    fun onRepoReload(event: RepositoryReloadEvent) {
+    private fun onRepoReload(event: RepositoryReloadEvent) {
         lividTextureToColor.clear()
         val data = event.getConstant<LividSolverJson>("dungeons/LividSolver")
         val names = mutableMapOf<String, LorenzColor>()
@@ -122,8 +121,8 @@ object DungeonLividFinder {
         }
     }
 
-    @HandleEvent(SecondPassedEvent::class)
-    fun onSecondPassed() {
+    @HandleEvent
+    private fun onSecondPassed() {
         if (!config.enabled.get()) return
         if (!inLividBossRoom()) return
         if (color == null) return
@@ -150,7 +149,7 @@ object DungeonLividFinder {
     }
 
     @HandleEvent
-    fun onBlockChange(event: ServerBlockChangeEvent) {
+    private fun onBlockChange(event: ServerBlockChangeEvent) {
         if (!inLividBossRoom()) return
         if (event.location != blockLocation) return
         if (!event.newState.isWool()) return
@@ -163,7 +162,7 @@ object DungeonLividFinder {
         fakeLivids.clear()
 
         for (mob in lividEntities) {
-            if (mob.isLividColor(LorenzColor.RED) && newColor != LorenzColor.RED) {
+            if (mob.isLividColor(RED) && newColor != RED) {
                 if (mob == livid) {
                     livid = null
                 }
@@ -183,26 +182,26 @@ object DungeonLividFinder {
     }
 
     @HandleEvent(DungeonBossRoomEnterEvent::class)
-    fun onBossStart() {
+    private fun onBossStart() {
         if (DungeonApi.getCurrentBoss() != DungeonFloor.F5) return
-        color = LorenzColor.RED
+        color = RED
     }
 
     @HandleEvent(DungeonCompleteEvent::class)
-    fun onBossEnd() {
+    private fun onBossEnd() {
         color = null
         livid = null
         fakeLivids.clear()
     }
 
     @HandleEvent
-    fun onWorldChange() {
+    private fun onWorldChange() {
         color = null
         livid = null
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.CATACOMBS)
-    fun onCheckRender(event: CheckRenderEntityEvent<Entity>) {
+    @HandleEvent(onlyOnIsland = CATACOMBS)
+    private fun onCheckRender(event: CheckRenderEntityEvent<Entity>) {
         if (!inLividBossRoom() || !config.hideWrong) return
         if (livid == null) return // in case livid detection fails, don't hide anything
         if (event.entity is RemotePlayer && event.entity in fakeLivids) event.cancel()
@@ -218,8 +217,7 @@ object DungeonLividFinder {
     private fun isCurrentlyBlind() = (MinecraftCompat.localPlayerOrNull?.activePotionEffect(EffectsCompat.BLINDNESS)?.duration ?: 0) > 10
 
     private fun RemotePlayer.isLividColor(color: LorenzColor): Boolean {
-        val chatColor = color.getChatColor()
-        return name.formattedTextCompatLessResets().startsWith("$chatColor﴾ $chatColor§lLivid")
+        return name.intoSpan().sampleStyleAtStart().color?.value == color.toColor().rgb && cleanName.startsWith("﴾ Livid")
     }
 
     private fun RemotePlayer.getLividColor(): LorenzColor? {
@@ -228,13 +226,13 @@ object DungeonLividFinder {
     }
 
     @HandleEvent
-    fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
+    private fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
         if (!inLividBossRoom() || !config.enabled.get()) return
         if (isBlind) return
 
         val entity = livid ?: return
         val lorenzColor =
-            if (config.colorOverride != LividColorHighlight.DEFAULT) config.colorOverride.color as LorenzColor else color ?: return
+            if (config.colorOverride != DEFAULT) config.colorOverride.color as LorenzColor else color ?: return
 
         if (!entity.canBeSeen(ignoreFrustum = true)) return
         val location = event.exactLocation(entity)
@@ -255,7 +253,7 @@ object DungeonLividFinder {
             return
         }
 
-        val newColor = if (config.colorOverride != LividColorHighlight.DEFAULT) config.colorOverride.color as LorenzColor else color
+        val newColor = if (config.colorOverride != DEFAULT) config.colorOverride.color as LorenzColor else color
 
         RenderLivingEntityHelper.setEntityColor(
             entity = this,
@@ -264,8 +262,8 @@ object DungeonLividFinder {
         )
     }
 
-    @HandleEvent(ConfigLoadEvent::class)
-    fun onConfigLoad() {
+    @HandleEvent
+    private fun onConfigLoad() {
         config.enabled.onToggle {
             reloadHighlight()
         }
@@ -309,11 +307,10 @@ object DungeonLividFinder {
         ;
 
         override fun toString() = prettyName
-
     }
 
     @HandleEvent
-    fun onDebugDataCollect(event: DebugDataCollectEvent) {
+    private fun onDebugDataCollect(event: DebugDataCollectEvent) {
         event.title("Livid Finder")
 
         if (!inLividBossRoom()) {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarApi.kt
@@ -47,7 +47,6 @@ import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object BazaarApi {
-
     private val storage get() = ProfileStorageData.playerSpecific?.bazaar
 
     private var loadedNpcPriceData = false
@@ -195,7 +194,6 @@ object BazaarApi {
             val nameStr = item.cleanName.removePrefix("BUY ").removePrefix("SELL ")
             val internalName = item.getInternalNameOrNull() ?: NeuInternalName.fromItemNameOrNull(nameStr)
 
-
             if (internalName != null) {
                 if (itemName.contains("SELL", ignoreCase = true)) {
                     orderOptionProduct = internalName
@@ -223,14 +221,14 @@ object BazaarApi {
 
     private fun getOpenedProduct(inventoryItems: Map<Int, SafeItemStack>): NeuInternalName? {
         val buyInstantly = inventoryItems[10] ?: return null
-        if (buyInstantly.hoverName.formattedTextCompatLeadingWhiteLessResets() != "§aBuy Instantly") return null
+        if (buyInstantly.cleanName != "Buy Instantly") return null
         val bazaarItem = inventoryItems[13] ?: return null
         return NeuInternalName.fromItemName(bazaarItem.hoverName.formattedTextCompatLeadingWhiteLessResets())
     }
 
     private fun updateTaxRate(inventoryItems: Map<Int, SafeItemStack>) {
         val sellInstantly = inventoryItems[11] ?: return
-        if (sellInstantly.hoverName.formattedTextCompatLeadingWhiteLessResets() != "§6Sell Instantly") return
+        if (sellInstantly.cleanName != "Sell Instantly") return
         taxPattern.firstMatcher(sellInstantly.getLore()) {
             taxRate = group("tax").formatDouble()
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabListReader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/compacttablist/TabListReader.kt
@@ -5,6 +5,7 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.TabListUpdateEvent
 import at.hannibal2.skyhanni.events.TablistFooterUpdateEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ComponentMatcherUtils.intoSpan
 import at.hannibal2.skyhanni.utils.ConditionalUtils
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
@@ -15,11 +16,11 @@ import at.hannibal2.skyhanni.utils.chat.TextHelper
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.network.chat.Component
+import net.minecraft.network.chat.TextColor
 
 // heavily inspired by SBA code
 @SkyHanniModule
 object TabListReader {
-
     private val config get() = SkyHanniMod.feature.gui.compactTabList
     private val patternGroup = RepoPattern.group("misc.compacttablist")
 
@@ -238,7 +239,7 @@ object TabListReader {
         }
         upgradesPattern.matchMatcher(component) {
             if (!inUpgrades) return@matchMatcher
-            if (!component.formattedTextCompat().startsWith("§e")) return@matchMatcher
+            if (component.intoSpan().sampleStyleAtStart().color != TextColor.fromLegacyFormat(YELLOW)) return@matchMatcher
 
             val firstComponent = TextHelper.matcher(component, group("firstPart")) ?: return@apply
             val secondComponent = TextHelper.matcher(component, group("secondPart")) ?: return@apply


### PR DESCRIPTION
## What
Small cleanup sweep searching for the regex `formattedTextCompat.*§` across the code. May be a slight win for memory usage.

Notable exclusions:
* DungeonHideItems (covered by #6404)
* HoppityCollectionStats (will be its own PR whenever I feel like it)
* InstanceChestProfit (covered by #6396)

## Changelog Technical Details
+ Replaced some unnecessary uses of formattedTextCompat methods with colorless or component style equivalents. - Luna
