### PR TITLE
Fix: Pest Cooldown Wrong Icon

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/CurrencyApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/CurrencyApi.kt
@@ -54,7 +54,7 @@ object CurrencyApi {
      */
     private val pestsAmountPattern by patternGroup.pattern(
         "pests.amount",
-        "Vacuum Bag: (?<amount>[\\d,]+) \uE018 Pests",
+        "Vacuum Bag: (?<amount>[\\d,]+) [\uE07F\uE018] Pests",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/data/effect/NonGodPotEffect.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/effect/NonGodPotEffect.kt
@@ -142,14 +142,14 @@ enum class NonGodPotEffect(
     PEST_REPELLENT(
         "Pest Repellent I",
         displayName = "§6Pest Repellent I§r",
-        effectGainedMessage = "YUM!  Pests will now spawn 2x less while you break crops for the next 60m!",
+        effectGainedMessage = "YUM! [\uE07F\uE018] Pests will now spawn 2x less while you break crops for the next 60m!",
         effectDuration = 1.hours,
         effectChangeType = EffectDurationChangeType.SET,
     ),
     PEST_REPELLENT_MAX(
         "Pest Repellent II",
         displayName = "§6Pest Repellent II",
-        effectGainedMessage = "YUM!  Pests will now spawn 4x less while you break crops for the next 60m!",
+        effectGainedMessage = "YUM! [\uE07F\uE018] Pests will now spawn 4x less while you break crops for the next 60m!",
         effectDuration = 1.hours,
         effectChangeType = EffectDurationChangeType.SET,
     ),

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestApi.kt
@@ -80,10 +80,11 @@ object PestApi {
 
     /**
      * WRAPPED-REGEX-TEST: " §7 §aThe Garden §4§l§7 x1"
+     * WRAPPED-REGEX-TEST: " §7 §cThe Garden §4§l§7 x8"
      */
     private val pestsInScoreboardPattern by patternGroup.pattern(
         "scoreboard.pests",
-        " §7. §[ac]The Garden §4§l\uE018§7 x(?<pests>.*)",
+        " §7. §[ac]The Garden §4§l[\uE07F\uE018]§7 x(?<pests>.*)",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestApi.kt
@@ -101,7 +101,7 @@ object PestApi {
      */
     private val pestsInPlotScoreboardPattern by patternGroup.pattern(
         "scoreboard.plot.pests",
-        "\\s*(?:§.)*Plot (?:§.)*- (?:§.)*(?<plot>.+) (?:§.)*(?:§.)* x(?<pests>\\d+)",
+        "\\s*(?:§.)*Plot (?:§.)*- (?:§.)*(?<plot>.+) (?:§.)*[\uE07F\uE018](?:§.)* x(?<pests>\\d+)",
     )
 
     /**
@@ -117,7 +117,7 @@ object PestApi {
      */
     private val pestInventoryPattern by patternGroup.pattern(
         "inventory",
-        "§4§l §cThis plot has §.(?<amount>\\d+) §2 Pests?§c!",
+        "§4§l[\uE07F\uE018] §cThis plot has §.(?<amount>\\d+) §2 Pests?§c!",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawn.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawn.kt
@@ -31,8 +31,8 @@ object PestSpawn {
      */
     private val onePestPattern by patternGroup.list(
         "one.colorless",
-        "^\\w+! A  Pest has appeared in Plot - (?<plot>.*)!",
-        "^\\w+! A  Pest has appeared in (?<plot>The Barn)!",
+        "^\\w+! A [\uE07F\uE018] Pest has appeared in Plot - (?<plot>.*)!",
+        "^\\w+! A [\uE07F\uE018] Pest has appeared in (?<plot>The Barn)!",
     )
 
     /**
@@ -42,8 +42,8 @@ object PestSpawn {
      */
     private val multiplePestsPattern by patternGroup.list(
         "multiple.colorless",
-        "^\\w+! (?<amount>\\d)  Pests? have spawned in Plot - (?<plot>.*)!",
-        "^\\w+! (?<amount>\\d)  Pests? have spawned in (?<plot>The Barn)!",
+        "^\\w+! (?<amount>\\d) [\uE07F\uE018] Pests? have spawned in Plot - (?<plot>.*)!",
+        "^\\w+! (?<amount>\\d) [\uE07F\uE018] Pests? have spawned in (?<plot>The Barn)!",
     )
 
     /**
@@ -52,7 +52,7 @@ object PestSpawn {
      */
     private val offlinePestsPattern by patternGroup.pattern(
         "offline.colorless",
-        "^\\w+! While you were offline,  Pests? spawned in Plots (?<plots>.*)!",
+        "^\\w+! While you were offline, [\uE07F\uE018] Pests? spawned in Plots (?<plots>.*)!",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/HideMobNames.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/HideMobNames.kt
@@ -20,7 +20,7 @@ object HideMobNames {
     // TODO: use SkyblockIcons instead of hardcoding the mob types
     private const val ALL_MOB_TYPES =
         "\uE070\uE071\uE072\uE073\uE074\uE075\uE076\uE077\uE078\uE079\uE07A\uE07B" +
-            "\uE07C\uE07D\uE07E\uE018\uE080\uE081\uE082\uE083\uE084\uE085\uE086\uE087"
+            "\uE07C\uE07D\uE07E\uE018\uE07F\uE080\uE081\uE082\uE083\uE084\uE085\uE086\uE087"
 
     /**
      * REGEX-TEST: [Lv1]  Graveyard Zombie 100/100❤

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyblockSeason.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyblockSeason.kt
@@ -27,7 +27,7 @@ enum class SkyblockSeason(
     AUTUMN(
         "§eAutumn",
         "§4Pests §7spawn §a15% §7more often.",
-        "§a15%+§",
+        "§a15%+§\uE07F",
         7
     ),
     WINTER(


### PR DESCRIPTION
Thanks hypixel. It looks the same. but diffrent unicode value.
Made it support both, just incase.

exclude_from_changelog