### PR TITLE
Fix: Custom Pest Cooldown Timer showing always ready sometimes

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/events/garden/pests/PestSpawnEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/garden/pests/PestSpawnEvent.kt
@@ -3,7 +3,6 @@ package at.hannibal2.skyhanni.events.garden.pests
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 
-
 /**
  * When a pest spawn message gets detected while in the garden.
  */

--- a/src/main/java/at/hannibal2/skyhanni/events/garden/pests/PestSpawnEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/garden/pests/PestSpawnEvent.kt
@@ -1,11 +1,13 @@
 package at.hannibal2.skyhanni.events.garden.pests
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 
 
 /**
  * When a pest spawn message gets detected while in the garden.
  */
+@PrimaryFunction("onPestSpawn")
 class PestSpawnEvent(val amountPests: Int?, val plotNames: List<String>) : SkyHanniEvent() {
     init {
         require(amountPests == null || amountPests > 0) { "amountPests must be a positive integer or null" }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
@@ -36,7 +36,6 @@ import at.hannibal2.skyhanni.utils.TimeUtils.average
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.TimeUtils.getTablistEndTime
 import at.hannibal2.skyhanni.utils.TimeUtils.ticks
-import at.hannibal2.skyhanni.utils.collection.CollectionUtils.takeIfNotEmpty
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
@@ -10,12 +10,7 @@ import at.hannibal2.skyhanni.data.Perk
 import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.data.title.TitleContext
 import at.hannibal2.skyhanni.data.title.TitleManager
-import at.hannibal2.skyhanni.events.ConfigLoadEvent
-import at.hannibal2.skyhanni.events.GuiRenderEvent
-import at.hannibal2.skyhanni.events.IslandJoinEvent
-import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.WidgetUpdateEvent
-import at.hannibal2.skyhanni.events.garden.pests.PestSpawnEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.features.garden.GardenApi
 import at.hannibal2.skyhanni.features.garden.GardenApi.hasFarmingToolInHand
@@ -41,6 +36,7 @@ import at.hannibal2.skyhanni.utils.TimeUtils.average
 import at.hannibal2.skyhanni.utils.TimeUtils.format
 import at.hannibal2.skyhanni.utils.TimeUtils.getTablistEndTime
 import at.hannibal2.skyhanni.utils.TimeUtils.ticks
+import at.hannibal2.skyhanni.utils.collection.CollectionUtils.takeIfNotEmpty
 import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.primitives.text
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -95,9 +91,9 @@ object PestSpawnTimer {
     }.get().seconds
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
-    fun onWidgetUpdate(event: WidgetUpdateEvent) {
+    private fun onWidgetUpdate(event: WidgetUpdateEvent) {
         if (!event.isWidget(TabWidget.PESTS)) return
-        val widgetLines = event.widget.lines.map { it.string }
+        val widgetLines = event.cleanLines.takeIfNotEmpty() ?: return
 
         // Hypixel can sometimes send partial widget
         // so we first check if the maximum number of pests is present as a workaround
@@ -121,7 +117,7 @@ object PestSpawnTimer {
                 return
             }
             if (time == null) return
-            pestCooldownEndTime = if (config.customCooldown.get()) {
+            pestCooldownEndTime = if (config.customCooldown.get() && !lastPestSpawnTime.isFarPast()) {
                 lastPestSpawnTime + getCustomCooldownTime()
             } else time
 
@@ -135,8 +131,8 @@ object PestSpawnTimer {
         }
     }
 
-    @HandleEvent(PestSpawnEvent::class)
-    fun onPestSpawn() {
+    @HandleEvent
+    private fun onPestSpawn() {
         shouldRepeatWarning = false
         val spawnTime = lastPestSpawnTime.passedSince()
 
@@ -156,14 +152,14 @@ object PestSpawnTimer {
         lastPestSpawnTime = SimpleTimeMark.now()
     }
 
-    @HandleEvent(GuiRenderEvent.GuiOverlayRenderEvent::class, onlyOnIsland = IslandType.GARDEN)
-    fun onGuiRenderOverlay() {
+    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
+    private fun onGuiRenderOverlay() {
         if (!shouldRender) return
         config.position.renderRenderables(display, posLabel = "Pest Spawn Timer")
     }
 
     @HandleEvent
-    fun onCropClick() {
+    private fun onCropClick() {
         val timeDiff = lastCropBrokenTime.passedSince()
 
         if (timeDiff > longestCropBrokenTime) {
@@ -173,8 +169,8 @@ object PestSpawnTimer {
         lastCropBrokenTime = SimpleTimeMark.now()
     }
 
-    @HandleEvent(SecondPassedEvent::class, onlyOnIsland = IslandType.GARDEN)
-    fun onSecondPassed() {
+    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
+    private fun onSecondPassed() {
         if (!isEnabled()) return
         update()
         if (shouldRepeatWarning) {
@@ -201,7 +197,7 @@ object PestSpawnTimer {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
-    fun onTick(event: SkyHanniTickEvent) {
+    private fun onTick(event: SkyHanniTickEvent) {
         if (shouldRepeatWarning) {
             if (ArmorWardrobeApi.inWardrobe() || EquipmentWardrobeApi.inWardrobe()) {
                 shouldRepeatWarning = false
@@ -215,14 +211,15 @@ object PestSpawnTimer {
         shouldRender = shouldRender()
     }
 
-    @HandleEvent(IslandJoinEvent::class, onlyOnIsland = IslandType.GARDEN)
-    fun onIslandJoin() {
+    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
+    private fun onIslandJoin() {
         shouldRepeatWarning = false
         longestCropBrokenTime = lastCropBrokenTime.passedSince()
+        lastPestSpawnTime = SimpleTimeMark.farPast()
     }
 
-    @HandleEvent(ConfigLoadEvent::class)
-    fun onConfigLoad() {
+    @HandleEvent
+    private fun onConfigLoad() {
         config.customCooldown.onToggle {
             setCustomCooldown()
         }
@@ -232,7 +229,7 @@ object PestSpawnTimer {
     }
 
     private fun setCustomCooldown() {
-        if (!config.customCooldown.get()) return
+        if (!config.customCooldown.get() || lastPestSpawnTime.isFarPast()) return
         pestCooldownEndTime = lastPestSpawnTime + getCustomCooldownTime()
     }
 
@@ -365,7 +362,7 @@ object PestSpawnTimer {
     }
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         val userSelections: List<HeldItem> = buildList {
             event.transform(97, "garden.pests.pestTimer.onlyWithFarmingTool") { entry ->
                 if (entry.asBoolean) add(HeldItem.FARMING_TOOL)

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
@@ -93,7 +93,7 @@ object PestSpawnTimer {
     @HandleEvent(onlyOnIsland = IslandType.GARDEN)
     private fun onWidgetUpdate(event: WidgetUpdateEvent) {
         if (!event.isWidget(TabWidget.PESTS)) return
-        val widgetLines = event.cleanLines.takeIfNotEmpty() ?: return
+        val widgetLines = event.cleanLines
 
         // Hypixel can sometimes send partial widget
         // so we first check if the maximum number of pests is present as a workaround


### PR DESCRIPTION
## What
The problem was that if the last pest spawn time was far past, it would still add the custom cooldown amount, which would be nonesense.
Also it never reset the lastPestSpawn when entering/leaving the garden.

Also did generic cleanup (private event listeners + primary function)

## Changelog Fixes
+ Fixed the Custom Pest Cooldown option always showing the Pest Cooldown as ready. - Avrg