### PR TITLE
Backend: Fix SkyHanniWorldRenderEvent injection point on 26.1

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinLevelRenderer.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinLevelRenderer.java
@@ -32,7 +32,6 @@ import com.llamalad7.mixinextras.sugar.Local;
 import com.mojang.blaze3d.textures.GpuSampler;
 import net.minecraft.client.renderer.OutlineBufferSource;
 import net.minecraft.client.renderer.RenderBuffers;
-import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.chunk.ChunkSectionsToRender;
 import net.minecraft.client.renderer.entity.state.EntityRenderState;
 import net.minecraft.world.entity.Entity;
@@ -43,7 +42,6 @@ import org.spongepowered.asm.mixin.injection.Slice;
 // The Fabric API event makes our lines render strange
 @Mixin(LevelRenderer.class)
 public abstract class MixinLevelRenderer {
-
     //? if < 26.2 {
     /*@Unique
     PoseStack contextMatrixStack;
@@ -114,7 +112,7 @@ public abstract class MixinLevelRenderer {
     //?} else {
     /*@WrapOperation(
         method = "lambda$addMainPass$0",
-        slice = @Slice(from = @At(value = "INVOKE_STRING", target = "Lnet/minecraft/util/profiling/ProfilerFiller;push(Ljava/lang/String;)V", args = "ldc=translucent")),
+        slice = @Slice(from = @At(value = "INVOKE_STRING", target = "Lnet/minecraft/util/profiling/ProfilerFiller;push(Ljava/lang/String;)V", args = "ldc=translucentTerrain")),
         at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/chunk/ChunkSectionsToRender;renderGroup(Lnet/minecraft/client/renderer/chunk/ChunkSectionLayerGroup;Lcom/mojang/blaze3d/textures/GpuSampler;)V", ordinal = 0)
     )
     private void onTranslucentRender(ChunkSectionsToRender instance, ChunkSectionLayerGroup group, GpuSampler gpuSampler, Operation<Void> original) {
@@ -151,24 +149,4 @@ public abstract class MixinLevelRenderer {
         if (!RenderLivingEntityHelper.isUsingCustomGlow()) return;
         SkyHanniOutlineHook.checkIfDepthAttachmentNeedsUpdating();
     }
-
-    //? if < 26.2 {
-    /*@Inject(method = "lambda$addMainPass$0", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/OutlineBufferSource;endOutlineBatch()V"))
-    private void renderSkyhanniGlow(CallbackInfo ci) {
-        if (!RenderLivingEntityHelper.isUsingCustomGlow()) return;
-        SkyHanniOutlineHook.getVertexConsumers().endOutlineBatch();
-    }
-
-    @Inject(
-        method = "lambda$addLateDebugPass$0",
-        at = @At(
-            value = "FIELD",
-            target = "Lcom/mojang/blaze3d/systems/RenderSystem;outputDepthTextureOverride:Lcom/mojang/blaze3d/textures/GpuTextureView;",
-            shift = At.Shift.AFTER
-        )
-    )
-    private void renderDeferredSeeThroughText(CallbackInfo ci, @Local MultiBufferSource.BufferSource bufferSource) {
-        WorldRenderUtils.renderDeferredSeeThroughText(bufferSource);
-    }
-    *///?}
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
@@ -55,22 +55,7 @@ object WorldRenderUtils {
 
     //? if >= 26.2 {
     private const val SKYHANNI_TEXT_SUBMIT_ORDER = 10_000
-    //?} else {
-    /*// 26.1 composites entity render targets over the main target after the normal world-render hook.
-    // Drawing see-through text in the late pass prevents entities from covering it (MC-265743).
-    private val deferredSeeThroughText = mutableListOf<(MultiBufferSource.BufferSource) -> Unit>()
-
-    @JvmStatic
-    fun renderDeferredSeeThroughText(bufferSource: MultiBufferSource.BufferSource) {
-        if (deferredSeeThroughText.isEmpty()) return
-        try {
-            deferredSeeThroughText.forEach { it(bufferSource) }
-            bufferSource.endBatch()
-        } finally {
-            deferredSeeThroughText.clear()
-        }
-    }
-    *///?}
+    //?}
 
     //? if >= 26.2 {
     private fun SkyHanniRenderWorldEvent.submitOrderedText(
@@ -348,24 +333,6 @@ object WorldRenderUtils {
         ).rotate(camera.rotation())
             .translate(0f, -yOffset * adjustedScale, 0f)
             .scale(adjustedScale, -adjustedScale, adjustedScale)
-
-        if (seeThroughBlocks) {
-            deferredSeeThroughText.add { bufferSource ->
-                fr.drawInBatch(
-                    text,
-                    x,
-                    0f,
-                    color?.rgb ?: LorenzColor.WHITE.toColor().rgb,
-                    shadow,
-                    matrix,
-                    bufferSource,
-                    SEE_THROUGH,
-                    backgroundColor,
-                    FULL_BRIGHT,
-                )
-            }
-            return
-        }
 
         fr.drawInBatch(
             text,


### PR DESCRIPTION
## What
The previous mixin was targeting `ldc=translucent`, which is invalid on 26.1+. And Mixin, in its infinite wisdom, instead of failing the injection, silently fell back to the first `ProfilerFiller#push` call, which is equivalent to `ldc=solidTerrain`. The correct target is `ldc=translucentTerrain`. That's why the whole "deferred see-through text" hack was required in the first place, which can now be removed with this PR.

No known immediate user-facing changes, since the existing hack already worked around the one known issue.

## Changelog Technical Details
+ Fixed SkyHanniWorldRenderEvent injection point on 26.1. - Luna