### PR TITLE
Fix: makePickblock/makeShiftClick compatibility with other mods

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/events/GuiContainerEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/GuiContainerEvent.kt
@@ -2,7 +2,7 @@ package at.hannibal2.skyhanni.events
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
-import at.hannibal2.skyhanni.utils.InventoryUtils
+import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.compat.SkyHanniGuiContainer
 import net.minecraft.client.gui.GuiGraphicsExtractor
@@ -10,10 +10,13 @@ import net.minecraft.world.inventory.AbstractContainerMenu
 import net.minecraft.world.inventory.ContainerInput
 import net.minecraft.world.inventory.Slot
 
-abstract class GuiContainerEvent(open val gui: SkyHanniGuiContainer, open val container: AbstractContainerMenu) : SkyHanniEvent() {
+abstract class GuiContainerEvent(
+    open val gui: SkyHanniGuiContainer,
+    open val container: AbstractContainerMenu,
+) : SkyHanniEvent() {
 
     @PrimaryFunction("onBackgroundDrawn")
-    data class BackgroundDrawnEvent(
+    class BackgroundDrawnEvent(
         override val context: GuiGraphicsExtractor,
         override val gui: SkyHanniGuiContainer,
         override val container: AbstractContainerMenu,
@@ -22,7 +25,7 @@ abstract class GuiContainerEvent(open val gui: SkyHanniGuiContainer, open val co
         val partialTicks: Float,
     ) : GuiContainerEvent(gui, container), Rendering
 
-    data class PreDraw(
+    class PreDraw(
         override val context: GuiGraphicsExtractor,
         override val gui: SkyHanniGuiContainer,
         override val container: AbstractContainerMenu,
@@ -31,7 +34,7 @@ abstract class GuiContainerEvent(open val gui: SkyHanniGuiContainer, open val co
         val partialTicks: Float,
     ) : GuiContainerEvent(gui, container), Cancellable, Rendering
 
-    data class PostDraw(
+    class PostDraw(
         override val context: GuiGraphicsExtractor,
         override val gui: SkyHanniGuiContainer,
         override val container: AbstractContainerMenu,
@@ -40,28 +43,31 @@ abstract class GuiContainerEvent(open val gui: SkyHanniGuiContainer, open val co
         val partialTicks: Float,
     ) : GuiContainerEvent(gui, container), Rendering
 
-    data class CloseWindowEvent(override val gui: SkyHanniGuiContainer, override val container: AbstractContainerMenu) :
-        GuiContainerEvent(gui, container), Cancellable
+    class CloseWindowEvent(
+        override val gui: SkyHanniGuiContainer,
+        override val container: AbstractContainerMenu,
+    ) : GuiContainerEvent(gui, container), Cancellable
 
-    abstract class DrawSlotEvent(gui: SkyHanniGuiContainer, container: AbstractContainerMenu, open val slot: Slot) :
-        GuiContainerEvent(gui, container) {
+    abstract class DrawSlotEvent(
+        gui: SkyHanniGuiContainer,
+        container: AbstractContainerMenu,
+        open val slot: Slot,
+    ) : GuiContainerEvent(gui, container) {
 
-        data class GuiContainerDrawSlotPre(
+        class GuiContainerDrawSlotPre(
             override val gui: SkyHanniGuiContainer,
             override val container: AbstractContainerMenu,
             override val slot: Slot,
-        ) :
-            DrawSlotEvent(gui, container, slot), Cancellable
+        ) : DrawSlotEvent(gui, container, slot), Cancellable
 
-        data class GuiContainerDrawSlotPost(
+        class GuiContainerDrawSlotPost(
             override val gui: SkyHanniGuiContainer,
             override val container: AbstractContainerMenu,
             override val slot: Slot,
-        ) :
-            DrawSlotEvent(gui, container, slot)
+        ) : DrawSlotEvent(gui, container, slot)
     }
 
-    data class ForegroundDrawnEvent(
+    class ForegroundDrawnEvent(
         override val context: GuiGraphicsExtractor,
         override val gui: SkyHanniGuiContainer,
         override val container: AbstractContainerMenu,
@@ -70,28 +76,64 @@ abstract class GuiContainerEvent(open val gui: SkyHanniGuiContainer, open val co
         val partialTicks: Float,
     ) : GuiContainerEvent(gui, container), Rendering
 
-    data class SlotClickEvent(
+    class SlotClickEvent private constructor(
         override val gui: SkyHanniGuiContainer,
         override val container: AbstractContainerMenu,
-        val item: SafeItemStack?,
-        val slot: Slot?,
-        val slotId: Int,
-        val clickedButton: Int,
-        val clickType: ContainerInput?,
+        var slotId: Int,
+        var clickedButton: Int,
+        var clickType: ContainerInput,
     ) : GuiContainerEvent(gui, container), Cancellable {
 
+        val slot: Slot?
+            get() = slotId.takeIf { it > -1 }?.let(container::getSlot)
+
+        val item: SafeItemStack?
+            get() = slot?.item
+
         fun makePickblock() {
-            if (this.clickedButton == 2 && this.clickType == ContainerInput.CLONE) return
-            slot?.index?.let { slotNumber ->
-                InventoryUtils.clickSlot(slotNumber, container.containerId, mouseButton = 2, mode = ContainerInput.CLONE)
-                cancel()
-            }
+            if (clickedButton == 2 && clickType == CLONE) return
+            if (slot == null) return
+
+            clickedButton = 2
+            clickType = CLONE
+        }
+
+        fun makeShiftClick() {
+            if (clickedButton == 1 && slot?.item?.getItemCategoryOrNull() == SACK) return
+            if (slot == null) return
+
+            clickedButton = 0
+            clickType = QUICK_MOVE
         }
 
         fun redirectClick(newSlotId: Int) {
-            InventoryUtils.clickSlot(newSlotId, container.containerId, clickedButton, clickType ?: ContainerInput.PICKUP)
-            cancel()
+            slotId = newSlotId
+        }
+
+        companion object {
+            private val postDepth = ThreadLocal.withInitial { 0 }
+
+            fun postEvent(
+                gui: SkyHanniGuiContainer,
+                container: AbstractContainerMenu,
+                slotId: Int,
+                clickedButton: Int,
+                clickType: ContainerInput,
+            ): SlotClickEvent? {
+                if (postDepth.get() > 0) return null
+
+                postDepth.set(postDepth.get() + 1)
+                try {
+                    return SlotClickEvent(gui, container, slotId, clickedButton, clickType).post() as SlotClickEvent
+                } finally {
+                    val depth = postDepth.get() - 1
+                    check(depth >= 0) {
+                        postDepth.remove()
+                        "SlotClickEvent postDepth underflow detected"
+                    }
+                    if (depth == 0) postDepth.remove() else postDepth.set(depth)
+                }
+            }
         }
     }
-
 }

--- a/src/main/java/at/hannibal2/skyhanni/events/GuiContainerEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/GuiContainerEvent.kt
@@ -111,7 +111,7 @@ abstract class GuiContainerEvent(
         }
 
         companion object {
-            private val postDepth = ThreadLocal.withInitial { 0 }
+            private val posting = ThreadLocal.withInitial { false }
 
             fun postEvent(
                 gui: SkyHanniGuiContainer,
@@ -120,20 +120,15 @@ abstract class GuiContainerEvent(
                 clickedButton: Int,
                 clickType: ContainerInput,
             ): SlotClickEvent? {
-                if (postDepth.get() > 0) return null
+                if (posting.get()) return null
 
-                postDepth.set(postDepth.get() + 1)
+                posting.set(true)
                 try {
                     val event = SlotClickEvent(gui, container, slotId, clickedButton, clickType)
                     event.post()
                     return event
                 } finally {
-                    val depth = postDepth.get() - 1
-                    check(depth >= 0) {
-                        postDepth.remove()
-                        "SlotClickEvent postDepth underflow detected"
-                    }
-                    if (depth == 0) postDepth.remove() else postDepth.set(depth)
+                    posting.remove()
                 }
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/events/GuiContainerEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/GuiContainerEvent.kt
@@ -124,7 +124,9 @@ abstract class GuiContainerEvent(
 
                 postDepth.set(postDepth.get() + 1)
                 try {
-                    return SlotClickEvent(gui, container, slotId, clickedButton, clickType).post() as SlotClickEvent
+                    val event = SlotClickEvent(gui, container, slotId, clickedButton, clickType)
+                    event.post()
+                    return event
                 } finally {
                     val depth = postDepth.get() - 1
                     check(depth >= 0) {

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.features.dungeon
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.api.event.HandleEvent.Companion.LOW
 import at.hannibal2.skyhanni.config.storage.ProfileSpecificStorage.DungeonStorage.DungeonRunInfo
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ProfileStorageData
@@ -137,8 +138,8 @@ object CroesusChestTracker {
 
     private val croesusChests get() = ProfileStorageData.profileSpecific?.dungeons?.runs
 
-    @HandleEvent(GuiContainerEvent.BackgroundDrawnEvent::class, priority = HandleEvent.LOW, onlyOnSkyblock = true)
-    fun onBackgroundDrawn() {
+    @HandleEvent(priority = LOW, onlyOnSkyblock = true)
+    private fun onBackgroundDrawn() {
         if (!SkyHanniMod.feature.dungeon.croesusUnopenedChestTracker) return
 
         if (!inCroesusInventory || croesusEmpty) return
@@ -154,7 +155,7 @@ object CroesusChestTracker {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
+    private fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
         if ((SkyHanniMod.feature.dungeon.croesusUnopenedChestTracker || config.showUsedKismets) &&
             croesusPattern.matches(event.inventoryName)
         ) {
@@ -224,18 +225,18 @@ object CroesusChestTracker {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
+    private fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
         if (!config.showUsedKismets) return
         if (inCroesusInventory && !croesusEmpty) {
-            if (event.slot == null) return
+            val item = event.item ?: return
             when (event.slotId) {
-                FRONT_ARROW_SLOT -> if (pageSwitchable && event.slot.item.isArrow()) {
+                FRONT_ARROW_SLOT -> if (pageSwitchable && item.isArrow()) {
                     pageSwitchable = false
                     currentPage++
                 }
 
                 // People are getting Index out of range errors presumably due to negative pages.
-                BACK_ARROW_SLOT -> if (pageSwitchable && currentPage != 0 && event.slot.item.isArrow()) {
+                BACK_ARROW_SLOT -> if (pageSwitchable && currentPage != 0 && item.isArrow()) {
                     pageSwitchable = false
                     currentPage--
                 }
@@ -246,7 +247,7 @@ object CroesusChestTracker {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onRenderItemTip(event: RenderItemTipEvent) {
+    private fun onRenderItemTip(event: RenderItemTipEvent) {
         if (!config.kismetStackSize) return
         if (chestInventory == null) return
         if (!kismetPattern.matches(event.stack.cleanName)) return
@@ -255,7 +256,7 @@ object CroesusChestTracker {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onRenderInventoryItemTip(event: RenderInventoryItemTipEvent) {
+    private fun onRenderInventoryItemTip(event: RenderInventoryItemTipEvent) {
         if (!config.showUsedKismets) return
         if (!inCroesusInventory) return
         if (event.slot.containerSlot != event.slot.index) return
@@ -268,12 +269,12 @@ object CroesusChestTracker {
     }
 
     @HandleEvent
-    fun onKuudraComplete(event: KuudraCompleteEvent) {
+    private fun onKuudraComplete(event: KuudraCompleteEvent) {
         addCroesusChest("T${event.kuudraTier}")
     }
 
     @HandleEvent
-    fun onDungeonComplete(event: DungeonCompleteEvent) {
+    private fun onDungeonComplete(event: DungeonCompleteEvent) {
         if (event.floor == "E") return
         addCroesusChest(event.floor)
     }
@@ -333,7 +334,6 @@ object CroesusChestTracker {
         }
         return unopenedChests
     }
-
 
     private fun addCroesusChest(floorOrTier: String) {
         croesusChests?.add(0, DungeonRunInfo(floorOrTier, SimpleTimeMark.now()))

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
@@ -7,7 +7,6 @@ import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ProfileStorageData
 import at.hannibal2.skyhanni.data.SackApi.getAmountInSacks
 import at.hannibal2.skyhanni.events.GuiContainerEvent
-import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.RenderInventoryItemTipEvent
 import at.hannibal2.skyhanni.events.RenderItemTipEvent
@@ -217,8 +216,8 @@ object CroesusChestTracker {
         openState = null
     }
 
-    @HandleEvent(InventoryCloseEvent::class)
-    fun onInventoryClose() {
+    @HandleEvent
+    private fun onInventoryClose() {
         inCroesusInventory = false
         chestInventory = null
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
@@ -2,7 +2,6 @@ package at.hannibal2.skyhanni.features.dungeon
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.api.event.HandleEvent.Companion.LOW
 import at.hannibal2.skyhanni.config.storage.ProfileSpecificStorage.DungeonStorage.DungeonRunInfo
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.ProfileStorageData
@@ -138,7 +137,7 @@ object CroesusChestTracker {
 
     private val croesusChests get() = ProfileStorageData.profileSpecific?.dungeons?.runs
 
-    @HandleEvent(priority = LOW, onlyOnSkyblock = true)
+    @HandleEvent(priority = HandleEvent.LOW, onlyOnSkyblock = true)
     private fun onBackgroundDrawn() {
         if (!SkyHanniMod.feature.dungeon.croesusUnopenedChestTracker) return
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityRabbitTheFishChecker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityRabbitTheFishChecker.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.features.event.hoppity
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.api.event.HandleEvent.Companion.HIGHEST
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 import at.hannibal2.skyhanni.data.title.TitleManager
 import at.hannibal2.skyhanni.events.GuiContainerEvent
@@ -22,7 +23,6 @@ import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object HoppityRabbitTheFishChecker {
-
     // <editor-fold desc="Patterns">
     /**
      * REGEX-TEST: Chocolate Breakfast Egg
@@ -58,7 +58,7 @@ object HoppityRabbitTheFishChecker {
     private var rabbitTheFishIndex: Int? = null
 
     @HandleEvent
-    fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
+    private fun onBackgroundDrawn() {
         if (!isEnabled()) return
 
         val index = rabbitTheFishIndex ?: return
@@ -66,7 +66,7 @@ object HoppityRabbitTheFishChecker {
     }
 
     @HandleEvent
-    fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
+    private fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
         rabbitTheFishIndex = null
         if (!isEnabled() || !mealEggInventoryPattern.matches(event.inventoryName)) return
 
@@ -77,15 +77,15 @@ object HoppityRabbitTheFishChecker {
         }?.key
     }
 
-    @HandleEvent(priority = HandleEvent.HIGHEST)
-    fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
+    @HandleEvent(priority = HIGHEST)
+    private fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
         if (!isEnabled() || rabbitTheFishIndex == null) return
 
-        // Prevent opening chocolate factory when Rabbit the Fish is present
-        val stack = event.slot?.item ?: return
-        if (openCfSlotLorePattern.anyMatches(stack.getLore())) {
+        // Prevent opening Chocolate Factory when Rabbit the Fish is present
+        val slot = event.slot ?: return
+        if (openCfSlotLorePattern.anyMatches(slot.item.getLore())) {
             event.sendPreventClosureTitle()
-        } else if (rabbitTheFishIndex == event.slot.containerSlot) {
+        } else if (rabbitTheFishIndex == slot.containerSlot) {
             rabbitTheFishIndex = null
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HarpFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HarpFeatures.kt
@@ -7,7 +7,6 @@ import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.events.GuiKeyPressEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.RenderItemTipEvent
-import at.hannibal2.skyhanni.events.minecraft.ClientDisconnectEvent
 import at.hannibal2.skyhanni.events.minecraft.ToolTipTextEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.DelayedRun
@@ -34,7 +33,6 @@ import kotlin.time.Duration.Companion.seconds
 // Delaying key presses by 300ms comes from NotEnoughUpdates
 @SkyHanniModule
 object HarpFeatures {
-
     private val config get() = SkyHanniMod.feature.inventory.helper.harp
     private var lastClick = SimpleTimeMark.farPast()
 
@@ -65,7 +63,7 @@ object HarpFeatures {
     private fun isMenuGui(chestName: String) = menuTitlePattern.matches(chestName)
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onGuiKeyPress(event: GuiKeyPressEvent) {
+    private fun onGuiKeyPress(event: GuiKeyPressEvent) {
         if (!config.keybinds) return
         if (!isHarpGui(InventoryUtils.openInventoryName())) return
         val chest = event.guiContainer as? ContainerScreen ?: return
@@ -98,7 +96,7 @@ object HarpFeatures {
     private var openTime: SimpleTimeMark = SimpleTimeMark.farPast()
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
+    private fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
         if (config.quickRestart && isMenuGui(event.inventoryName)) {
             openTime = SimpleTimeMark.now()
         }
@@ -120,19 +118,19 @@ object HarpFeatures {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onInventoryClose() {
+    private fun onInventoryClose() {
         if (!config.guiScale) return
         unSetGuiScale()
     }
 
     @HandleEvent
-    fun onDisconnect(event: ClientDisconnectEvent) {
+    private fun onDisconnect() {
         if (!config.guiScale) return
         unSetGuiScale()
     }
 
     @HandleEvent
-    fun onIslandChange() {
+    private fun onWorldChange() {
         if (!config.guiScale) return
         unSetGuiScale()
     }
@@ -170,8 +168,7 @@ object HarpFeatures {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
-
+    private fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
         if (isHarpGui(InventoryUtils.openInventoryName())) {
             if (config.keybinds) {
                 // needed to not send duplicate clicks via keybind feature
@@ -190,14 +187,14 @@ object HarpFeatures {
             songSelectedPattern.anyMatches(it.item.getLore())
         }
         indexOfFirst.takeIf { it != -1 }?.let {
-            val clickType = event.clickType ?: return
+            val clickType = event.clickType
             event.cancel()
             InventoryUtils.clickSlot(it, event.container.containerId, mouseButton = event.clickedButton, mode = clickType)
         }
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onRenderItemTip(event: RenderItemTipEvent) {
+    private fun onRenderItemTip(event: RenderItemTipEvent) {
         if (!config.showNumbers) return
         if (!isHarpGui(InventoryUtils.openInventoryName())) return
         if (!event.stack.isStainedClay()) return
@@ -211,13 +208,13 @@ object HarpFeatures {
     }
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(2, "misc.harpKeybinds", "inventory.helper.harp.keybinds")
         event.move(2, "misc.harpNumbers", "inventory.helper.harp.showNumbers")
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onToolTip(event: ToolTipTextEvent) {
+    private fun onToolTip(event: ToolTipTextEvent) {
         if (!config.hideMelodyTooltip) return
         if (!isHarpGui(InventoryUtils.openInventoryName())) return
         if (event.slot?.container !is SimpleContainer) return

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ReforgeHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ReforgeHelper.kt
@@ -44,7 +44,6 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 @SkyHanniModule
 object ReforgeHelper {
-
     private val config get() = SkyHanniMod.feature.inventory.helper.reforge
 
     private val patternGroup = RepoPattern.group("reforge")
@@ -139,8 +138,8 @@ object ReforgeHelper {
         if (!isEnabled()) return
         rareReforgeBlocked = false
 
-        if (event.slot?.index == reforgeButton) {
-            val lastLine = event.slot.item.getLoreComponent().lastOrNull()?.string
+        if (event.slotId == reforgeButton) {
+            val lastLine = event.item?.getLoreComponent()?.lastOrNull()?.string
             if (!clickToReforgePattern.matches(lastLine)) return
             if (handleNonBasicReforgeBlock(event)) return
             if (handleReforgeButtonClick(event)) return

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ShiftClickBrewing.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ShiftClickBrewing.kt
@@ -5,7 +5,6 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.InventoryUtils
-import at.hannibal2.skyhanni.utils.InventoryUtils.makeShiftClick
 import net.minecraft.client.gui.screens.inventory.ContainerScreen
 
 @SkyHanniModule
@@ -13,7 +12,7 @@ object ShiftClickBrewing {
     private const val closeButtonIndex = 49
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
+    private fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
         if (!SkyHanniMod.feature.inventory.shiftClickBrewing) return
 
         if (event.gui !is ContainerScreen) return

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ShiftClickEquipment.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ShiftClickEquipment.kt
@@ -4,14 +4,12 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.InventoryUtils.makeShiftClick
 import net.minecraft.client.gui.screens.inventory.ContainerScreen
 
 @SkyHanniModule
 object ShiftClickEquipment {
-
     @HandleEvent(onlyOnSkyblock = true)
-    fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
+    private fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
         if (!SkyHanniMod.feature.inventory.shiftClickForEquipment) return
 
         if (event.gui !is ContainerScreen) return

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ShiftClickNpcSell.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ShiftClickNpcSell.kt
@@ -4,10 +4,8 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.events.GuiContainerEvent
-import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.InventoryUtils.makeShiftClick
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
@@ -15,7 +13,6 @@ import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 
 @SkyHanniModule
 object ShiftClickNpcSell {
-
     private val config get() = SkyHanniMod.feature.inventory.shiftClickNpcSell
 
     private const val SELL_SLOT = -4
@@ -34,7 +31,7 @@ object ShiftClickNpcSell {
     fun isEnabled() = SkyBlockUtils.inSkyBlock && config
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
+    private fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
         if (event.inventoryItems.isEmpty()) return
         val item = event.inventoryItems[event.inventoryItems.keys.last() + SELL_SLOT] ?: return
 
@@ -42,12 +39,12 @@ object ShiftClickNpcSell {
     }
 
     @HandleEvent
-    fun onInventoryClose(event: InventoryCloseEvent) {
+    private fun onInventoryClose() {
         inInventory = false
     }
 
     @HandleEvent
-    fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
+    private fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
         if (!isEnabled()) return
         if (!inInventory) return
 
@@ -59,7 +56,7 @@ object ShiftClickNpcSell {
     }
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(97, "inventory.shiftClickNPCSell", "inventory.shiftClickNpcSell")
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsAddonsHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsAddonsHelper.kt
@@ -6,7 +6,6 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.GuiContainerEvent
-import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryUpdatedEvent
 import at.hannibal2.skyhanni.events.PlaySoundEvent
 import at.hannibal2.skyhanni.events.render.gui.ReplaceItemEvent
@@ -35,7 +34,6 @@ import com.google.gson.JsonPrimitive
 
 @SkyHanniModule
 object ExperimentsAddonsHelper {
-
     private enum class HelperPhase {
         READ,
         REPLICATE
@@ -95,8 +93,8 @@ object ExperimentsAddonsHelper {
     )
     // </editor-fold>
 
-    @HandleEvent(InventoryCloseEvent::class, onlyOnIsland = IslandType.PRIVATE_ISLAND)
-    fun resetAddonsData() {
+    @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND)
+    private fun onInventoryClose() {
         hypixelChronomatronData.clear()
         userChronomatronProgress.clear()
         hypixelUltrasequencerData.clear()
@@ -116,16 +114,12 @@ object ExperimentsAddonsHelper {
         "Cyan" -> LorenzColor.DARK_AQUA
         "Orange" -> LorenzColor.GOLD
         "Purple" -> LorenzColor.DARK_PURPLE
-        else -> try {
-            LorenzColor.valueOf(cleanName.uppercase())
-        } catch (exception: IllegalArgumentException) {
-            null
-        }
+        else -> runCatching { LorenzColor.valueOf(cleanName.uppercase()) }.getOrNull()
     }
 
     // <editor-fold desc="Next click highlighting">
     @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND)
-    fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
+    private fun onBackgroundDrawn() {
         if (!config.enabled) return
         if (!config.highlightNextClick || currentAddonPhase != HelperPhase.REPLICATE) return
 
@@ -165,7 +159,7 @@ object ExperimentsAddonsHelper {
 
     // <editor-fold desc="Slot click stuff">
     @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND)
-    fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
+    private fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
         if (!config.enabled) return
         if (event.slot == null || event.item == null || !ExperimentationTableApi.inAddon) return
         if (currentAddonPhase != HelperPhase.REPLICATE) return
@@ -189,7 +183,7 @@ object ExperimentsAddonsHelper {
     private fun GuiContainerEvent.SlotClickEvent.handleUltrasequencerClick() {
         if (!ExperimentationTableApi.inUltrasequencer || slot == null) return
         if (userUltrasequencerProgress.size == hypixelUltrasequencerData.size) return
-        val clickedSlot = slot.index.takeIf {
+        val clickedSlot = slotId.takeIf {
             val expectedSlot = hypixelUltrasequencerData[userUltrasequencerProgress.size]
             it == expectedSlot
         } ?: run {
@@ -229,7 +223,7 @@ object ExperimentsAddonsHelper {
 
     // <editor-fold desc="Inventory Update reading logic">
     @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND)
-    fun onPlaySound(event: PlaySoundEvent) {
+    private fun onPlaySound(event: PlaySoundEvent) {
         if (!ExperimentationTableApi.inChronomatron) return
         // This sound indicates when the player has finished a round in chronomatron
         if (event.soundName != "entity.player.levelup" || event.pitch != 1.7619047f || event.volume != 0.7f) return
@@ -237,7 +231,7 @@ object ExperimentsAddonsHelper {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND)
-    fun onInventoryUpdated(event: InventoryUpdatedEvent) {
+    private fun onInventoryUpdated(event: InventoryUpdatedEvent) {
         if (!ExperimentationTableApi.inAddon) return
 
         val oldAddonPhase = currentAddonPhase
@@ -367,7 +361,7 @@ object ExperimentsAddonsHelper {
     // </editor-fold>
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         val basePath = "inventory.experimentationTable.addons"
         event.move(94, "$basePath.highlightNextClick", "$basePath.enabled")
         event.transform(94, "$basePath.highlightNextClick") {

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/EnigmaSoulWaypoints.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/EnigmaSoulWaypoints.kt
@@ -1,10 +1,11 @@
 package at.hannibal2.skyhanni.features.rift.everywhere
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.api.event.HandleEvent.Companion.HIGH
+import at.hannibal2.skyhanni.api.event.HandleEvent.Companion.LOWEST
 import at.hannibal2.skyhanni.data.IslandGraphs
 import at.hannibal2.skyhanni.data.jsonobjects.repo.EnigmaSoulsJson
 import at.hannibal2.skyhanni.events.GuiContainerEvent
-import at.hannibal2.skyhanni.events.InventoryCloseEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
@@ -38,7 +39,6 @@ import net.minecraft.world.inventory.ChestMenu
 
 @SkyHanniModule
 object EnigmaSoulWaypoints {
-
     private val config get() = RiftApi.config.enigmaSoulWaypoints
     private var inInventory = false
     var soulLocations = mapOf<String, Map<String, LorenzVec>>()
@@ -102,7 +102,7 @@ object EnigmaSoulWaypoints {
     )
 
     @HandleEvent
-    fun replaceItem(event: ReplaceItemEvent) {
+    private fun replaceItem(event: ReplaceItemEvent) {
         if (!isEnabled()) return
 
         if (inventoryUnfound.isEmpty()) return
@@ -112,7 +112,7 @@ object EnigmaSoulWaypoints {
     }
 
     @HandleEvent
-    fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
+    private fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
         inInventory = false
         if (!inventoryNamePattern.matches(event.inventoryName)) return
         inInventory = true
@@ -129,14 +129,14 @@ object EnigmaSoulWaypoints {
     }
 
     @HandleEvent
-    fun onInventoryClose(event: InventoryCloseEvent) {
+    private fun onInventoryClose() {
         inInventory = false
         inventoryUnfound.clear()
         adding = true
     }
 
-    @HandleEvent(priority = HandleEvent.HIGH)
-    fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
+    @HandleEvent(priority = HIGH)
+    private fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
         if (!inInventory || !isEnabled()) return
 
         val area = getSelectedArea() ?: return
@@ -155,9 +155,9 @@ object EnigmaSoulWaypoints {
             }
         }
 
-        if (event.slot?.item == null) return
+        val item = event.item ?: return
 
-        val name = enigmaTitlePattern.matchMatcher(event.slot.item.cleanName) {
+        val name = enigmaTitlePattern.matchMatcher(item.cleanName) {
             group("name")
         } ?: return
         event.makePickblock()
@@ -189,8 +189,8 @@ object EnigmaSoulWaypoints {
         }
     }
 
-    @HandleEvent(priority = HandleEvent.LOWEST)
-    fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
+    @HandleEvent(priority = LOWEST)
+    private fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
         if (!isEnabled() || !inInventory) return
 
         if (event.gui !is ContainerScreen) return
@@ -212,7 +212,7 @@ object EnigmaSoulWaypoints {
     }
 
     @HandleEvent
-    fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
+    private fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
         if (!isEnabled()) return
         for ((area, souls) in trackedSouls) {
             for (name in souls) {
@@ -225,7 +225,7 @@ object EnigmaSoulWaypoints {
     }
 
     @HandleEvent
-    fun onRepoReload(event: RepositoryReloadEvent) {
+    private fun onRepoReload(event: RepositoryReloadEvent) {
         val data = event.getConstant<EnigmaSoulsJson>("EnigmaSouls")
         val areas = data.areas
         soulLocations = buildMap {
@@ -240,7 +240,7 @@ object EnigmaSoulWaypoints {
     }
 
     @HandleEvent
-    fun onChat(event: SkyHanniChatEvent.Allow) {
+    private fun onChat(event: SkyHanniChatEvent.Allow) {
         if (!isEnabled()) return
         if (foundPattern.matches(event.cleanMessage.trim())) {
             hideClosestSoul()

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/EnigmaSoulWaypoints.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/everywhere/EnigmaSoulWaypoints.kt
@@ -1,8 +1,6 @@
 package at.hannibal2.skyhanni.features.rift.everywhere
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.api.event.HandleEvent.Companion.HIGH
-import at.hannibal2.skyhanni.api.event.HandleEvent.Companion.LOWEST
 import at.hannibal2.skyhanni.data.IslandGraphs
 import at.hannibal2.skyhanni.data.jsonobjects.repo.EnigmaSoulsJson
 import at.hannibal2.skyhanni.events.GuiContainerEvent
@@ -135,7 +133,7 @@ object EnigmaSoulWaypoints {
         adding = true
     }
 
-    @HandleEvent(priority = HIGH)
+    @HandleEvent(priority = HandleEvent.HIGH)
     private fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
         if (!inInventory || !isEnabled()) return
 
@@ -189,7 +187,7 @@ object EnigmaSoulWaypoints {
         }
     }
 
-    @HandleEvent(priority = LOWEST)
+    @HandleEvent(priority = HandleEvent.LOWEST)
     private fun onBackgroundDrawn(event: GuiContainerEvent.BackgroundDrawnEvent) {
         if (!isEnabled() || !inInventory) return
 

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/GuiContainerHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/GuiContainerHook.kt
@@ -9,18 +9,19 @@ import at.hannibal2.skyhanni.events.GuiContainerEvent.SlotClickEvent
 import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.compat.DrawContextUtils
 import at.hannibal2.skyhanni.utils.compat.SkyHanniGuiContainer
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation
 import net.minecraft.client.gui.GuiGraphicsExtractor
 import net.minecraft.world.inventory.AbstractContainerMenu
 import net.minecraft.world.inventory.ContainerInput
 import net.minecraft.world.inventory.Slot
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable
 
 class GuiContainerHook(guiAny: Any) {
-
     private val gui: SkyHanniGuiContainer = guiAny as SkyHanniGuiContainer
     private val container: AbstractContainerMenu get() = gui.menu
 
-    fun closeWindowPressed(ci: org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable<Boolean>) {
+    fun closeWindowPressed(ci: CallbackInfoReturnable<Boolean>) {
         if (CloseWindowEvent(gui, container).post().isCancelled) ci.cancel()
     }
 
@@ -70,12 +71,30 @@ class GuiContainerHook(guiAny: Any) {
         GuiContainerEvent.DrawSlotEvent.GuiContainerDrawSlotPost(gui, container, slot).post()
     }
 
-    fun onMouseClick(slot: Slot?, slotId: Int, clickedButton: Int, clickType: ContainerInput, ci: CallbackInfo) {
-        val item = container.items.takeIf { it.size > slotId && slotId >= 0 }?.get(slotId)
-        val event = SlotClickEvent(gui, container, item, slot, slotId, clickedButton, clickType)
-        if (event.post().isCancelled) {
-            ci.cancel()
+    fun onMouseClick(
+        // Required for Java interop with Operation<Void>
+        @Suppress("ForbiddenVoid")
+        original: Operation<Void>,
+        slot: Slot?,
+        slotId: Int,
+        buttonNum: Int,
+        containerInput: ContainerInput,
+    ) {
+        val event = SlotClickEvent.postEvent(gui, container, slotId, buttonNum, containerInput)
+
+        if (event == null) {
+            original.call(slot, slotId, buttonNum, containerInput)
+            return
         }
+
+        if (event.isCancelled) return
+
+        original.call(
+            event.slot,
+            event.slotId,
+            event.clickedButton,
+            event.clickType,
+        )
     }
 
     fun onDrawScreenAfter(
@@ -86,5 +105,4 @@ class GuiContainerHook(guiAny: Any) {
     ) {
         if (DrawScreenAfterEvent(context, mouseX, mouseY, ci).post().isCancelled) ci.cancel()
     }
-
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinAbstractContainerScreen.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinAbstractContainerScreen.java
@@ -4,7 +4,6 @@ import at.hannibal2.skyhanni.data.GlobalRender;
 import at.hannibal2.skyhanni.data.GuiData;
 import at.hannibal2.skyhanni.data.ToolTipData;
 import at.hannibal2.skyhanni.data.model.TextInput;
-import at.hannibal2.skyhanni.events.DrawScreenAfterEvent;
 import at.hannibal2.skyhanni.events.GuiContainerEvent;
 import at.hannibal2.skyhanni.events.GuiKeyPressEvent;
 import at.hannibal2.skyhanni.events.render.gui.DrawBackgroundEvent;
@@ -16,6 +15,7 @@ import at.hannibal2.skyhanni.utils.DelayedRun;
 import at.hannibal2.skyhanni.utils.KeyboardManager;
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat;
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
@@ -25,7 +25,6 @@ import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.input.KeyEvent;
 import net.minecraft.client.input.MouseButtonEvent;
 import net.minecraft.network.chat.Component;
-import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.ContainerInput;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
@@ -41,8 +40,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import java.util.List;
 
 @Mixin(AbstractContainerScreen.class)
-public abstract class MixinAbstractContainerScreen<T extends AbstractContainerMenu> extends Screen {
-
+public abstract class MixinAbstractContainerScreen extends Screen {
     @Shadow
     @Nullable
     protected Slot hoveredSlot;
@@ -68,7 +66,7 @@ public abstract class MixinAbstractContainerScreen<T extends AbstractContainerMe
 
     @Inject(method = "extractRenderState", at = @At(value = "TAIL"), cancellable = true)
     private void renderTail(GuiGraphicsExtractor context, int mouseX, int mouseY, float deltaTicks, CallbackInfo ci) {
-        if (new DrawScreenAfterEvent(context, mouseX, mouseY, ci).post().isCancelled()) ci.cancel();
+        skyhanni$hook.onDrawScreenAfter(context, mouseX, mouseY, ci);
     }
 
     @Inject(method = "extractContents", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screens/Screen;extractRenderState(Lnet/minecraft/client/gui/GuiGraphicsExtractor;IIF)V", shift = At.Shift.AFTER))
@@ -179,9 +177,11 @@ public abstract class MixinAbstractContainerScreen<T extends AbstractContainerMe
         skyhanni$hook.onDrawSlotPost(slot);
     }
 
-    @Inject(method = "slotClicked(Lnet/minecraft/world/inventory/Slot;IILnet/minecraft/world/inventory/ContainerInput;)V", at = @At("HEAD"), cancellable = true)
-    private void onMouseClick(Slot slot, int slotId, int button, ContainerInput actionType, CallbackInfo cir) {
-        skyhanni$hook.onMouseClick(slot, slotId, button, actionType, cir);
+    @WrapMethod(
+        method = "slotClicked(Lnet/minecraft/world/inventory/Slot;IILnet/minecraft/world/inventory/ContainerInput;)V"
+    )
+    private void onMouseClick(Slot slot, int slotId, int buttonNum, ContainerInput containerInput, Operation<Void> original) {
+        skyhanni$hook.onMouseClick(original, slot, slotId, buttonNum, containerInput);
     }
 
     @Inject(

--- a/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/InventoryUtils.kt
@@ -2,10 +2,9 @@ package at.hannibal2.skyhanni.utils
 
 import at.hannibal2.skyhanni.data.OtherInventoryData
 import at.hannibal2.skyhanni.data.SackApi.getAmountInSacks
-import at.hannibal2.skyhanni.events.GuiContainerEvent
 import at.hannibal2.skyhanni.utils.EntityUtils.getArmorInventory
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
-import at.hannibal2.skyhanni.utils.ItemUtils.getItemCategoryOrNull
+import at.hannibal2.skyhanni.utils.ItemUtils.takeUnlessEmpty
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedSet
 import at.hannibal2.skyhanni.utils.compat.InventoryCompat
 import at.hannibal2.skyhanni.utils.compat.InventoryCompat.convertEmptyToNull
@@ -25,13 +24,11 @@ import net.minecraft.world.entity.player.Inventory
 import net.minecraft.world.inventory.ChestMenu
 import net.minecraft.world.inventory.ContainerInput
 import net.minecraft.world.inventory.Slot
-import net.minecraft.world.item.Items
 import kotlin.time.Duration.Companion.seconds
 
 // TODO refactor
 @Suppress("MemberVisibilityCanBePrivate", "TooManyFunctions", "Unused")
 object InventoryUtils {
-
     var itemInHandId = NeuInternalName.NONE
     fun NeuInternalName.recentlyHeld(): Boolean = this in recentItemsInHand
 
@@ -75,7 +72,9 @@ object InventoryUtils {
         return getItemsInOpenChest().mapNotNull { it.item.getInternalNameOrNull() }.toSet()
     }
 
-    // only works while not in an inventory
+    /**
+     * Only works while not in an inventory.
+     */
     fun getSlotsInOwnInventory(): List<Slot> {
         val guiInventory = MinecraftCompat.screen as? SkyHanniGuiContainer ?: return emptyList()
         return guiInventory.slots()
@@ -119,8 +118,7 @@ object InventoryUtils {
             it.contains("Ender Chest") || it.contains("Backpack")
     }
 
-    // mainHandItem can be AIR, since equipment in EntityLiving is an array of item stacks that can be AIR as well.
-    fun getItemInHand(): SafeItemStack? = MinecraftCompat.localPlayerOrNull?.mainHandItem?.takeIf { it.item != Items.AIR }
+    fun getItemInHand(): SafeItemStack? = MinecraftCompat.localPlayerOrNull?.mainHandItem?.takeUnlessEmpty()
 
     fun getArmor(): Array<SafeItemStack?> = MinecraftCompat.localPlayerOrNull?.getArmorInventory() ?: arrayOfNulls(4)
     fun getArmorInternalNames(): Set<NeuInternalName> = getArmor().mapNotNull { it?.getInternalNameOrNull() }.toSet()
@@ -129,14 +127,6 @@ object InventoryUtils {
     fun getChestplate(): SafeItemStack? = getArmor()[2]
     fun getLeggings(): SafeItemStack? = getArmor()[1]
     fun getBoots(): SafeItemStack? = getArmor()[0]
-
-    internal fun GuiContainerEvent.SlotClickEvent.makeShiftClick() {
-        if (this.clickedButton == 1 && slot?.item?.getItemCategoryOrNull() == ItemCategory.SACK) return
-        slot?.index?.let { slotNumber ->
-            clickSlot(slotNumber, container.containerId, mouseButton = 0, mode = ContainerInput.QUICK_MOVE)
-            this.cancel()
-        }
-    }
 
     fun isSlotInPlayerInventory(itemStack: SafeItemStack): Boolean {
         val slotUnderMouse = slotUnderCursor() ?: return false
@@ -194,21 +184,31 @@ object InventoryUtils {
         MinecraftCompat.screen = null
     }
 
-    fun isInNormalChest(name: String = openInventoryName()): Boolean = name in normalChestInternalNames.map { I18n.get(it) }
+    fun isInNormalChest(name: String = openInventoryName()): Boolean =
+        name in normalChestInternalNames.map { I18n.get(it) }
 
+    /**
+     * Clicks a slot by calling MultiPlayerGameMode's `handleContainerInput` method.
+     * Less compatible with other mods that intercept clicks than [mouseClickSlot].
+     */
     fun clickSlot(
         slotId: Int,
         windowId: Int = InventoryCompat.getWindowId(),
         mouseButton: Int = 0,
-        mode: ContainerInput = ContainerInput.PICKUP,
+        mode: ContainerInput = PICKUP,
     ) {
         InventoryCompat.clickInventorySlot(windowId, slotId, mouseButton, mode)
     }
 
+    /**
+     * Clicks a slot by calling the AbstractContainerScreen's `slotClicked` method.
+     * Preferred over [clickSlot] for compatibility with other mods, especially when
+     * modifying an existing player click.
+     */
     fun mouseClickSlot(
         slotId: Int,
         mouseButton: Int = 0,
-        mode: ContainerInput = ContainerInput.PICKUP,
+        mode: ContainerInput = PICKUP,
     ) {
         InventoryCompat.mouseClickInventorySlot(slotId, mouseButton, mode)
     }


### PR DESCRIPTION
## What
Fixes some SkyHanni features that change clicks being incompatible with other mods because we bypass the `AbstractContainerScreen` and click via `MultiPlayerGameMode` directly. This required the addition of a ThreadLocal depth guard to prevent a StackOverflowError. 

`makeShiftClick` has been moved inside the event rather than being an extension method, for consistency with `makePickblock` and `redirectClick`.

I also documented the two click methods (`InventoryUtils.clickSlot` and `InventoryUtils.mouseClickSlot`), but did not change other invocations to use the latter for now out of fear of accidentally breaking something.

Also changed the events in this file from data classes to regular classes because making them data classes is pointless overhead and would require a `@ConsistentCopyVisibility` annotation because of the private constructor.

## Changelog Fixes
+ Fixed Shift Click NPC sell bypassing item protection from certain other mods such as Skyblocker. - Luna