### PR TITLE
Backend: Fix Gradle deprecation warnings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -126,19 +126,19 @@ dependencies {
     ksp(libs.autoservice.ksp)
     implementation(libs.autoservice.annotations)
 
-    target.fabricLoaderVersion?.let {
+    target.fabricLoaderVersion.let {
         implementation(it)
         "productionRuntimeMods"(it)
         mixinTestRuntime("net.fabricmc:fabric-loader-junit:${it.substringAfterLast(':')}")
     }
-    target.fabricApiVersion?.let {
+    target.fabricApiVersion.let {
         implementation(it)
         "productionRuntimeMods"(it)
     }
     implementation(libs.fabricLanguageKotlin)
     "productionRuntimeMods"(libs.fabricLanguageKotlin)
 
-    target.modMenuVersion?.let {
+    target.modMenuVersion.let {
         implementation("maven.modrinth:modmenu:$it")
     }
 
@@ -259,7 +259,7 @@ kotlin {
 tasks.processResources {
     from(includeBackupRepo)
     from(includeBackupNeuRepo)
-    val fapiVersion = target.fabricApiVersion?.split(":")?.last() ?: ""
+    val fapiVersion = target.fabricApiVersion.split(":").last()
     val hypixelModApiVersion = target.hypixelModApiFabricVersion.split(":").last()
     val minecraftVersion = target.minecraftVersion.fabricModJsonVersion
     val props = buildMap {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,28 +57,28 @@ loom.apply {
     runs {
         named("client") {
             appendProjectPathToDisplayName.set(true)
-            this.runDir(rootProject.file("versions/${target.projectName}/run").relativeTo(projectDir).toString())
+            this.runDirectory = rootProject.file("versions/${target.projectName}/run").relativeTo(projectDir)
             if (System.getenv("repo_action") != "true") {
-                property("devauth.configDir", rootProject.file(".devauth").absolutePath)
+                systemProperties.put("devauth.configDir", rootProject.file(".devauth").absolutePath)
             }
-            vmArgs("-Xmx4G", "-Dnarrator.none=true")
+            jvmArguments.addAll("-Xmx4G", "-Dnarrator.none=true")
         }
         removeIf { it.name == "server" }
     }
 }
 
-val shadowImpl: Configuration by configurations.creating {
+val shadowImpl = configurations.create("shadowImpl") {
     configurations.implementation.get().extendsFrom(this)
 }
 
-val shadowOnly: Configuration by configurations.creating
+val shadowOnly = configurations.create("shadowOnly")
 
-val mixinTestRuntime: Configuration by configurations.creating {
+val mixinTestRuntime = configurations.create("mixinTestRuntime") {
     isCanBeConsumed = false
     extendsFrom(configurations.testRuntimeClasspath.get())
 }
 
-val includeBackupRepo by tasks.registering(DownloadBackupRepo::class) {
+val includeBackupRepo = tasks.register<DownloadBackupRepo>("includeBackupRepo") {
     this.user = "hannibal002"
     this.repo = "SkyHanni-Repo"
     this.branch = "main"
@@ -86,7 +86,7 @@ val includeBackupRepo by tasks.registering(DownloadBackupRepo::class) {
     this.outputDirectory.set(layout.buildDirectory.dir("downloadedRepo"))
 }
 
-val includeBackupNeuRepo by tasks.registering(DownloadBackupRepo::class) {
+val includeBackupNeuRepo = tasks.register<DownloadBackupRepo>("includeBackupNeuRepo") {
     this.user = "NotEnoughUpdates"
     this.repo = "NotEnoughUpdates-Repo"
     this.branch = "master"
@@ -94,7 +94,7 @@ val includeBackupNeuRepo by tasks.registering(DownloadBackupRepo::class) {
     this.outputDirectory.set(layout.buildDirectory.dir("downloadedNeuRepo"))
 }
 
-val publishToModrinth by tasks.registering(PublishToModrinth::class)
+val publishToModrinth = tasks.register<PublishToModrinth>("publishToModrinth")
 
 tasks.named<JavaExec>("runClient") {
     this.javaLauncher.set(javaToolchains.launcherFor(java.toolchain))
@@ -204,7 +204,7 @@ fun DependencyHandler.includeImplementation(dep: Any, configure: ExternalModuleD
 
 afterEvaluate {
     loom.runs.named("client") {
-        programArgs("--quickPlayMultiplayer", "hypixel.net")
+        programArguments.addAll("--quickPlayMultiplayer", "hypixel.net")
     }
 
     ksp {
@@ -232,7 +232,7 @@ tasks.withType<Test> {
     )
 }
 
-val mixinTest by tasks.registering(Test::class) {
+val mixinTest = tasks.register<Test>("mixinTest") {
     description = "Audits mixin application under Fabric Loader."
     group = "verification"
     testClassesDirs = sourceSets.test.get().output.classesDirs
@@ -368,7 +368,7 @@ tasks.jar {
 
 tasks.assemble.get().dependsOn(tasks.shadowJar)
 
-val sourcesJar by tasks.registering(Jar::class) {
+val sourcesJar = tasks.register<Jar>("sourcesJar") {
     destinationDirectory.set(layout.buildDirectory.dir("badjars"))
     archiveClassifier.set("src")
     from(sourceSets.main.get().allSource)


### PR DESCRIPTION
## What
Stop using deprecated Gradle and Loom syntax to get rid of Gradle warnings. Also removed unnecessary safe calls (`?.`) – they weren't being flagged on my end, but might as well.

## Changelog Technical Details
+ Updated deprecated build script syntax to new syntax. - Luna
