### PR TITLE
Backend: Remove old Forge tweaker relocation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -359,7 +359,6 @@ tasks.shadowJar {
     mergeServiceFiles()
     relocate("io.github.notenoughupdates.moulconfig", "at.hannibal2.skyhanni.deps.moulconfig")
     relocate("moe.nea.libautoupdate", "at.hannibal2.skyhanni.deps.libautoupdate")
-    relocate("net.hypixel.modapi.tweaker", "at.hannibal2.skyhanni.deps.hypixel.modapi.tweaker")
 }
 tasks.jar {
     archiveClassifier.set("nodeps")


### PR DESCRIPTION
## What
Removes an ancient Hypixel Mod API relocation that is specific to the Forge tweaker. It does absolutely nothing since we're Fabric only now and the Fabric library doesn't have this.

exclude_from_changelog