### PR TITLE
Improvement: Aqua overflow skill levels

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemDisplayOverlayFeatures.kt
@@ -69,6 +69,7 @@ object ItemDisplayOverlayFeatures {
 
     private val patternGroup = RepoPattern.group("inventory.item.overlay")
     private var lastSize = 0
+    private const val OVERFLOW_STACK_DIAMOND_LEVEL = 100
 
     /**
      * REGEX-TEST: MASTER_SKULL_TIER_1
@@ -130,6 +131,11 @@ object ItemDisplayOverlayFeatures {
         val cachedData = stack.cachedData
         val tip = cachedData.stackTip ?: getStackTip(stack).also { cachedData.stackTip = it.orEmpty() }
         tip?.takeIf { it.isNotEmpty() }?.let { event.stackTip = it }
+    }
+
+    private fun overflowSkillStackTip(overflowLevel: Int): String {
+        val digits = overflowLevel.toString()
+        return if (overflowLevel >= OVERFLOW_STACK_DIAMOND_LEVEL) "§b$digits" else digits
     }
 
     private fun getStackTip(item: SafeItemStack): String? {
@@ -219,8 +225,11 @@ object ItemDisplayOverlayFeatures {
                 val level = "" + text.romanToDecimalIfNecessary()
                 val skill = SkillType.getByNameOrNull(skillName) ?: return level
                 val skillInfo = SkillApi.storage?.get(skill) ?: return level
-                return if (SkillProgress.config.overflowConfig.enableInSkillMenuAsStackSize)
-                    "" + skillInfo.overflowLevel else level
+                return if (SkillProgress.config.overflowConfig.enableInSkillMenuAsStackSize) {
+                    overflowSkillStackTip(skillInfo.overflowLevel)
+                } else {
+                    level
+                }
             }
         }
 


### PR DESCRIPTION
## What
Overflow skill levels in Your Skills use aqua (light blue) instead of vanilla gold.

The Skills menu stack overlay prefixes overflow numbers with `§b` when Skill Overflow → Skill Menu Stack Size is on. The overflow skill item name uses the same aqua when Skill Overflow → Skill Menu Tooltips is on.

There is no level-100 cutoff.

## Changelog Improvements
+ Overflow skill levels now show as aqua in the Skills menu. - Nharington