### PR TITLE
Fix: Double Hook Leaking to next sea creature catch

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/pet/PetStorageApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/pet/PetStorageApi.kt
@@ -714,7 +714,7 @@ object PetStorageApi {
         this.skinTag == skinTag
 
     fun isAutopetMessage(message: String): Boolean =
-        PetStoragePatterns.autoPetMessageColorlessPattern.matches(message.removeColor().removeResets())
+        PetStoragePatterns.autoPetMessageColorlessPattern.matches(message)
 
     fun markDirty() {
         jsonNeedsSave = true

--- a/src/main/java/at/hannibal2/skyhanni/api/pet/PetStorageApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/pet/PetStorageApi.kt
@@ -713,9 +713,6 @@ object PetStorageApi {
         this.level <= level &&
         this.skinTag == skinTag
 
-    fun isAutopetMessage(message: String): Boolean =
-        PetStoragePatterns.autoPetMessageColorlessPattern.matches(message)
-
     fun markDirty() {
         jsonNeedsSave = true
     }

--- a/src/main/java/at/hannibal2/skyhanni/api/pet/PetStoragePatterns.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/pet/PetStoragePatterns.kt
@@ -109,21 +109,6 @@ internal object PetStoragePatterns {
     )
 
     /**
-     * REGEX-TEST: Autopet equipped your [Lvl 100] Enderman! VIEW RULE
-     * REGEX-TEST: Autopet equipped your [Lvl 200] Golden Dragon! VIEW RULE
-     * REGEX-TEST: Autopet equipped your [Lvl 100] Rabbit ✦! VIEW RULE
-     * REGEX-TEST: Autopet equipped your [Lvl 200] [122✦] Golden Dragon! VIEW RULE
-     * REGEX-TEST: Autopet equipped your [Lvl 200] [34✦] Golden Dragon! VIEW RULE
-     * REGEX-TEST: Autopet equipped your [Lvl 67] T-Rex! VIEW RULE
-     * REGEX-TEST: Autopet equipped your [Lvl 200] [335✦] Golden Dragon! VIEW RULE
-     */
-    @Suppress("MaxLineLength")
-    val autoPetMessageColorlessPattern by patternGroup.pattern(
-        "autopet.message.colorless",
-        "Autopet equipped your \\[Lvl (?<level>\\d+)] (?:\\[\\d+(?<altskin>✦)\\] )?(?<pet>[\\w -]+)(?<skin> ✦)?! VIEW RULE",
-    )
-
-    /**
      * REGEX-TEST: §cAutopet §eequipped your §7[Lvl 100] §6Mosquito§e! §a§lVIEW RULE
      * REGEX-TEST: §cAutopet §eequipped your §7[Lvl 100] §5Rabbit§9 ✦§e! §a§lVIEW RULE
      * REGEX-TEST: §cAutopet §eequipped your §7[Lvl 200] §6[122✦] Golden Dragon§e! §a§lVIEW RULE

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
@@ -60,7 +60,6 @@ object SeaCreatureManager {
 
         getSeaCreatureFromMessage(message)?.let {
             SeaCreatureFishEvent(it, doubleHook).post()
-
             if (config.seaCreatureTracker.hideChat) {
                 event.blockedReason = "sea_creature_tracker"
                 doubleHook = false
@@ -103,7 +102,6 @@ object SeaCreatureManager {
             edited = when (config.compactDoubleHookPosition) {
                 CompactDoubleHookPosition.LEFT ->
                     "§e§lDOUBLE HOOK! ".asComponent().append(edited)
-
                 CompactDoubleHookPosition.RIGHT ->
                     edited.append(" §e§lDOUBLE HOOK!".asComponent())
             }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
@@ -2,8 +2,6 @@ package at.hannibal2.skyhanni.features.fishing
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.api.pet.PetStorageApi
-import at.hannibal2.skyhanni.data.WinterApi
 import at.hannibal2.skyhanni.data.jsonobjects.repo.SeaCreatureJson
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
@@ -11,15 +9,16 @@ import at.hannibal2.skyhanni.events.fishing.SeaCreatureFishEvent
 import at.hannibal2.skyhanni.features.fishing.seaCreatureXMLGui.SpecificSeaCreatures
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import at.hannibal2.skyhanni.utils.TimeUtils.inWholeTicks
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 
 @SkyHanniModule
 object SeaCreatureManager {
-
-    private var doubleHook = false
+    private var lastDoubleHookTime = SimpleTimeMark.farPast()
 
     private val seaCreatureMap = mutableMapOf<String, SeaCreature>()
     var allFishingMobs = mapOf<String, SeaCreature>()
@@ -36,14 +35,6 @@ object SeaCreatureManager {
         "It's a Double Hook!(?: Woot woot!)?",
     )
 
-    /**
-     * REGEX-TEST: > Your bottle of thunder has fully charged!
-     */
-    private val thunderBottleChargedPattern by patternGroup.pattern(
-        "thundercharged.colorless",
-        "> Your bottle of thunder has fully charged!",
-    )
-
     private val config get() = SkyHanniMod.feature.fishing
 
     @HandleEvent(onlyOnSkyblock = true)
@@ -53,21 +44,19 @@ object SeaCreatureManager {
             if (config.compactDoubleHook) {
                 event.blockedReason = "double_hook"
             }
-            doubleHook = true
+            lastDoubleHookTime = SimpleTimeMark.now()
             return
         }
-        if (isInterceptingMessage(message)) return
+        val isDoubleHook = isDoubleHookRecently(lastDoubleHookTime)
 
         getSeaCreatureFromMessage(message)?.let {
-            SeaCreatureFishEvent(it, doubleHook).post()
+            SeaCreatureFishEvent(it, isDoubleHook).post()
+
             if (config.seaCreatureTracker.hideChat) {
                 event.blockedReason = "sea_creature_tracker"
-                doubleHook = false
             }
             return
         }
-
-        doubleHook = false
     }
 
     // if you can do it better make a pr
@@ -75,19 +64,15 @@ object SeaCreatureManager {
     private fun onChat(event: SkyHanniChatEvent.Modify) {
         val message = event.cleanMessage
         if (doubleHookPattern.matches(message)) {
-            doubleHook = true
+            lastDoubleHookTime = SimpleTimeMark.now()
             return
         }
-
-        if (isInterceptingMessage(message)) return
 
         val seaCreature = getSeaCreatureFromMessage(message) ?: run {
-            doubleHook = false
             return
         }
 
-        val wasDoubleHook = doubleHook
-        doubleHook = false
+        val isDoubleHook = isDoubleHookRecently(lastDoubleHookTime)
 
         val original = event.chatComponent.copy()
         var edited = original
@@ -98,29 +83,20 @@ object SeaCreatureManager {
             edited = "§9You caught $aOrAn $name§9!".asComponent()
         }
 
-        if (config.compactDoubleHook && wasDoubleHook) {
+        if (config.compactDoubleHook && isDoubleHook) {
             edited = when (config.compactDoubleHookPosition) {
                 CompactDoubleHookPosition.LEFT ->
                     "§e§lDOUBLE HOOK! ".asComponent().append(edited)
+
                 CompactDoubleHookPosition.RIGHT ->
                     edited.append(" §e§lDOUBLE HOOK!".asComponent())
             }
         }
 
+        lastDoubleHookTime = SimpleTimeMark.farPast()
         if (original == edited) return
         event.replaceComponent(edited, "sea_creature")
     }
-
-    /**
-     * Autopet can be triggered via Sinkers as rod parts (Sponge, Prismarine, Icy) to trigger collection gain which goes between Double Hook! and the Catch message.
-     * The Thunder sea Creature gives charge when hooked, which can cause thunder bottles to charge and send the full charge message between Double Hook! and Catch message.
-     * Reindrakes send an empty line, the global message & another empty line between Double Hook! and Catch message.
-     */
-    private fun isInterceptingMessage(message: String): Boolean =
-        WinterApi.isReindrakeSpawnMessage(message) ||
-            message.isEmpty() ||
-            PetStorageApi.isAutopetMessage(message) ||
-            thunderBottleChargedPattern.matches(message)
 
     @HandleEvent
     private fun onRepoReload(event: RepositoryReloadEvent) {
@@ -159,6 +135,9 @@ object SeaCreatureManager {
         allVariants = variants
         SpecificSeaCreatures.saveSeaCreatures(SpecificSeaCreatures.updateList())
     }
+
+    private fun isDoubleHookRecently(lastDoubleHookTime: SimpleTimeMark): Boolean =
+        lastDoubleHookTime.passedSince().inWholeTicks <= 2
 
     private fun getSeaCreatureFromMessage(message: String): SeaCreature? {
         return seaCreatureMap.getOrDefault(message, null)

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
@@ -59,7 +59,11 @@ object SeaCreatureManager {
         if (isInterceptingMessage(message)) return
 
         getSeaCreatureFromMessage(message)?.let {
-            SeaCreatureFishEvent(it, doubleHook).post()
+            val wasDoubleHook = doubleHook
+            doubleHook = false
+
+            SeaCreatureFishEvent(it, wasDoubleHook).post()
+
             if (config.seaCreatureTracker.hideChat) {
                 event.blockedReason = "sea_creature_tracker"
             }
@@ -81,6 +85,9 @@ object SeaCreatureManager {
         if (isInterceptingMessage(message)) return
 
         getSeaCreatureFromMessage(message)?.let {
+            val wasDoubleHook = doubleHook
+            doubleHook = false
+
             val original = event.chatComponent.copy()
             var edited = original
 
@@ -90,7 +97,7 @@ object SeaCreatureManager {
                 edited = "§9You caught $aOrAn $name§9!".asComponent()
             }
 
-            if (config.compactDoubleHook && doubleHook) {
+            if (config.compactDoubleHook && wasDoubleHook) {
                 edited = when (config.compactDoubleHookPosition) {
                     CompactDoubleHookPosition.LEFT ->
                         "§e§lDOUBLE HOOK! ".asComponent().append(edited)
@@ -99,7 +106,6 @@ object SeaCreatureManager {
                 }
             }
 
-            doubleHook = false
             if (original == edited) return
             event.replaceComponent(edited, "sea_creature")
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
@@ -137,7 +137,7 @@ object SeaCreatureManager {
     }
 
     private fun isDoubleHookRecently(lastDoubleHookTime: SimpleTimeMark): Boolean =
-        lastDoubleHookTime.passedSince().inWholeTicks <= 2
+        lastDoubleHookTime.passedSince().inWholeTicks <= 1
 
     private fun getSeaCreatureFromMessage(message: String): SeaCreature? {
         return seaCreatureMap.getOrDefault(message, null)

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
@@ -59,13 +59,11 @@ object SeaCreatureManager {
         if (isInterceptingMessage(message)) return
 
         getSeaCreatureFromMessage(message)?.let {
-            val wasDoubleHook = doubleHook
-            doubleHook = false
-
-            SeaCreatureFishEvent(it, wasDoubleHook).post()
+            SeaCreatureFishEvent(it, doubleHook).post()
 
             if (config.seaCreatureTracker.hideChat) {
                 event.blockedReason = "sea_creature_tracker"
+                doubleHook = false
             }
             return
         }
@@ -84,33 +82,35 @@ object SeaCreatureManager {
 
         if (isInterceptingMessage(message)) return
 
-        getSeaCreatureFromMessage(message)?.let {
-            val wasDoubleHook = doubleHook
+        val seaCreature = getSeaCreatureFromMessage(message) ?: run {
             doubleHook = false
-
-            val original = event.chatComponent.copy()
-            var edited = original
-
-            if (config.shortenFishingMessage) {
-                val name = it.displayName
-                val aOrAn = StringUtils.optionalAn(name.removeColor())
-                edited = "§9You caught $aOrAn $name§9!".asComponent()
-            }
-
-            if (config.compactDoubleHook && wasDoubleHook) {
-                edited = when (config.compactDoubleHookPosition) {
-                    CompactDoubleHookPosition.LEFT ->
-                        "§e§lDOUBLE HOOK! ".asComponent().append(edited)
-                    CompactDoubleHookPosition.RIGHT ->
-                        edited.append(" §e§lDOUBLE HOOK!".asComponent())
-                }
-            }
-
-            if (original == edited) return
-            event.replaceComponent(edited, "sea_creature")
+            return
         }
 
+        val wasDoubleHook = doubleHook
         doubleHook = false
+
+        val original = event.chatComponent.copy()
+        var edited = original
+
+        if (config.shortenFishingMessage) {
+            val name = seaCreature.displayName
+            val aOrAn = StringUtils.optionalAn(name.removeColor())
+            edited = "§9You caught $aOrAn $name§9!".asComponent()
+        }
+
+        if (config.compactDoubleHook && wasDoubleHook) {
+            edited = when (config.compactDoubleHookPosition) {
+                CompactDoubleHookPosition.LEFT ->
+                    "§e§lDOUBLE HOOK! ".asComponent().append(edited)
+
+                CompactDoubleHookPosition.RIGHT ->
+                    edited.append(" §e§lDOUBLE HOOK!".asComponent())
+            }
+        }
+
+        if (original == edited) return
+        event.replaceComponent(edited, "sea_creature")
     }
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
@@ -68,9 +68,9 @@ object SeaCreatureManager {
             return
         }
 
-        val seaCreature = getSeaCreatureFromMessage(message) ?: run {
-            return
-        }
+        // Does not reset lastDoubleHookTime on fail due to intercepting messages like:
+        // Auto pet rule, thunder bottle, reindrake empty line + global message
+        val seaCreature = getSeaCreatureFromMessage(message) ?: return
 
         val isDoubleHook = isDoubleHookRecently(lastDoubleHookTime)
 

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
@@ -12,9 +12,9 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
-import at.hannibal2.skyhanni.utils.TimeUtils.inWholeTicks
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import kotlin.time.Duration.Companion.milliseconds
 
 @SkyHanniModule
 object SeaCreatureManager {
@@ -37,6 +37,7 @@ object SeaCreatureManager {
 
     private val config get() = SkyHanniMod.feature.fishing
 
+    // Does not reset lastDoubleHookTime at the end due to intercepting messages
     @HandleEvent(onlyOnSkyblock = true)
     private fun onChat(event: SkyHanniChatEvent.Allow) {
         val message = event.cleanMessage
@@ -48,7 +49,7 @@ object SeaCreatureManager {
             return
         }
         getSeaCreatureFromMessage(message)?.let {
-            val isDoubleHook = isDoubleHookRecently(lastDoubleHookTime)
+            val isDoubleHook = wasDoubleHookRecently()
             SeaCreatureFishEvent(it, isDoubleHook).post()
 
             if (config.seaCreatureTracker.hideChat) {
@@ -57,8 +58,6 @@ object SeaCreatureManager {
             }
             return
         }
-
-        // Does not reset lastDoubleHookTime on fail due to intercepting messages
     }
 
     // if you can do it better make a pr
@@ -74,7 +73,7 @@ object SeaCreatureManager {
         // Auto pet rule, thunder bottle, reindrake empty line + global message
         val seaCreature = getSeaCreatureFromMessage(message) ?: return
 
-        val isDoubleHook = isDoubleHookRecently(lastDoubleHookTime)
+        val isDoubleHook = wasDoubleHookRecently()
 
         val original = event.chatComponent.copy()
         var edited = original
@@ -136,8 +135,8 @@ object SeaCreatureManager {
         SpecificSeaCreatures.saveSeaCreatures(SpecificSeaCreatures.updateList())
     }
 
-    private fun isDoubleHookRecently(lastDoubleHookTime: SimpleTimeMark): Boolean =
-        lastDoubleHookTime.passedSince().inWholeTicks <= 1
+    private fun wasDoubleHookRecently(): Boolean =
+        lastDoubleHookTime.passedSince() <= 100.milliseconds
 
     private fun getSeaCreatureFromMessage(message: String): SeaCreature? {
         return seaCreatureMap.getOrDefault(message, null)

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
@@ -57,6 +57,8 @@ object SeaCreatureManager {
             }
             return
         }
+
+        // Does not reset lastDoubleHookTime on fail due to intercepting messages
     }
 
     // if you can do it better make a pr
@@ -102,7 +104,6 @@ object SeaCreatureManager {
     private fun onRepoReload(event: RepositoryReloadEvent) {
         seaCreatureMap.clear()
         allFishingMobs = emptyMap()
-        var counter = 0
 
         val data = event.getConstant<Map<String, SeaCreatureJson>>("SeaCreatures")
         val allFishingMobs = mutableMapOf<String, SeaCreature>()
@@ -128,7 +129,6 @@ object SeaCreatureManager {
                 }
                 allFishingMobs[name] = creature
                 variantFishes.add(name)
-                counter++
             }
         }
         SeaCreatureManager.allFishingMobs = allFishingMobs

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
@@ -113,8 +113,10 @@ object SeaCreatureManager {
      * Reindrakes send an empty line, the global message & another empty line between Double Hook! and Catch message.
      */
     private fun isInterceptingMessage(message: String): Boolean =
-        (WinterApi.isReindrakeSpawnMessage(message) || message.isEmpty() ||
-            PetStorageApi.isAutopetMessage(message) || thunderBottleChargedPattern.matches(message))
+        WinterApi.isReindrakeSpawnMessage(message) ||
+            message.isEmpty() ||
+            PetStorageApi.isAutopetMessage(message) ||
+            thunderBottleChargedPattern.matches(message)
 
     @HandleEvent
     private fun onRepoReload(event: RepositoryReloadEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
@@ -47,9 +47,8 @@ object SeaCreatureManager {
             lastDoubleHookTime = SimpleTimeMark.now()
             return
         }
-        val isDoubleHook = isDoubleHookRecently(lastDoubleHookTime)
-
         getSeaCreatureFromMessage(message)?.let {
+            val isDoubleHook = isDoubleHookRecently(lastDoubleHookTime)
             SeaCreatureFishEvent(it, isDoubleHook).post()
 
             if (config.seaCreatureTracker.hideChat) {

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
@@ -99,6 +99,7 @@ object SeaCreatureManager {
                 }
             }
 
+            doubleHook = false
             if (original == edited) return
             event.replaceComponent(edited, "sea_creature")
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
@@ -54,6 +54,7 @@ object SeaCreatureManager {
 
             if (config.seaCreatureTracker.hideChat) {
                 event.blockedReason = "sea_creature_tracker"
+                lastDoubleHookTime = SimpleTimeMark.farPast()
             }
             return
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/SeaCreatureManager.kt
@@ -28,37 +28,37 @@ object SeaCreatureManager {
     private val patternGroup = RepoPattern.group("fishing.seacreature")
 
     /**
-     * REGEX-TEST: §eIt's a §r§aDouble Hook§r§e! Woot woot!
-     * REGEX-TEST: §eIt's a §r§aDouble Hook§r§e!
+     * REGEX-TEST: It's a Double Hook! Woot woot!
+     * REGEX-TEST: It's a Double Hook!
      */
     private val doubleHookPattern by patternGroup.pattern(
-        "doublehook",
-        "§eIt's a §r§aDouble Hook§r§e!(?: Woot woot!)?",
+        "doublehook.colorless",
+        "It's a Double Hook!(?: Woot woot!)?",
     )
 
     /**
-     * REGEX-TEST: §e> Your bottle of thunder has fully charged!
+     * REGEX-TEST: > Your bottle of thunder has fully charged!
      */
     private val thunderBottleChargedPattern by patternGroup.pattern(
-        "thundercharged",
-        "§e> Your bottle of thunder has fully charged!",
+        "thundercharged.colorless",
+        "> Your bottle of thunder has fully charged!",
     )
 
     private val config get() = SkyHanniMod.feature.fishing
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onChat(event: SkyHanniChatEvent.Allow) {
-        if (doubleHookPattern.matches(event.message)) {
+    private fun onChat(event: SkyHanniChatEvent.Allow) {
+        val message = event.cleanMessage
+        if (doubleHookPattern.matches(message)) {
             if (config.compactDoubleHook) {
                 event.blockedReason = "double_hook"
             }
             doubleHook = true
             return
         }
-        if (isInterceptingColorCodeMessage(event.message)) return
-        if (isInterceptingCleanMessage(event.cleanMessage)) return
+        if (isInterceptingMessage(message)) return
 
-        getSeaCreatureFromMessage(event.cleanMessage)?.let {
+        getSeaCreatureFromMessage(message)?.let {
             SeaCreatureFishEvent(it, doubleHook).post()
             if (config.seaCreatureTracker.hideChat) {
                 event.blockedReason = "sea_creature_tracker"
@@ -71,16 +71,16 @@ object SeaCreatureManager {
 
     // if you can do it better make a pr
     @HandleEvent(onlyOnSkyblock = true)
-    fun onChat(event: SkyHanniChatEvent.Modify) {
-        if (doubleHookPattern.matches(event.message)) {
+    private fun onChat(event: SkyHanniChatEvent.Modify) {
+        val message = event.cleanMessage
+        if (doubleHookPattern.matches(message)) {
             doubleHook = true
             return
         }
 
-        if (isInterceptingColorCodeMessage(event.message)) return
-        if (isInterceptingCleanMessage(event.cleanMessage)) return
+        if (isInterceptingMessage(message)) return
 
-        getSeaCreatureFromMessage(event.cleanMessage)?.let {
+        getSeaCreatureFromMessage(message)?.let {
             val original = event.chatComponent.copy()
             var edited = original
 
@@ -109,20 +109,14 @@ object SeaCreatureManager {
     /**
      * Autopet can be triggered via Sinkers as rod parts (Sponge, Prismarine, Icy) to trigger collection gain which goes between Double Hook! and the Catch message.
      * The Thunder sea Creature gives charge when hooked, which can cause thunder bottles to charge and send the full charge message between Double Hook! and Catch message.
-     */
-    private fun isInterceptingColorCodeMessage(message: String): Boolean =
-        (PetStorageApi.isAutopetMessage(message) || thunderBottleChargedPattern.matches(message))
-
-    // TODO Unify when both use CleanMessage.
-
-    /**
      * Reindrakes send an empty line, the global message & another empty line between Double Hook! and Catch message.
      */
-    private fun isInterceptingCleanMessage(message: String): Boolean =
-        (WinterApi.isReindrakeSpawnMessage(message) || message.isEmpty())
+    private fun isInterceptingMessage(message: String): Boolean =
+        (WinterApi.isReindrakeSpawnMessage(message) || message.isEmpty() ||
+            PetStorageApi.isAutopetMessage(message) || thunderBottleChargedPattern.matches(message))
 
     @HandleEvent
-    fun onRepoReload(event: RepositoryReloadEvent) {
+    private fun onRepoReload(event: RepositoryReloadEvent) {
         seaCreatureMap.clear()
         allFishingMobs = emptyMap()
         var counter = 0


### PR DESCRIPTION
## What
Made it store the timestamp for when a double hook was observed, and only counted it as a double hook if it's in the same or next tick, this way the timer naturally expires and no need to worry about intercepting messages.

Also made the regex be colorless and private listeners while I was here.

## Changelog Fixes
+ Fixed Fishing Double Hook sometimes being applied to the next caught Sea Creature. - Avrg