### PR TITLE
Backend + Improvement: Cleanup RenderLivingEntityHelper

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/events/RenderEntityOutlineEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/RenderEntityOutlineEvent.kt
@@ -47,7 +47,7 @@ class RenderEntityOutlineEvent : SkyHanniEvent() {
             val entity: Entity = iterator.next()
             val color: Color? = outlineColor(entity)
             if (color != null) {
-                entitiesToOutline[entity] = color.rgb or 0xFF000000.toInt()
+                entitiesToOutline[entity] = color.rgb
                 iterator.remove()
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/events/RenderEntityOutlineEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/RenderEntityOutlineEvent.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.events
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 import at.hannibal2.skyhanni.utils.AllEntitiesGetter
 import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.isEmptyInvisibleArmorStand
@@ -8,17 +9,12 @@ import net.minecraft.world.entity.Entity
 import net.minecraft.world.entity.decoration.ItemFrame
 import java.awt.Color
 
-class RenderEntityOutlineEvent(theType: Type?, potentialEntities: HashSet<Entity> = hashSetOf()) : SkyHanniEvent() {
-
-    /**
-     * The phase of the event (see [Type]
-     */
-    var type: Type? = null
-
+@PrimaryFunction("onRenderEntityOutline")
+class RenderEntityOutlineEvent : SkyHanniEvent() {
     /**
      * The entities to outline. This is progressively cumulated from [.entitiesToChooseFrom]
      */
-    var entitiesToOutline: HashMap<Entity, Color> = hashMapOf()
+    var entitiesToOutline: HashMap<Entity, Int> = hashMapOf()
 
     /**
      * The entities we can outline. Note that this set and [.entitiesToOutline] are disjoint at all times.
@@ -29,22 +25,6 @@ class RenderEntityOutlineEvent(theType: Type?, potentialEntities: HashSet<Entity
      * Whether [.entitiesToChooseFrom] has been computed already.
      */
     private var computed: Boolean = false
-
-    /**
-     * Constructs the event, given the type and optional entities to outline.
-     *
-     *
-     * This will modify {@param potentialEntities} internally, so make a copy before passing it if necessary.
-     *
-     * @param theType of the event (see [Type]
-     */
-    init {
-        type = theType
-        entitiesToChooseFrom = potentialEntities
-        if (!potentialEntities.isEmpty()) {
-            entitiesToOutline = HashMap(potentialEntities.size)
-        }
-    }
 
     /**
      * Conditionally queue entities around which to render entities
@@ -62,13 +42,13 @@ class RenderEntityOutlineEvent(theType: Type?, potentialEntities: HashSet<Entity
             return
         }
         computeAndCacheEntitiesToChooseFrom()
-        val itr: MutableIterator<Entity> = entitiesToChooseFrom.iterator()
-        while (itr.hasNext()) {
-            val e: Entity = itr.next()
-            val i: Color? = outlineColor(e)
-            if (i != null) {
-                entitiesToOutline[e] = i
-                itr.remove()
+        val iterator: MutableIterator<Entity> = entitiesToChooseFrom.iterator()
+        while (iterator.hasNext()) {
+            val entity: Entity = iterator.next()
+            val color: Color? = outlineColor(entity)
+            if (color != null) {
+                entitiesToOutline[entity] = color.rgb or 0xFF000000.toInt()
+                iterator.remove()
             }
         }
     }
@@ -91,15 +71,5 @@ class RenderEntityOutlineEvent(theType: Type?, potentialEntities: HashSet<Entity
             }
         }
         entitiesToOutline = HashMap(entitiesToChooseFrom.size)
-    }
-
-    /**
-     * The phase of the event.
-     * [.XRAY] means that this directly precedes entities whose outlines are rendered through walls (Vanilla 1.9+)
-     * [.NO_XRAY] means that this directly precedes entities whose outlines are rendered only when visible to the client
-     */
-    enum class Type {
-        XRAY,
-        NO_XRAY
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/events/entity/EntityLeaveWorldEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/entity/EntityLeaveWorldEvent.kt
@@ -1,6 +1,11 @@
 package at.hannibal2.skyhanni.events.entity
 
 import at.hannibal2.skyhanni.api.event.GenericSkyHanniEvent
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 import net.minecraft.world.entity.Entity
 
+@Deprecated("Use EntityLeaveWorldEvent instead", ReplaceWith("EntityLeaveWorldEvent"))
+typealias EntityRemovedEvent<T> = EntityLeaveWorldEvent<T>
+
+@PrimaryFunction("onEntityLeaveWorld")
 class EntityLeaveWorldEvent<T : Entity>(val entity: T) : GenericSkyHanniEvent<T>(entity.javaClass)

--- a/src/main/java/at/hannibal2/skyhanni/events/entity/EntityRemovedEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/entity/EntityRemovedEvent.kt
@@ -1,6 +1,0 @@
-package at.hannibal2.skyhanni.events.entity
-
-import at.hannibal2.skyhanni.api.event.GenericSkyHanniEvent
-import net.minecraft.world.entity.Entity
-
-class EntityRemovedEvent<T : Entity>(val entity: T) : GenericSkyHanniEvent<T>(entity.javaClass)

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureFeatures.kt
@@ -36,7 +36,7 @@ object SeaCreatureFeatures {
     private val entityIds = TimeLimitedSet<Int>(6.minutes)
 
     @HandleEvent
-    fun onMobSpawn(event: MobEvent.Spawn.SkyblockMob) {
+    private fun onMobSpawn(event: MobEvent.Spawn.SkyblockMob) {
         if (!isEnabled()) return
         val mob = event.mob
 
@@ -46,7 +46,7 @@ object SeaCreatureFeatures {
     }
 
     @HandleEvent
-    fun onSkyblockMobFirstSeen(event: MobEvent.FirstSeen.SkyblockMob) {
+    private fun onSkyblockMobFirstSeen(event: MobEvent.FirstSeen.SkyblockMob) {
         if (!isEnabled()) return
         val mob = event.mob
         val seaCreature = mob.seaCreature ?: return
@@ -65,7 +65,7 @@ object SeaCreatureFeatures {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onSeaCreatureFish(event: SeaCreatureFishEvent) {
+    private fun onSeaCreatureFish(event: SeaCreatureFishEvent) {
         val fishedSCSettings = SeaCreatureSettings.getConfig(event.seaCreature) ?: return
         if (config.alertOwnCatches && fishedSCSettings.shouldSelfNotifyOnCatch == true) {
             val text = if (config.creatureName) "${event.seaCreature.displayName}!"
@@ -84,19 +84,19 @@ object SeaCreatureFeatures {
     }
 
     @HandleEvent
-    fun onWorldChange() {
+    private fun onWorldChange() {
         entityIds.clear()
     }
 
     @HandleEvent
-    fun onRenderEntityOutlines(event: RenderEntityOutlineEvent) {
-        if (isEnabled() && config.highlight && event.type === RenderEntityOutlineEvent.Type.NO_XRAY) {
+    private fun onRenderEntityOutline(event: RenderEntityOutlineEvent) {
+        if (isEnabled() && config.highlight) {
             event.queueEntitiesToOutline(getEntityOutlineColor)
         }
     }
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(2, "fishing.rareSeaCreatureHighlight", "fishing.rareCatches.highlight")
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/GlowingDroppedItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/GlowingDroppedItems.kt
@@ -16,9 +16,8 @@ object GlowingDroppedItems {
     private val config get() = SkyHanniMod.feature.misc
 
     @HandleEvent
-    fun onRenderEntityOutlines(event: RenderEntityOutlineEvent) {
+    private fun onRenderEntityOutline(event: RenderEntityOutlineEvent) {
         if (!isEnabled()) return
-        if (event.type != RenderEntityOutlineEvent.Type.NO_XRAY) return
 
         event.queueEntitiesToOutline(::getGlowColor)
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/PartyMemberOutlines.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/PartyMemberOutlines.kt
@@ -18,11 +18,9 @@ object PartyMemberOutlines {
     private val config get() = SkyHanniMod.feature.misc.highlightPartyMembers
 
     @HandleEvent(onlyOnSkyblockOrFeatures = [OutsideSBFeature.HIGHLIGHT_PARTY_MEMBERS])
-    fun onRenderEntityOutlines(event: RenderEntityOutlineEvent) {
+    private fun onRenderEntityOutline(event: RenderEntityOutlineEvent) {
         if (!config.enabled || DungeonApi.inDungeon()) return
-        if (event.type === RenderEntityOutlineEvent.Type.NO_XRAY) {
-            event.queueEntitiesToOutline { entity -> getEntityOutlineColor(entity) }
-        }
+        event.queueEntitiesToOutline { entity -> getEntityOutlineColor(entity) }
     }
 
     private fun getEntityOutlineColor(entity: Entity): Color? {

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderLivingEntityHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/RenderLivingEntityHelper.kt
@@ -3,43 +3,38 @@ package at.hannibal2.skyhanni.mixins.hooks
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.GlobalRender
 import at.hannibal2.skyhanni.events.RenderEntityOutlineEvent
-import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
+import at.hannibal2.skyhanni.events.entity.EntityLeaveWorldEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.EntityUtils.hasVisibleEquipment
-import at.hannibal2.skyhanni.utils.collection.CollectionUtils.removeIfKey
-import at.hannibal2.skyhanni.utils.compat.deceased
 import net.minecraft.world.entity.Entity
 import net.minecraft.world.entity.LivingEntity
 import java.awt.Color
-import java.util.concurrent.ConcurrentHashMap
 
 @SkyHanniModule
 object RenderLivingEntityHelper {
+    private data class EntityGlowData(val rgb: Int, val condition: () -> Boolean)
 
-    private val entityColorMap = mutableMapOf<LivingEntity, Color>()
-    private val entityColorCondition = ConcurrentHashMap<LivingEntity, () -> Boolean>()
+    private val entityGlowMap = mutableMapOf<Int, EntityGlowData>()
+    private var currentGlowEvent: RenderEntityOutlineEvent? = null
 
     @JvmStatic
     var isUsingCustomGlow = false
         private set
 
-    private var currentGlowEvent: RenderEntityOutlineEvent? = null
-
-    private fun getEntityGlowEventColor(entity: Entity): Int? =
-        currentGlowEvent?.entitiesToOutline?.get(entity)?.rgb?.takeIf { it != 0 }
-
     @JvmStatic
     fun postNoXrayOutlineEvent() {
-        isUsingCustomGlow = entityColorCondition.values.any { it() } ||
+        isUsingCustomGlow = entityGlowMap.values.any { it.condition() } ||
             currentGlowEvent?.entitiesToOutline.orEmpty().isNotEmpty()
 
-        val event = RenderEntityOutlineEvent(NO_XRAY)
+        val event = RenderEntityOutlineEvent()
         currentGlowEvent = event
         event.post()
     }
 
     @JvmStatic
     fun getEntityGlowColor(entity: Entity): Int? {
+        if (GlobalRender.renderDisabled) return null
         if (entity is LivingEntity) {
             if (entity.isInvisible && !entity.hasVisibleEquipment()) return null
             getLivingEntityGlowColor(entity)?.let { return it }
@@ -47,41 +42,37 @@ object RenderLivingEntityHelper {
         return getEntityGlowEventColor(entity)
     }
 
-    private fun getLivingEntityGlowColor(entity: LivingEntity): Int? =
-        internalSetColorMultiplier(entity, 0).takeIf { it != 0 }
+    private fun getEntityGlowEventColor(entity: Entity): Int? =
+        currentGlowEvent?.entitiesToOutline?.get(entity)
 
-    @HandleEvent
-    fun onWorldChange() {
-        entityColorMap.clear()
-        entityColorCondition.clear()
+    private fun getLivingEntityGlowColor(entity: LivingEntity): Int? {
+        val entityGlowData = entityGlowMap[entity.id] ?: return null
+        if (!entityGlowData.condition()) return null
+        return entityGlowData.rgb
     }
 
-    @HandleEvent(SkyHanniTickEvent::class)
-    fun onTick() {
-        entityColorMap.removeIfKey { it.deceased }
-        entityColorCondition.removeIfKey { it.deceased }
+    @HandleEvent
+    private fun onWorldChange() {
+        entityGlowMap.clear()
+    }
+
+    @HandleEvent
+    private fun onEntityLeaveWorld(event: EntityLeaveWorldEvent<LivingEntity>) {
+        entityGlowMap.remove(event.entity.id)
     }
 
     fun <T : LivingEntity> removeEntityColor(entity: T) {
-        entityColorMap.remove(entity)
-        entityColorCondition.remove(entity)
+        val entityId = entity.id
+        DelayedRun.runOrNextTick {
+            entityGlowMap.remove(entityId)
+        }
     }
 
     fun <T : LivingEntity> setEntityColor(entity: T, color: Color, condition: () -> Boolean) {
-        if (color.rgb == 0) return
-        entityColorMap[entity] = color
-        entityColorCondition[entity] = condition
-    }
-
-    @JvmStatic
-    fun <T : LivingEntity> internalSetColorMultiplier(entity: T, default: Int): Int {
-        if (GlobalRender.renderDisabled) return default
-        if (entityColorMap.containsKey(entity)) {
-            val condition = entityColorCondition[entity] ?: return default
-            if (condition.invoke()) {
-                return entityColorMap[entity]?.rgb ?: return default
-            }
+        val rgb = color.rgb.takeUnless { it == 0 } ?: return
+        val entityId = entity.id
+        DelayedRun.runOrNextTick {
+            entityGlowMap[entityId] = EntityGlowData(rgb, condition)
         }
-        return default
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinTransientEntitySectionManager$Callback.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinTransientEntitySectionManager$Callback.java
@@ -1,7 +1,6 @@
 package at.hannibal2.skyhanni.mixins.transformers;
 
 import at.hannibal2.skyhanni.data.EntityData;
-import at.hannibal2.skyhanni.events.entity.EntityRemovedEvent;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.Entity.RemovalReason;
 import net.minecraft.world.level.entity.EntityAccess;
@@ -24,7 +23,6 @@ public abstract class MixinTransientEntitySectionManager$Callback<T extends Enti
     private void remove(RemovalReason reason, CallbackInfo ci) {
         if (entity instanceof Entity typedEntity) {
             EntityData.despawnEntity(typedEntity);
-            new EntityRemovedEvent<>(typedEntity).post();
         }
     }
 }


### PR DESCRIPTION
## What

1. Removed the XRAY type of the `RenderEntityOutlineEvent` since it was unused
2. replaced the `onTick` usage in `RenderLivingEntityHelper` with just a `EntityLeaveWorldEvent`
3. Made `EntityRemovedEvent` a type alias to `EntityLeaveWorldEvent` (they were fired one after the other, so I just merged them)
4. Switched the `ConcurrentHashMap` to ~`Int2ObjectOpenHashMap`~ `MutableMap` + `DelayedRun`

For the last point, `Int2ObjectOpenHashMap` is from fastutils. which would be the first usage of it in SkyHanni.
(It is bundled into minecraft).
And since this map is called for every entity in the world and every tick, it's usage would be beneficial.

## Changelog Improvements
+ Improved entity glowing performance. - Avrg

## Changelog Technical Details
+ Cleaned up RenderLivingEntityHelper. - Avrg
