### PR TITLE
Fix: Rendering correctness + performance fixes

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/ClientEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/ClientEvents.kt
@@ -9,6 +9,7 @@ import at.hannibal2.skyhanni.events.minecraft.ClientConnectEvent
 import at.hannibal2.skyhanni.events.minecraft.ClientDisconnectEvent
 import at.hannibal2.skyhanni.events.minecraft.ClientShutdownEvent
 import at.hannibal2.skyhanni.events.minecraft.ResourcePackReloadEvent
+import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -22,7 +23,9 @@ import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents
 import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents
+import net.fabricmc.fabric.api.client.rendering.v1.level.LevelRenderEvents
 import net.fabricmc.fabric.api.resource.v1.ResourceLoader
+import net.minecraft.client.Minecraft
 import net.minecraft.client.multiplayer.chat.GuiMessage
 import net.minecraft.client.multiplayer.chat.GuiMessageSource
 import net.minecraft.client.multiplayer.chat.GuiMessageTag
@@ -33,12 +36,9 @@ import java.util.concurrent.CompletableFuture
 
 @SkyHanniModule
 object ClientEvents {
-
     var totalTicks = 0
 
     init {
-
-        // Tick event
         ClientTickEvents.END_CLIENT_TICK.register {
             if (!MinecraftCompat.localPlayerExists) return@register
             if (!MinecraftCompat.localWorldExists) return@register
@@ -46,20 +46,28 @@ object ClientEvents {
             SkyHanniTickEvent(++totalTicks).post()
         }
 
-        // Disconnect event
         ClientPlayConnectionEvents.DISCONNECT.register { _, _ ->
             SkyHanniEvents.markEventCacheDirty(DirtyReason.SERVER_DISCONNECTED)
             ClientDisconnectEvent.post()
         }
 
-        // Connect event
         ClientPlayConnectionEvents.JOIN.register { _, _, _ ->
             ClientConnectEvent.post()
         }
 
-        // World change event
         ClientLevelEvents.AFTER_CLIENT_LEVEL_CHANGE.register { _, _ ->
             WorldChangeEvent.post()
+        }
+
+        //~ if < 26.2 'COLLECT_SUBMITS' -> 'AFTER_TRANSLUCENT_TERRAIN'
+        LevelRenderEvents.COLLECT_SUBMITS.register { ctx ->
+            SkyHanniRenderWorldEvent(
+                ctx.poseStack(),
+                ctx.levelState().cameraRenderState,
+                //~ if < 26.2 'submitNodeCollector' -> 'bufferSource'
+                ctx.submitNodeCollector(),
+                Minecraft.getInstance().deltaTracker.getGameTimeDeltaPartialTick(true),
+            ).post()
         }
 
         ResourceLoader.get(PackType.CLIENT_RESOURCES).registerReloadListener(

--- a/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/ClientEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/ClientEvents.kt
@@ -64,8 +64,9 @@ object ClientEvents {
             SkyHanniRenderWorldEvent(
                 ctx.poseStack(),
                 ctx.levelState().cameraRenderState,
-                //~ if < 26.2 'submitNodeCollector' -> 'bufferSource'
                 ctx.submitNodeCollector(),
+                //? if < 26.2
+                //ctx.bufferSource(),
                 Minecraft.getInstance().deltaTracker.getGameTimeDeltaPartialTick(true),
             ).post()
         }

--- a/src/main/java/at/hannibal2/skyhanni/events/minecraft/SkyHanniRenderWorldEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/minecraft/SkyHanniRenderWorldEvent.kt
@@ -19,8 +19,4 @@ class SkyHanniRenderWorldEvent(
     val submitNodeStorage: SubmitNodeStorage,
     val partialTicks: Float,
     var isCurrentlyDeferring: Boolean = true,
-) : SkyHanniEvent() {
-
-    //? if >= 26.2
-    internal var skyHanniTextSubmitOrder = 0
-}
+) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/minecraft/SkyHanniRenderWorldEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/minecraft/SkyHanniRenderWorldEvent.kt
@@ -15,8 +15,8 @@ import net.minecraft.client.renderer.SubmitNodeCollector
 class SkyHanniRenderWorldEvent(
     val matrices: PoseStack,
     val camera: CameraRenderState,
-    //~ if < 26.2 'submitNodeStorage: SubmitNodeCollector' -> 'bufferSource: MultiBufferSource.BufferSource'
-    val submitNodeStorage: SubmitNodeCollector,
+    //~ if < 26.2 'submitNodeCollector: SubmitNodeCollector' -> 'bufferSource: MultiBufferSource.BufferSource'
+    val submitNodeCollector: SubmitNodeCollector,
     val partialTicks: Float,
 ) : SkyHanniEvent() {
     var isCurrentlyDeferring: Boolean = true

--- a/src/main/java/at/hannibal2/skyhanni/events/minecraft/SkyHanniRenderWorldEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/minecraft/SkyHanniRenderWorldEvent.kt
@@ -3,11 +3,10 @@ package at.hannibal2.skyhanni.events.minecraft
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 import com.mojang.blaze3d.vertex.PoseStack
+import net.minecraft.client.renderer.SubmitNodeCollector
 import net.minecraft.client.renderer.state.level.CameraRenderState
 
-//? if >= 26.2 {
-import net.minecraft.client.renderer.SubmitNodeCollector
-//?} else {
+//? if < 26.2 {
 /*import net.minecraft.client.renderer.MultiBufferSource
 *///?}
 
@@ -15,8 +14,9 @@ import net.minecraft.client.renderer.SubmitNodeCollector
 class SkyHanniRenderWorldEvent(
     val matrices: PoseStack,
     val camera: CameraRenderState,
-    //~ if < 26.2 'submitNodeCollector: SubmitNodeCollector' -> 'bufferSource: MultiBufferSource.BufferSource'
     val submitNodeCollector: SubmitNodeCollector,
+    //? if < 26.2
+    //val bufferSource: MultiBufferSource.BufferSource,
     val partialTicks: Float,
 ) : SkyHanniEvent() {
     var isCurrentlyDeferring: Boolean = true

--- a/src/main/java/at/hannibal2/skyhanni/events/minecraft/SkyHanniRenderWorldEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/minecraft/SkyHanniRenderWorldEvent.kt
@@ -6,7 +6,7 @@ import com.mojang.blaze3d.vertex.PoseStack
 import net.minecraft.client.renderer.state.level.CameraRenderState
 
 //? if >= 26.2 {
-import net.minecraft.client.renderer.SubmitNodeStorage
+import net.minecraft.client.renderer.SubmitNodeCollector
 //?} else {
 /*import net.minecraft.client.renderer.MultiBufferSource
 *///?}
@@ -15,8 +15,9 @@ import net.minecraft.client.renderer.SubmitNodeStorage
 class SkyHanniRenderWorldEvent(
     val matrices: PoseStack,
     val camera: CameraRenderState,
-    //~ if < 26.2 'submitNodeStorage: SubmitNodeStorage' -> 'bufferSource: MultiBufferSource.BufferSource'
-    val submitNodeStorage: SubmitNodeStorage,
+    //~ if < 26.2 'submitNodeStorage: SubmitNodeCollector' -> 'bufferSource: MultiBufferSource.BufferSource'
+    val submitNodeStorage: SubmitNodeCollector,
     val partialTicks: Float,
-    var isCurrentlyDeferring: Boolean = true,
-) : SkyHanniEvent()
+) : SkyHanniEvent() {
+    var isCurrentlyDeferring: Boolean = true
+}

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinLevelRenderer.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinLevelRenderer.java
@@ -1,142 +1,25 @@
 package at.hannibal2.skyhanni.mixins.transformers;
 
-import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent;
 import at.hannibal2.skyhanni.mixins.hooks.RenderLivingEntityHelper;
 import at.hannibal2.skyhanni.mixins.hooks.SkyHanniOutlineHook;
-import com.mojang.blaze3d.buffers.GpuBufferSlice;
-import com.mojang.blaze3d.resource.GraphicsResourceAllocator;
-import com.mojang.blaze3d.vertex.PoseStack;
-import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.renderer.LevelRenderer;
-import net.minecraft.client.renderer.chunk.ChunkSectionLayerGroup;
-import net.minecraft.client.renderer.state.level.CameraRenderState;
-import org.joml.Matrix4fc;
-import org.joml.Vector4f;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-//? if >= 26.2 {
-import net.minecraft.client.renderer.SubmitNodeStorage;
-import net.minecraft.client.renderer.feature.FeatureRenderDispatcher;
-//?} else {
-/*import at.hannibal2.skyhanni.utils.render.WorldRenderUtils;
-import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+//? if < 26.2 {
+/*import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
-import com.mojang.blaze3d.textures.GpuSampler;
-import net.minecraft.client.renderer.OutlineBufferSource;
-import net.minecraft.client.renderer.RenderBuffers;
-import net.minecraft.client.renderer.chunk.ChunkSectionsToRender;
 import net.minecraft.client.renderer.entity.state.EntityRenderState;
 import net.minecraft.world.entity.Entity;
-import org.spongepowered.asm.mixin.injection.Slice;
 *///?}
 
-// Adapted from Fabric API implementation
-// The Fabric API event makes our lines render strange
 @Mixin(LevelRenderer.class)
 public abstract class MixinLevelRenderer {
     //? if < 26.2 {
-    /*@Unique
-    PoseStack contextMatrixStack;
-    *///?}
-
-    @Unique
-    CameraRenderState currentCameraState;
-
-    @Unique
-    DeltaTracker currentTickCounter;
-
-    //? if >= 26.2 {
-    @Final
-    @Shadow
-    private SubmitNodeStorage submitNodeStorage;
-    //?} else {
-    /*@Final
-    @Shadow
-    private RenderBuffers renderBuffers;
-    *///?}
-
-    //~ if < 26.2 'render' -> 'renderLevel'
-    @Inject(method = "render", at = @At("HEAD"))
-    private void beginRender(
-        GraphicsResourceAllocator resourceAllocator,
-        DeltaTracker deltaTracker, boolean renderOutline,
-        CameraRenderState cameraState,
-        Matrix4fc modelViewMatrix,
-        GpuBufferSlice terrainFog,
-        Vector4f fogColor,
-        boolean shouldRenderSky,
-        //? if < 26.2
-        //ChunkSectionsToRender chunkSectionsToRender,
-        CallbackInfo ci
-    ) {
-        currentCameraState = cameraState;
-        currentTickCounter = deltaTracker;
-    }
-
-    //? if >= 26.2 {
-    @Inject(
-        method = "render",
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/client/renderer/feature/FeatureRenderDispatcher;prepareFrame(Lnet/minecraft/client/renderer/SubmitNodeStorage;)Lnet/minecraft/client/renderer/feature/FeatureRenderDispatcher$PreparedFrame;"
-        )
-    )
-    private void postRenderWorldBeforePrepareFeatures(
-        GraphicsResourceAllocator resourceAllocator,
-        DeltaTracker deltaTracker,
-        boolean renderOutline,
-        CameraRenderState cameraState,
-        Matrix4fc modelViewMatrix,
-        GpuBufferSlice terrainFog,
-        Vector4f fogColor,
-        boolean shouldRenderSky,
-        CallbackInfo ci
-    ) {
-        SkyHanniRenderWorldEvent event = new SkyHanniRenderWorldEvent(
-            new PoseStack(),
-            cameraState,
-            submitNodeStorage,
-            deltaTracker.getGameTimeDeltaPartialTick(true),
-            true
-        );
-        event.post();
-    }
-    //?} else {
-    /*@WrapOperation(
-        method = "lambda$addMainPass$0",
-        slice = @Slice(from = @At(value = "INVOKE_STRING", target = "Lnet/minecraft/util/profiling/ProfilerFiller;push(Ljava/lang/String;)V", args = "ldc=translucentTerrain")),
-        at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/chunk/ChunkSectionsToRender;renderGroup(Lnet/minecraft/client/renderer/chunk/ChunkSectionLayerGroup;Lcom/mojang/blaze3d/textures/GpuSampler;)V", ordinal = 0)
-    )
-    private void onTranslucentRender(ChunkSectionsToRender instance, ChunkSectionLayerGroup group, GpuSampler gpuSampler, Operation<Void> original) {
-        original.call(instance, group, gpuSampler);
-        if (contextMatrixStack == null) return;
-
-        SkyHanniRenderWorldEvent event = new SkyHanniRenderWorldEvent(
-            contextMatrixStack,
-            currentCameraState,
-            renderBuffers.bufferSource(),
-            currentTickCounter.getGameTimeDeltaPartialTick(true),
-            true
-        );
-        event.post();
-        contextMatrixStack = null;
-    }
-
-    @ModifyExpressionValue(method = "lambda$addMainPass$0", at = @At(value = "NEW", target = "()Lcom/mojang/blaze3d/vertex/PoseStack;"))
-    private PoseStack onCreateMatrixStack(PoseStack matrixStack) {
-        contextMatrixStack = matrixStack;
-        return matrixStack;
-    }
-
-    @WrapOperation(method = "extractVisibleEntities", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/entity/state/EntityRenderState;appearsGlowing()Z"))
+    /*@WrapOperation(method = "extractVisibleEntities", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/entity/state/EntityRenderState;appearsGlowing()Z"))
     public boolean shouldAlsoGlow(EntityRenderState instance, Operation<Boolean> original, @Local Entity entity) {
         Integer glowColor = RenderLivingEntityHelper.getEntityGlowColor(entity);
         return glowColor != null || original.call(instance);

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinLevelRenderer.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinLevelRenderer.java
@@ -32,7 +32,6 @@ import com.llamalad7.mixinextras.sugar.Local;
 import com.mojang.blaze3d.textures.GpuSampler;
 import net.minecraft.client.renderer.OutlineBufferSource;
 import net.minecraft.client.renderer.RenderBuffers;
-import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.chunk.ChunkSectionsToRender;
 import net.minecraft.client.renderer.entity.state.EntityRenderState;
 import net.minecraft.world.entity.Entity;
@@ -43,7 +42,6 @@ import org.spongepowered.asm.mixin.injection.Slice;
 // The Fabric API event makes our lines render strange
 @Mixin(LevelRenderer.class)
 public abstract class MixinLevelRenderer {
-
     //? if < 26.2 {
     /*@Unique
     PoseStack contextMatrixStack;
@@ -114,7 +112,7 @@ public abstract class MixinLevelRenderer {
     //?} else {
     /*@WrapOperation(
         method = "lambda$addMainPass$0",
-        slice = @Slice(from = @At(value = "INVOKE_STRING", target = "Lnet/minecraft/util/profiling/ProfilerFiller;push(Ljava/lang/String;)V", args = "ldc=translucent")),
+        slice = @Slice(from = @At(value = "INVOKE_STRING", target = "Lnet/minecraft/util/profiling/ProfilerFiller;push(Ljava/lang/String;)V", args = "ldc=translucentTerrain")),
         at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/chunk/ChunkSectionsToRender;renderGroup(Lnet/minecraft/client/renderer/chunk/ChunkSectionLayerGroup;Lcom/mojang/blaze3d/textures/GpuSampler;)V", ordinal = 0)
     )
     private void onTranslucentRender(ChunkSectionsToRender instance, ChunkSectionLayerGroup group, GpuSampler gpuSampler, Operation<Void> original) {
@@ -151,24 +149,4 @@ public abstract class MixinLevelRenderer {
         if (!RenderLivingEntityHelper.isUsingCustomGlow()) return;
         SkyHanniOutlineHook.checkIfDepthAttachmentNeedsUpdating();
     }
-
-    //? if < 26.2 {
-    /*@Inject(method = "lambda$addMainPass$0", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/OutlineBufferSource;endOutlineBatch()V"))
-    private void renderSkyhanniGlow(CallbackInfo ci) {
-        if (!RenderLivingEntityHelper.isUsingCustomGlow()) return;
-        SkyHanniOutlineHook.getVertexConsumers().endOutlineBatch();
-    }
-
-    @Inject(
-        method = "lambda$addLateDebugPass$0",
-        at = @At(
-            value = "FIELD",
-            target = "Lcom/mojang/blaze3d/systems/RenderSystem;outputDepthTextureOverride:Lcom/mojang/blaze3d/textures/GpuTextureView;",
-            shift = At.Shift.AFTER
-        )
-    )
-    private void renderDeferredSeeThroughText(CallbackInfo ci, @Local MultiBufferSource.BufferSource bufferSource) {
-        WorldRenderUtils.renderDeferredSeeThroughText(bufferSource);
-    }
-    *///?}
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/HolographicEntities.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/HolographicEntities.kt
@@ -27,7 +27,6 @@ import kotlin.reflect.KClass
 import kotlin.reflect.full.isSuperclassOf
 
 //? if >= 26.2 {
-import net.minecraft.client.renderer.SubmitNodeStorage
 import net.minecraft.util.LightCoordsUtil
 //?} else {
 /*import net.minecraft.client.renderer.LevelRenderer
@@ -38,12 +37,11 @@ import net.minecraft.util.LightCoordsUtil
  */
 @SkyHanniModule
 object HolographicEntities {
-
     private var debugHologram: HolographicEntity<Zombie>? = null
     private var debugHologramTransparency: Float = 1f
 
     @HandleEvent
-    fun onCommandRegistration(event: CommandRegistrationEvent) {
+    private fun onCommandRegistration(event: CommandRegistrationEvent) {
         event.registerBrigadier("shdebughologram") {
             description = "Spawns a holographic zombie 5 blocks in front of you for testing"
             category = CommandCategory.DEVELOPER_TEST
@@ -79,7 +77,7 @@ object HolographicEntities {
 
 
     @HandleEvent
-    fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
+    private fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
         val hologram = debugHologram ?: return
         event.renderHolographicEntity(hologram, opacity = debugHologramTransparency)
     }
@@ -196,8 +194,8 @@ object HolographicEntities {
         //~ if < 26.2 'gameRenderState()' -> 'gameRenderState'
         val cameraRenderState = gameRenderer.gameRenderState().levelRenderState.cameraRenderState
         val cameraPos = cameraRenderState.pos
-        //~ if < 26.2 'SubmitNodeStorage()' -> 'gameRenderer.featureRenderDispatcher.submitNodeStorage'
-        val submitNodeCollector = SubmitNodeStorage()
+        //~ if < 26.2 'submitNodeStorage' -> 'gameRenderer.featureRenderDispatcher.submitNodeStorage'
+        val submitNodeCollector = submitNodeStorage
         renderer.extractRenderState(entity, entityRenderState, partialTicks)
         entityRenderState.`skyhanni$setEntity`(entity)
         (entityRenderState as? LivingEntityRenderState)?.isBaby = holographicEntity.isChild
@@ -218,8 +216,6 @@ object HolographicEntities {
                     matrices,
                     submitNodeCollector,
                 )
-                //? if >= 26.2
-                gameRenderer.featureRenderDispatcher().renderAllFeatures(submitNodeCollector)
             }
         } finally {
             activeHolographicEntities.remove(entity)

--- a/src/main/java/at/hannibal2/skyhanni/utils/HolographicEntities.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/HolographicEntities.kt
@@ -194,8 +194,8 @@ object HolographicEntities {
         //~ if < 26.2 'gameRenderState()' -> 'gameRenderState'
         val cameraRenderState = gameRenderer.gameRenderState().levelRenderState.cameraRenderState
         val cameraPos = cameraRenderState.pos
-        //~ if < 26.2 'submitNodeStorage' -> 'gameRenderer.featureRenderDispatcher.submitNodeStorage'
-        val submitNodeCollector = submitNodeStorage
+        //~ if < 26.2 'this.submitNodeCollector' -> 'gameRenderer.featureRenderDispatcher.submitNodeStorage'
+        val submitNodeCollector = this.submitNodeCollector
         renderer.extractRenderState(entity, entityRenderState, partialTicks)
         entityRenderState.`skyhanni$setEntity`(entity)
         (entityRenderState as? LivingEntityRenderState)?.isBaby = holographicEntity.isChild

--- a/src/main/java/at/hannibal2/skyhanni/utils/HolographicEntities.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/HolographicEntities.kt
@@ -194,8 +194,6 @@ object HolographicEntities {
         //~ if < 26.2 'gameRenderState()' -> 'gameRenderState'
         val cameraRenderState = gameRenderer.gameRenderState().levelRenderState.cameraRenderState
         val cameraPos = cameraRenderState.pos
-        //~ if < 26.2 'this.submitNodeCollector' -> 'gameRenderer.featureRenderDispatcher.submitNodeStorage'
-        val submitNodeCollector = this.submitNodeCollector
         renderer.extractRenderState(entity, entityRenderState, partialTicks)
         entityRenderState.`skyhanni$setEntity`(entity)
         (entityRenderState as? LivingEntityRenderState)?.isBaby = holographicEntity.isChild

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/LineDrawer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/LineDrawer.kt
@@ -14,7 +14,6 @@ import net.minecraft.client.renderer.gizmos.DrawableGizmoPrimitives
 *///?}
 
 class LineDrawer @PublishedApi internal constructor(val event: SkyHanniRenderWorldEvent, val lineWidth: Int, val depth: Boolean) {
-
     private val queuedLines = mutableListOf<QueuedLine>()
 
     @PublishedApi
@@ -26,7 +25,7 @@ class LineDrawer @PublishedApi internal constructor(val event: SkyHanniRenderWor
         for (line in queuedLines) {
             gizmos.addLine(line.p1.toVec3(), line.p2.toVec3(), line.color.rgb, lineWidth.toFloat())
         }
-        gizmos.submit(event.submitNodeStorage, event.camera, !depth)
+        gizmos.submit(event.submitNodeCollector, event.camera, !depth)
         //?} else {
         /*val layer = SkyHanniRenderLayers.getLines(!depth)
         event.submitCustomGeometry(layer) { buf ->

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
@@ -53,23 +53,6 @@ object WorldRenderUtils {
 
     private val beaconBeam = createResourceLocation("textures/entity/beacon/beacon_beam.png")
 
-    //? if < 26.2 {
-    /*// 26.1 composites entity render targets over the main target after the normal world-render hook.
-    // Drawing see-through text in the late pass prevents entities from covering it (MC-265743).
-    private val deferredSeeThroughText = mutableListOf<(MultiBufferSource.BufferSource) -> Unit>()
-
-    @JvmStatic
-    fun renderDeferredSeeThroughText(bufferSource: MultiBufferSource.BufferSource) {
-        if (deferredSeeThroughText.isEmpty()) return
-        try {
-            deferredSeeThroughText.forEach { it(bufferSource) }
-            bufferSource.endBatch()
-        } finally {
-            deferredSeeThroughText.clear()
-        }
-    }
-    *///?}
-
     //? if >= 26.2 {
     private fun SkyHanniRenderWorldEvent.submitOrderedText(
         x: Float,
@@ -346,24 +329,6 @@ object WorldRenderUtils {
         ).rotate(camera.rotation())
             .translate(0f, -yOffset * adjustedScale, 0f)
             .scale(adjustedScale, -adjustedScale, adjustedScale)
-
-        if (seeThroughBlocks) {
-            deferredSeeThroughText.add { bufferSource ->
-                fr.drawInBatch(
-                    text,
-                    x,
-                    0f,
-                    color?.rgb ?: LorenzColor.WHITE.toColor().rgb,
-                    shadow,
-                    matrix,
-                    bufferSource,
-                    SEE_THROUGH,
-                    backgroundColor,
-                    FULL_BRIGHT,
-                )
-            }
-            return
-        }
 
         fr.drawInBatch(
             text,

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
@@ -65,7 +65,7 @@ object WorldRenderUtils {
         outlineColor: Int,
     ) {
         // The order ensures see-through text renders over our custom geometry, like on 26.1.
-        submitNodeStorage.order(1).submitText(
+        submitNodeCollector.order(1).submitText(
             matrices,
             x,
             y,
@@ -85,7 +85,7 @@ object WorldRenderUtils {
         crossinline render: (VertexConsumer) -> Unit,
     ) {
         //? if >= 26.2 {
-        submitNodeStorage.submitCustomGeometry(matrices, layer) { _, buffer -> render(buffer) }
+        submitNodeCollector.submitCustomGeometry(matrices, layer) { _, buffer -> render(buffer) }
         //?} else {
         /*render(bufferSource.getBuffer(layer))
         *///?}
@@ -109,8 +109,8 @@ object WorldRenderUtils {
         matrices.translate(x - camera.position.x, y - camera.position.y, z - camera.position.z)
         BeaconRenderer.submitBeaconBeam(
             matrices,
-            //~ if < 26.2 'submitNodeStorage' -> 'Minecraft.getInstance().gameRenderer.featureRenderDispatcher.submitNodeStorage'
-            submitNodeStorage,
+            //~ if < 26.2 'submitNodeCollector' -> 'Minecraft.getInstance().gameRenderer.featureRenderDispatcher.submitNodeStorage'
+            submitNodeCollector,
             beaconBeam,
             1f,
             Math.floorMod(MinecraftCompat.clientTime, 40) + partialTicks,

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
@@ -53,9 +53,7 @@ object WorldRenderUtils {
 
     private val beaconBeam = createResourceLocation("textures/entity/beacon/beacon_beam.png")
 
-    //? if >= 26.2 {
-    private const val SKYHANNI_TEXT_SUBMIT_ORDER = 10_000
-    //?} else {
+    //? if < 26.2 {
     /*// 26.1 composites entity render targets over the main target after the normal world-render hook.
     // Drawing see-through text in the late pass prevents entities from covering it (MC-265743).
     private val deferredSeeThroughText = mutableListOf<(MultiBufferSource.BufferSource) -> Unit>()
@@ -84,8 +82,8 @@ object WorldRenderUtils {
         backgroundColor: Int,
         outlineColor: Int,
     ) {
-        val order = SKYHANNI_TEXT_SUBMIT_ORDER + skyHanniTextSubmitOrder++
-        submitNodeStorage.order(order).submitText(
+        // The order ensures see-through text renders over our custom geometry, like on 26.1.
+        submitNodeStorage.order(1).submitText(
             matrices,
             x,
             y,

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
@@ -109,7 +109,6 @@ object WorldRenderUtils {
         matrices.translate(x - camera.position.x, y - camera.position.y, z - camera.position.z)
         BeaconRenderer.submitBeaconBeam(
             matrices,
-            //~ if < 26.2 'submitNodeCollector' -> 'Minecraft.getInstance().gameRenderer.featureRenderDispatcher.submitNodeStorage'
             submitNodeCollector,
             beaconBeam,
             1f,

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
@@ -50,7 +50,6 @@ import org.joml.Matrix4f
 
 @Suppress("LargeClass")
 object WorldRenderUtils {
-
     private val beaconBeam = createResourceLocation("textures/entity/beacon/beacon_beam.png")
 
     //? if >= 26.2 {
@@ -927,11 +926,8 @@ object WorldRenderUtils {
     }
 
     internal fun SkyHanniRenderWorldEvent.exactPlayerCrosshairLocation(): LorenzVec {
-        //? if >= 26.2 {
         val look = Vector3f(0f, 0f, -1f).rotate(camera.rotation())
         return camera.position.toLorenzVec() + LorenzVec(look.x.toDouble(), look.y.toDouble(), look.z.toDouble()).times(2)
-        //?} else
-        //return exactPlayerEyeLocation() + MinecraftCompat.localPlayerOrThrow.lookAngle.toLorenzVec().times(2)
     }
 
     fun SkyHanniRenderWorldEvent.exactBoundingBox(entity: Entity): AABB {


### PR DESCRIPTION
## What
Various rendering fixes. These have all been verified in game.

### General
- Fixed Holographic Entities making the game unplayably slow on 26.2 because it was instantiating a new `SubmitNodeStorage` object and calling `renderAllFeatures` every frame.
- Fixed lines drawn to the crosshair (e.g. burrow and pest waypoints) jumping around whenever the player sneaks or unsneaks on 26.1. The fix is to just use the 26.2 code for 26.1 as well, and then everything seems to work fine. 

### 26.1
- Fixed the world rendering using the wrong injection point (`AFTER_SOLID_FEATURES` instead of `AFTER_TRANSLUCENT_TERRAIN`). It also goes through the Fabric API event now instead of our own mixin.
  * The previous mixin was targeting `ldc=translucent`, which doesn't exist on 26.1+ – so it was silently ignoring the `ldc` filter fall back to the first `ProfilerFiller#push` call, which is `ldc=solidTerrain` (AKA Fabric API's `AFTER_SOLID_FEATURES`). The correct target is `ldc=translucentTerrain` (AKA Fabric API's `AFTER_TRANSLUCENT_TERRAIN`).
  * This is why the whole "deferred see-through text" hack was required in the first place to fix things like damage indicator text rendering below entities. It has now been removed.
  * As far as I can tell, this change doesn't currently have any known user-facing impact, but it may prevent subtle bugs in the future.

### 26.2
- Moved world rendering injection from our own mixin to Fabric API's `COLLECT_SUBMITS` (in practice, the injection point is effectively unchanged).
- Removed the unnecessarily incrementing `skyHanniTextSubmitOrder` – based on further reading on Minecraft rendering and verifying in-game, I've found that a simple `.order(1)` is sufficient to fix the issue it was created for (the Fruit Digging solver's see-through text rendering below its gray boxes).

## Changelog Fixes
+ Fixed extreme lag spikes in the Mirrorverse Crafting Room in the Rift on Minecraft 26.2. - Luna
+ Fixed some lines (e.g. for Burrow and Pest waypoints) jumping around when you sneak on Minecraft 26.1. - Luna

## Changelog Technical Details
+ Fixed the SkyHanniRenderWorldEvent injection point on Minecraft 26.1. - Luna
+ Changed world text rendering to no longer unnecessarily increment the submit order on Minecraft 26.2. - Luna