### PR TITLE
Fix: Don't corrupt category volume when playing own sounds

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
@@ -11,9 +11,8 @@ import com.google.gson.JsonObject
 import com.google.gson.JsonPrimitive
 
 object ConfigUpdaterMigrator {
-
     val logger = SkyHanniLogger("ConfigMigration")
-    const val CONFIG_VERSION = 144
+    const val CONFIG_VERSION = 145
     fun JsonElement.at(chain: List<String>, init: Boolean): JsonElement? {
         if (chain.isEmpty()) return this
         if (this !is JsonObject) return null

--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.kt
@@ -397,10 +397,11 @@ class MiscConfig {
     @Expose
     @ConfigOption(
         name = "Maintain Volume During Warnings",
-        desc = "Do not change game volume levels when warning sounds are played.",
+        desc = "Respect game volume settings for warning sounds instead of always playing them at 100%.",
     )
     @ConfigEditorBoolean
     @FeatureToggle
+    @SearchTag("levels loud quiet")
     var maintainGameVolume: Boolean = false
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.kt
@@ -396,13 +396,14 @@ class MiscConfig {
 
     @Expose
     @ConfigOption(
-        name = "Maintain Volume During Warnings",
-        desc = "Respect game volume settings for warning sounds instead of always playing them at 100%.",
+        name = "Boost Warning Volume",
+        desc = "Play SkyHanni warning sounds at 100% volume regardless of game volume settings.\n" +
+            "If the game is muted, you still won't hear the sounds.",
     )
     @ConfigEditorBoolean
     @FeatureToggle
-    @SearchTag("levels loud quiet")
-    var maintainGameVolume: Boolean = false
+    @SearchTag("beep change ding during loud maintain pling quiet warnings")
+    var boostWarningVolume: Boolean = true
 
     @Expose
     @ConfigOption(

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/SoundEngineHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/SoundEngineHook.kt
@@ -11,7 +11,7 @@ object SoundEngineHook {
      * A complete mute is still respected and not bypassed.
      */
     @JvmStatic
-    fun modifySoundVolume(soundInstance: SoundInstance, original: Float): Float {
+    fun modifyVolume(soundInstance: SoundInstance, original: Float): Float {
         if (soundInstance !is SkyHanniSoundInstance) return original
         if (original == 0f) return original
         if (!SkyHanniMod.feature.misc.boostWarningVolume) return original

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/SoundEngineHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/SoundEngineHook.kt
@@ -12,6 +12,7 @@ object SoundEngineHook {
     @JvmStatic
     fun modifySoundVolume(soundInstance: SoundInstance, original: Float): Float {
         if (soundInstance !is SkyHanniSoundInstance) return original
+        if (original == 0f) return original
         if (SkyHanniMod.feature.misc.maintainGameVolume) return original
         return soundInstance.volume.coerceIn(0f, 1f)
     }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/SoundEngineHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/SoundEngineHook.kt
@@ -8,12 +8,13 @@ object SoundEngineHook {
     /**
      * Makes SkyHanni's own sounds bypass the user's volume settings, without touching
      * the volume of any other sound or the sound engine's global volume state.
+     * A complete mute is still respected and not bypassed.
      */
     @JvmStatic
     fun modifySoundVolume(soundInstance: SoundInstance, original: Float): Float {
         if (soundInstance !is SkyHanniSoundInstance) return original
         if (original == 0f) return original
-        if (SkyHanniMod.feature.misc.maintainGameVolume) return original
+        if (!SkyHanniMod.feature.misc.boostWarningVolume) return original
         return soundInstance.volume.coerceIn(0f, 1f)
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/SoundEngineHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/SoundEngineHook.kt
@@ -1,0 +1,18 @@
+package at.hannibal2.skyhanni.mixins.hooks
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.utils.SkyHanniSoundInstance
+import net.minecraft.client.resources.sounds.SoundInstance
+
+object SoundEngineHook {
+    /**
+     * Makes SkyHanni's own sounds bypass the user's volume settings, without touching
+     * the volume of any other sound or the sound engine's global volume state.
+     */
+    @JvmStatic
+    fun modifySoundVolume(soundInstance: SoundInstance, original: Float): Float {
+        if (soundInstance !is SkyHanniSoundInstance) return original
+        if (SkyHanniMod.feature.misc.maintainGameVolume) return original
+        return soundInstance.volume.coerceIn(0f, 1f)
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinSoundEngine.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinSoundEngine.java
@@ -45,7 +45,7 @@ public abstract class MixinSoundEngine {
         )
     )
     public float overrideSkyHanniSoundVolume(float original, @Local(argsOnly = true) SoundInstance soundInstance) {
-        return SoundEngineHook.modifySoundVolume(soundInstance, original);
+        return SoundEngineHook.modifyVolume(soundInstance, original);
     }
 
     @ModifyReturnValue(
@@ -53,6 +53,6 @@ public abstract class MixinSoundEngine {
         at = @At("RETURN")
     )
     public float overrideSkyHanniSoundVolumeOnRefresh(float original, @Local(argsOnly = true) SoundInstance soundInstance) {
-        return SoundEngineHook.modifySoundVolume(soundInstance, original);
+        return SoundEngineHook.modifyVolume(soundInstance, original);
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinSoundEngine.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinSoundEngine.java
@@ -1,7 +1,11 @@
 package at.hannibal2.skyhanni.mixins.transformers;
 
 import at.hannibal2.skyhanni.events.PlaySoundEvent;
+import at.hannibal2.skyhanni.mixins.hooks.SoundEngineHook;
 import at.hannibal2.skyhanni.utils.LorenzVec;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.client.resources.sounds.SoundInstance;
 import net.minecraft.client.sounds.SoundEngine;
 import org.apache.commons.lang3.StringUtils;
@@ -12,7 +16,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(SoundEngine.class)
 public abstract class MixinSoundEngine {
-
     @Inject(
         method = "play",
         at = @At(
@@ -32,5 +35,24 @@ public abstract class MixinSoundEngine {
         ) {
             cir.setReturnValue(SoundEngine.PlayResult.NOT_STARTED);
         }
+    }
+
+    @ModifyExpressionValue(
+        method = "play",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/client/sounds/SoundEngine;calculateVolume(FLnet/minecraft/sounds/SoundSource;)F"
+        )
+    )
+    public float overrideSkyHanniSoundVolume(float original, @Local(argsOnly = true) SoundInstance soundInstance) {
+        return SoundEngineHook.modifySoundVolume(soundInstance, original);
+    }
+
+    @ModifyReturnValue(
+        method = "calculateVolume(Lnet/minecraft/client/resources/sounds/SoundInstance;)F",
+        at = @At("RETURN")
+    )
+    public float overrideSkyHanniSoundVolumeOnRefresh(float original, @Local(argsOnly = true) SoundInstance soundInstance) {
+        return SoundEngineHook.modifySoundVolume(soundInstance, original);
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyHanniSoundInstance.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyHanniSoundInstance.kt
@@ -2,7 +2,7 @@ package at.hannibal2.skyhanni.utils
 
 import net.minecraft.client.resources.sounds.SimpleSoundInstance
 import net.minecraft.client.resources.sounds.SoundInstance
-import net.minecraft.sounds.SoundEvent
+import net.minecraft.resources.Identifier
 import net.minecraft.sounds.SoundSource
 
 /**
@@ -11,11 +11,11 @@ import net.minecraft.sounds.SoundSource
  * See `MixinSoundEngine` and [at.hannibal2.skyhanni.mixins.hooks.SoundEngineHook].
  */
 class SkyHanniSoundInstance(
-    soundEvent: SoundEvent,
+    identifier: Identifier,
     pitch: Float,
     volume: Float,
 ) : SimpleSoundInstance(
-    soundEvent.location(),
+    identifier,
     SoundSource.UI,
     volume,
     pitch,

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyHanniSoundInstance.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyHanniSoundInstance.kt
@@ -6,9 +6,9 @@ import net.minecraft.resources.Identifier
 import net.minecraft.sounds.SoundSource
 
 /**
- * A UI sound created by SkyHanni. Unless the user opted out via the Maintain Volume During Warnings option,
- * these sounds bypass the volume settings and play at their instance volume, without affecting any other sounds.
- * A complete mute is still respected and not bypassed.
+ * A UI sound created by SkyHanni. Unless the user turned off the Boost Warning Volume option,
+ * these sounds bypass the volume settings and play at their instance volume, without affecting
+ * any other sounds. A complete mute is still respected and not bypassed.
  * See `MixinSoundEngine` and [at.hannibal2.skyhanni.mixins.hooks.SoundEngineHook].
  */
 class SkyHanniSoundInstance(

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyHanniSoundInstance.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyHanniSoundInstance.kt
@@ -1,0 +1,30 @@
+package at.hannibal2.skyhanni.utils
+
+import net.minecraft.client.resources.sounds.SimpleSoundInstance
+import net.minecraft.client.resources.sounds.SoundInstance
+import net.minecraft.sounds.SoundEvent
+import net.minecraft.sounds.SoundSource
+
+/**
+ * A UI sound created by SkyHanni. Unless the user opted out via the Maintain Volume During Warnings option,
+ * these sounds bypass the volume settings and play at their instance volume, without affecting any other sounds.
+ * See `MixinSoundEngine` and [at.hannibal2.skyhanni.mixins.hooks.SoundEngineHook].
+ */
+class SkyHanniSoundInstance(
+    soundEvent: SoundEvent,
+    pitch: Float,
+    volume: Float,
+) : SimpleSoundInstance(
+    soundEvent.location(),
+    SoundSource.UI,
+    volume,
+    pitch,
+    SoundInstance.createUnseededRandom(),
+    false,
+    0,
+    SoundInstance.Attenuation.NONE,
+    0.0,
+    0.0,
+    0.0,
+    true,
+)

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyHanniSoundInstance.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyHanniSoundInstance.kt
@@ -26,5 +26,6 @@ class SkyHanniSoundInstance(
     0.0,
     0.0,
     0.0,
+    // isRelative = true means the sound is relative to the listener so (0.0, 0.0, 0.0) is centered on the player
     true,
 )

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyHanniSoundInstance.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyHanniSoundInstance.kt
@@ -8,6 +8,7 @@ import net.minecraft.sounds.SoundSource
 /**
  * A UI sound created by SkyHanni. Unless the user opted out via the Maintain Volume During Warnings option,
  * these sounds bypass the volume settings and play at their instance volume, without affecting any other sounds.
+ * A complete mute is still respected and not bypassed.
  * See `MixinSoundEngine` and [at.hannibal2.skyhanni.mixins.hooks.SoundEngineHook].
  */
 class SkyHanniSoundInstance(

--- a/src/main/java/at/hannibal2/skyhanni/utils/SoundUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SoundUtils.kt
@@ -9,7 +9,6 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.compat.SoundCompat
 import net.minecraft.client.Minecraft
-import net.minecraft.client.resources.sounds.SimpleSoundInstance
 import net.minecraft.client.resources.sounds.SoundInstance
 import net.minecraft.resources.Identifier
 import net.minecraft.sounds.SoundEvent
@@ -17,20 +16,15 @@ import kotlinx.coroutines.delay
 
 @SkyHanniModule
 object SoundUtils {
-
-    private val config get() = SkyHanniMod.feature.misc
     private val beepSoundCache = mutableMapOf<Float, SoundInstance>()
     private val clickSound by lazy { createSound("ui.button.click", 1f) }
     private val errorSound by lazy { createSound("entity.enderman.teleport", 0f) }
     val plingSound by lazy { createSound("block.note_block.pling", 1f) }
 
+    // Sounds created via createSound bypass the user's volume settings
+    // unless the maintainGameVolume option is enabled, see SoundEngineHook.
     fun SoundInstance.playSound() {
         DelayedRun.runOrNextTick {
-            val category = this.source
-
-            val oldLevel = Minecraft.getInstance().options.getSoundSourceVolume(category)
-            if (!config.maintainGameVolume) this.setLevel(1f)
-
             try {
                 Minecraft.getInstance().soundManager.play(this)
             } catch (e: IllegalArgumentException) {
@@ -46,19 +40,14 @@ object SoundUtils {
                     "Failed to play a sound",
                     "soundLocation" to this.identifier,
                 )
-            } finally {
-                if (!config.maintainGameVolume) this.setLevel(oldLevel)
             }
         }
     }
 
-    private fun SoundInstance.setLevel(level: Float) =
-        Minecraft.getInstance().soundManager.updateCategoryVolume(source, level)
-
     fun createSound(name: String, pitch: Float, volume: Float = 50f): SoundInstance {
         val newSound = SoundCompat.getModernSoundName(name)
         val identifier = Identifier.parse(newSound.replace(Regex("[^a-z0-9:/._-]"), ""))
-        return SimpleSoundInstance.forUI(SoundEvent.createVariableRangeEvent(identifier), pitch, volume)
+        return SkyHanniSoundInstance(SoundEvent.createVariableRangeEvent(identifier), pitch, volume)
     }
 
     fun playBeepSound(pitch: Float = 1f) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/SoundUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SoundUtils.kt
@@ -2,12 +2,14 @@ package at.hannibal2.skyhanni.utils
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierArguments
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.compat.SoundCompat
+import com.google.gson.JsonPrimitive
 import net.minecraft.client.Minecraft
 import net.minecraft.client.resources.sounds.SoundInstance
 import net.minecraft.resources.Identifier
@@ -21,7 +23,7 @@ object SoundUtils {
     val plingSound by lazy { createSound("block.note_block.pling", 1f) }
 
     // Sounds created via createSound bypass the user's volume settings
-    // unless the maintainGameVolume option is enabled, see SoundEngineHook.
+    // if the boostWarningVolume option is enabled, see SoundEngineHook.
     fun SoundInstance.playSound() {
         DelayedRun.runOrNextTick {
             try {
@@ -77,7 +79,7 @@ object SoundUtils {
     }
 
     @HandleEvent
-    fun onCommandRegistration(event: CommandRegistrationEvent) {
+    private fun onCommandRegistration(event: CommandRegistrationEvent) {
         event.registerBrigadier("shplaysound") {
             description = "Play the specified sound effect at the given pitch and volume."
             category = CommandCategory.DEVELOPER_TEST
@@ -99,6 +101,13 @@ object SoundUtils {
             simpleCallback {
                 ChatUtils.userError("Specify a sound effect to test")
             }
+        }
+    }
+
+    @HandleEvent
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+        event.move(145, "misc.maintainGameVolume", "misc.boostWarningVolume") { element ->
+            JsonPrimitive(!element.asBoolean)
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/SoundUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SoundUtils.kt
@@ -11,7 +11,6 @@ import at.hannibal2.skyhanni.utils.compat.SoundCompat
 import net.minecraft.client.Minecraft
 import net.minecraft.client.resources.sounds.SoundInstance
 import net.minecraft.resources.Identifier
-import net.minecraft.sounds.SoundEvent
 import kotlinx.coroutines.delay
 
 @SkyHanniModule
@@ -47,7 +46,7 @@ object SoundUtils {
     fun createSound(name: String, pitch: Float, volume: Float = 50f): SoundInstance {
         val newSound = SoundCompat.getModernSoundName(name)
         val identifier = Identifier.parse(newSound.replace(Regex("[^a-z0-9:/._-]"), ""))
-        return SkyHanniSoundInstance(SoundEvent.createVariableRangeEvent(identifier), pitch, volume)
+        return SkyHanniSoundInstance(identifier, pitch, volume)
     }
 
     fun playBeepSound(pitch: Float = 1f) {


### PR DESCRIPTION
## What
`SoundManager.updateCategoryVolume` sets a persistent engine gain multiplier rather than the options volume, so restoring the old level permanently quieted the category until a resource reload. SkyHanni sounds now bypass the volume settings via a mixin that only affects `SkyHanniSoundInstance`, leaving all other sounds and global state untouched.

This also broke our own volume boost (with "Maintain Volume During Warnings", we were supposed to be forcing the equivalent of 100% master+category volume for our own sounds, but in effect we didn't). It has now been flipped and renamed to "Boost Warning Volume" to better reflect the new behavior.

## Changelog Fixes
+ Fixed SkyHanni alert sounds being too quiet. - Luna
    * If you find that they are now too loud for your liking, turn off the "Boost Warning Volume" option.
+ Fixed SkyHanni making UI sounds from the game and other mods quieter. - Luna