### PR TITLE
Improvement: Add toggle for smooth Pet Display XP animation

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/pets/display/PetDisplayConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/pets/display/PetDisplayConfig.kt
@@ -45,6 +45,14 @@ class PetDisplayConfig : Config() {
         val xpAccuracyWarning: String = ""
 
         @Expose
+        @ConfigOption(
+            name = "Smooth XP",
+            desc = "Smoothly animate changes to the pet XP instead of jumping to new values instantly."
+        )
+        @ConfigEditorBoolean
+        val smoothXp: Property<Boolean> = Property.of(true)
+
+        @Expose
         @ConfigLink(owner = GeneralPetDisplayConfig::class, field = "enabled")
         val position: Position = Position(200, 200)
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/pets/CurrentPetDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/pets/CurrentPetDisplay.kt
@@ -402,6 +402,10 @@ object CurrentPetDisplay {
     }
 
     private fun PetData.withAnimatedExp(): PetData {
+        if (!config.general.smoothXp.get()) {
+            xpAnimation = null
+            return this
+        }
         val targetExp = exp ?: return this
         val petUuid = uuid
         val currentAnimation = xpAnimation
@@ -424,6 +428,10 @@ object CurrentPetDisplay {
     }
 
     private fun List<ExpSharePetState>.withAnimatedExpShare(): List<ExpSharePetState> {
+        if (!config.general.smoothXp.get()) {
+            expShareXpAnimations.clear()
+            return this
+        }
         val activeUuids = mapNotNull { it.petData.uuid }.toSet()
         expShareXpAnimations.keys.removeAll { it !in activeUuids }
         return map { it.copy(petData = it.petData.withAnimatedExpShare()) }


### PR DESCRIPTION
## What
Adds a toggle to disable the current behavior of Pet Display where it smoothly animates the pet XP instead of instantly jumping to the new value.

## Changelog Improvements
+ Added "Smooth XP" option to Pet Display. - Luna
    * This was already how it worked before, but now the smoothening can be turned off.
