### PR TITLE
Backend: Remove misleading/redundant includeImplementation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -181,11 +181,11 @@ dependencies {
     "minecraftTestClientRuntimeLibraries"(libs.basicMath)
 
     // getting clock offset
-    includeImplementation(libs.commons.net)
+    shadowImpl(libs.commons.net)
     "minecraftTestClientRuntimeLibraries"(libs.commons.net)
 
     // Calculator
-    includeImplementation(libs.keval) {
+    shadowImpl(libs.keval) {
         exclude(group = "org.jetbrains.kotlin")
     }
     "minecraftTestClientRuntimeLibraries"(libs.keval)
@@ -196,10 +196,6 @@ dependencies {
 
     shadowImpl(libs.httpclient)
     "minecraftTestClientRuntimeLibraries"(libs.httpclient)
-}
-
-fun DependencyHandler.includeImplementation(dep: Any, configure: ExternalModuleDependency.() -> Unit = {}) {
-    add("shadowImpl", dependencyNotation(dep)).also { (it as? ExternalModuleDependency)?.configure() }
 }
 
 afterEvaluate {


### PR DESCRIPTION
## What
`build.gradle.kts` has an `includeImplementation` method which appears to literally just be an alias of `shadowImpl`. It achieves nothing, the output JAR's files are the exact same after this change\*. And it's also misleading, because traditionally what you call `includeImplementation` very much *does not* shadow, but rather embeds a nested JAR (jar-in-jar).

\*The only difference may come from KSP deciding to put GeneratedPrimaryFunctionNames/LoadedModules in a different order, which has no effect on behavior and is unrelated to this change.

## Changelog Technical Details
+ Removed redundant and misleadingly named includeImplementation from the build script. - Luna
