### PR TITLE
Fix: PIP renderer performance

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinGuiRenderer.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinGuiRenderer.java
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.mixins.transformers;
 
 import at.hannibal2.skyhanni.mixins.hooks.GuiRendererHook;
 import at.hannibal2.skyhanni.utils.render.item.SkyHanniGuiItemRenderState;
+import at.hannibal2.skyhanni.utils.render.item.SkyHanniItemRenderCoordinator;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
@@ -28,7 +29,6 @@ import java.util.Map;
 
 @Mixin(GuiRenderer.class)
 public abstract class MixinGuiRenderer {
-
     @Inject(method = "executeDrawRange", at = @At("HEAD"))
     public void computeChromaBufferSlice(
         CallbackInfo ci) {
@@ -94,6 +94,14 @@ public abstract class MixinGuiRenderer {
             featureRenderDispatcher,
             skyhanni$frameNumber
         );
+    }
+
+    @Inject(
+        method = "preparePictureInPicture",
+        at = @At("TAIL")
+    )
+    private void skyhanni$evictUnusedRealtimeSlots(CallbackInfo ci) {
+        SkyHanniItemRenderCoordinator.evictUnusedRealtimeSlots(skyhanni$frameNumber);
     }
 
     @Inject(

--- a/src/main/java/at/hannibal2/skyhanni/utils/VectorUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/VectorUtils.kt
@@ -1,0 +1,10 @@
+package at.hannibal2.skyhanni.utils
+
+import net.minecraft.world.phys.Vec3
+
+object VectorUtils {
+    /**
+     * Compares two vectors for equality, treating -0.0 and 0.0 as equal, unlike [Vec3.equals].
+     */
+    fun Vec3.isEqualTo(other: Vec3): Boolean = x == other.x && y == other.y && z == other.z
+}

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/item/SkyHanniItemRenderCoordinator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/item/SkyHanniItemRenderCoordinator.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.utils.render.item
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.VectorUtils.isEqualTo
 import at.hannibal2.skyhanni.utils.render.item.atlas.SkyHanniItemAtlas
 import net.minecraft.client.Minecraft
 import net.minecraft.client.renderer.ProjectionMatrixBuffer
@@ -14,34 +15,48 @@ import kotlin.math.abs
 //? if >= 26.2 {
 import net.minecraft.client.renderer.SubmitNodeStorage
 //?} else {
-/*import net.minecraft.client.renderer.MultiBufferSource.BufferSource
+/*import net.minecraft.client.renderer.MultiBufferSource
 *///?}
 
 @SkyHanniModule
 internal object SkyHanniItemRenderCoordinator {
-
     @HandleEvent
-    fun onDebugDataCollect(event: DebugDataCollectEvent) {
+    private fun onDebugDataCollect(event: DebugDataCollectEvent) {
         event.title("Item Atlas")
         event.addIrrelevant {
             atlas.atlasDebugInfo().onEach(::add)
+            add("Realtime slot pools: ${slotPools.size} sizes, ${slotPools.values.sumOf { it.slots.size }} slots")
+            add("Settle tracker entries: ${settleTracker.size}")
         }
     }
 
+    //? if >= 26.2
+    private val submitNodeStorage = SubmitNodeStorage()
+
     private data class FrameRenderResources(
-        //~ if < 26.2 'submitNodeStorage: SubmitNodeStorage' -> 'bufferSource: BufferSource'
+        //~ if < 26.2 'submitNodeStorage: SubmitNodeStorage' -> 'bufferSource: MultiBufferSource.BufferSource'
         val submitNodeStorage: SubmitNodeStorage,
         val featureRenderDispatcher: FeatureRenderDispatcher,
         val guiScale: Int,
     )
     private var frameResources: FrameRenderResources? = null
 
-    // items actively spinning re-render every frame, same as Mojang's isAnimated path.
-    // items that have been stable for this many frames are committed to the atlas.
+    // Items actively spinning re-render every frame, same as Mojang's isAnimated path.
+    // Items that have been stable for this many frames are committed to the atlas.
     private const val SETTLE_FRAMES = 4
+
+    // Pooled slots idle for this many frames are closed, and stale settle entries dropped
+    private const val IDLE_EVICT_FRAMES = 100
     private val projectionBuffer by lazy { ProjectionMatrixBuffer("SkyHanni items") }
-    private val realtimeSlots = LinkedHashMap<Int, SkyHanniRealtimeItemSlot>()
-    private val realtimeSlotLastSeen = HashMap<Int, Int>() // stableId -> frameNumber
+
+    // Realtime slots are cleared and re-rendered every frame, so they carry no item identity.
+    // Pooling them by size lets frames reuse textures even when callers lose their stableId.
+    private class RealtimeSlotPool {
+        val slots = ArrayList<SkyHanniRealtimeItemSlot>()
+        var cursor = 0
+    }
+    private val slotPools = HashMap<Int, RealtimeSlotPool>() // slotSize -> pool
+    private var poolFrame = -1
     private val settleTracker = HashMap<Int, SettleEntry>() // keyed by stableId, NOT atlasKey
     private val atlas by lazy { SkyHanniItemAtlas() }
     private var lastEvictFrame = -1
@@ -49,15 +64,18 @@ internal object SkyHanniItemRenderCoordinator {
     fun invalidateAtlas() {
         atlas.invalidate()
         settleTracker.clear()
-        realtimeSlots.values.forEach { it.close() }
-        realtimeSlots.clear()
+        closeRealtimeSlots()
     }
 
     fun closeAtlas() {
         atlas.close()
         projectionBuffer.close()
-        realtimeSlots.values.forEach { it.close() }
-        realtimeSlots.clear()
+        closeRealtimeSlots()
+    }
+
+    private fun closeRealtimeSlots() {
+        slotPools.values.forEach { pool -> pool.slots.forEach { it.close() } }
+        slotPools.clear()
     }
 
     // Called once per frame at HEAD of preparePictureInPicture.
@@ -65,23 +83,26 @@ internal object SkyHanniItemRenderCoordinator {
     fun preRenderAtlas(
         pipStates: List<SkyHanniGuiItemRenderState>,
         //? if < 26.2
-        //bufferSource: BufferSource,
+        //bufferSource: MultiBufferSource.BufferSource,
         featureRenderDispatcher: FeatureRenderDispatcher,
         frameNumber: Int,
     ) {
-        if (pipStates.isEmpty()) return
-        handleEviction(frameNumber)
+        if (pipStates.isEmpty()) {
+            frameResources = null
+            return
+        }
 
         val guiScale = Minecraft.getInstance().window.guiScale
-        //~ if < 26.2 'SubmitNodeStorage()' -> 'bufferSource'
-        frameResources = FrameRenderResources(SubmitNodeStorage(), featureRenderDispatcher, guiScale)
+        //~ if < 26.2 'submitNodeStorage' -> 'bufferSource'
+        frameResources = FrameRenderResources(submitNodeStorage, featureRenderDispatcher, guiScale)
         val atlasStates = ArrayList<SkyHanniGuiItemRenderState>(pipStates.size)
 
         for (state in pipStates) {
             val settle = settleTracker.getOrPut(state.stableId) {
-                SettleEntry(state.rotationVector, state.adjustedScale, 0)
+                SettleEntry(state.rotationVector, state.adjustedScale, 0, frameNumber)
             }
-            val stable = settle.rotationVec == state.rotationVector &&
+            settle.lastSeenFrame = frameNumber
+            val stable = settle.rotationVec.isEqualTo(state.rotationVector) &&
                 abs(settle.lastScale - state.adjustedScale) < 0.01f
             if (stable) settle.framesStable++
             else {
@@ -96,8 +117,8 @@ internal object SkyHanniItemRenderCoordinator {
         if (atlasStates.isEmpty()) return
 
         val renderContext = SkyHanniItemRenderContext(
-            //~ if < 26.2 'SubmitNodeStorage()' -> 'bufferSource'
-            atlasStates, SubmitNodeStorage(), featureRenderDispatcher, frameNumber, guiScale,
+            //~ if < 26.2 'submitNodeStorage' -> 'bufferSource'
+            atlasStates, submitNodeStorage, featureRenderDispatcher, frameNumber, guiScale,
         )
 
         with(atlas) { renderContext.setupAtlasRendering(frameNumber, projectionBuffer) }
@@ -122,14 +143,8 @@ internal object SkyHanniItemRenderCoordinator {
             // Atlas miss (overflow or not yet allocated) - fall through to realtime
         }
 
-        realtimeSlotLastSeen[state.stableId] = frameNumber
         val slotSize = (16 * resources.guiScale * state.adjustedScale).toInt()
-        val existing = realtimeSlots[state.stableId]
-        val slot = if (existing != null && existing.slotSize == slotSize) existing
-        else {
-            existing?.close()
-            SkyHanniRealtimeItemSlot(slotSize).also { realtimeSlots[state.stableId] = it }
-        }
+        val slot = acquireRealtimeSlot(slotSize, frameNumber)
         val renderContext = SkyHanniItemRenderContext(
             atlasStates = emptyList(),
             //~ if < 26.2 'submitNodeStorage' -> 'bufferSource'
@@ -141,18 +156,38 @@ internal object SkyHanniItemRenderCoordinator {
         slot.render(renderContext, state, guiRenderState, projectionBuffer)
     }
 
-    private fun handleEviction(frameNumber: Int) {
+    private fun acquireRealtimeSlot(slotSize: Int, frameNumber: Int): SkyHanniRealtimeItemSlot {
+        if (poolFrame != frameNumber) {
+            poolFrame = frameNumber
+            slotPools.values.forEach { it.cursor = 0 }
+        }
+        val pool = slotPools.getOrPut(slotSize) { RealtimeSlotPool() }
+        val slot = pool.slots.getOrNull(pool.cursor) ?: SkyHanniRealtimeItemSlot(slotSize).also(pool.slots::add)
+        pool.cursor++
+        slot.lastUsedFrame = frameNumber
+        return slot
+    }
+
+    @JvmStatic
+    fun evictUnusedRealtimeSlots(frameNumber: Int) {
         if (frameNumber == lastEvictFrame) return
         lastEvictFrame = frameNumber
-        realtimeSlots.entries.removeIf { (id, slot) ->
-            val stale = realtimeSlotLastSeen.getOrDefault(id, -1) < frameNumber - 1
-            if (stale) {
-                slot.close()
-                realtimeSlotLastSeen.remove(id)
+        slotPools.values.removeIf { pool ->
+            // Slots are acquired front-to-back, so the stalest slot is always last
+            while (pool.slots.isNotEmpty() && frameNumber - pool.slots.last().lastUsedFrame > IDLE_EVICT_FRAMES) {
+                pool.slots.removeLast().close()
             }
-            stale
+            pool.slots.isEmpty()
+        }
+        if (frameNumber % IDLE_EVICT_FRAMES == 0) {
+            settleTracker.values.removeIf { frameNumber - it.lastSeenFrame > IDLE_EVICT_FRAMES }
         }
     }
 
-    private data class SettleEntry(var rotationVec: Vec3, var lastScale: Float, var framesStable: Int)
+    private data class SettleEntry(
+        var rotationVec: Vec3,
+        var lastScale: Float,
+        var framesStable: Int,
+        var lastSeenFrame: Int,
+    )
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/item/SkyHanniItemRenderCoordinator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/item/SkyHanniItemRenderCoordinator.kt
@@ -87,11 +87,6 @@ internal object SkyHanniItemRenderCoordinator {
         featureRenderDispatcher: FeatureRenderDispatcher,
         frameNumber: Int,
     ) {
-        if (pipStates.isEmpty()) {
-            frameResources = null
-            return
-        }
-
         val guiScale = Minecraft.getInstance().window.guiScale
         //~ if < 26.2 'submitNodeStorage' -> 'bufferSource'
         frameResources = FrameRenderResources(submitNodeStorage, featureRenderDispatcher, guiScale)

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/item/SkyHanniRealtimeItemSlot.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/item/SkyHanniRealtimeItemSlot.kt
@@ -15,6 +15,8 @@ import net.minecraft.client.renderer.state.gui.GuiRenderState
 import kotlin.math.roundToInt
 
 internal class SkyHanniRealtimeItemSlot(val slotSize: Int) : SkyHanniAbstractItemTexture() {
+    // Frame the pool last handed this slot out; used for idle eviction
+    var lastUsedFrame = -1
 
     init { allocate(slotSize) }
 


### PR DESCRIPTION
## What
Realtime slots are cleared and re-rendered every frame, so keying them by `stableId` caused a full texture alloc/free cycle per item per frame whenever callers rebuilt their renderables. Size-keyed pooling reuses the textures regardless of caller identity, and stale settle tracker entries are now evicted instead of accumulating.

In addition, PIP textures are now also checked for eviction when we're not currently rendering any items, which is another small optimization, because previously some could have remained stale.

## Changelog Fixes
+ Fixed FPS drops caused by rendering items in SkyHanni GUIs. - Luna