### PR TITLE
Fix: Crosshair location on 26.1

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
@@ -50,7 +50,6 @@ import org.joml.Matrix4f
 
 @Suppress("LargeClass")
 object WorldRenderUtils {
-
     private val beaconBeam = createResourceLocation("textures/entity/beacon/beacon_beam.png")
 
     //? if >= 26.2 {
@@ -964,11 +963,8 @@ object WorldRenderUtils {
     }
 
     internal fun SkyHanniRenderWorldEvent.exactPlayerCrosshairLocation(): LorenzVec {
-        //? if >= 26.2 {
         val look = Vector3f(0f, 0f, -1f).rotate(camera.rotation())
         return camera.position.toLorenzVec() + LorenzVec(look.x.toDouble(), look.y.toDouble(), look.z.toDouble()).times(2)
-        //?} else
-        //return exactPlayerEyeLocation() + MinecraftCompat.localPlayerOrThrow.lookAngle.toLorenzVec().times(2)
     }
 
     fun SkyHanniRenderWorldEvent.exactBoundingBox(entity: Entity): AABB {


### PR DESCRIPTION
## What
Fixes lines drawn to the crosshair jumping around whenever the player sneaks or unsneaks on 26.1. The fix is to just use the 26.2 code for 26.1 as well, and then everything seems to work fine. 

https://discord.com/channels/997079228510117908/1094190239532208228/1540349883888701530

## Changelog Fixes
+ Fixed lines drawn to crosshair jumping around when you sneak or unsneak on 26.1. - Luna