### PR TITLE
Fix: Potential mod incompatibility related to Chroma Text

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinPreparedTextBuilder.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinPreparedTextBuilder.java
@@ -27,7 +27,7 @@ public abstract class MixinPreparedTextBuilder {
 
     @WrapOperation(method = "accept(ILnet/minecraft/network/chat/Style;Lnet/minecraft/client/gui/font/glyphs/BakedGlyph;)Z", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/chat/Style;getColor()Lnet/minecraft/network/chat/TextColor;"))
     private TextColor wrapGetColor(Style original, Operation<TextColor> operation) {
-        return ChromaFontManager.forceWhiteTextColorForChroma(original.getColor());
+        return ChromaFontManager.forceWhiteTextColorForChroma(operation.call(original));
     }
 
     @ModifyArg(method = "accept(ILnet/minecraft/network/chat/Style;Lnet/minecraft/client/gui/font/glyphs/BakedGlyph;)Z", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/font/glyphs/BakedGlyph;createGlyph(FFIILnet/minecraft/network/chat/Style;FF)Lnet/minecraft/client/gui/font/TextRenderable$Styled;"))


### PR DESCRIPTION
## What
Fixes a small mistake where a chroma text related mixin was using @WrapOperation but ignoring the operation causing it to behave as if it were a normal @Redirect. I don't think this caused any problems but you never know if it will become one later...

## Changelog Fixes
+ Fixed a potential mod incompatibility related to Chroma Text. - AzureAaron

## Changelog Technical Details
+ Fixed a Chroma Text mixin @WrapOperation effectively behaving as a @Redirect. - AzureAaron