### PR TITLE
Feature: Ban specific users from skyhanni

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/shader/RobloxReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/shader/RobloxReminder.kt
@@ -6,11 +6,14 @@ import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.NotificationManager
 import at.hannibal2.skyhanni.data.SkyHanniNotification
 import at.hannibal2.skyhanni.events.IslandChangeEvent
+import at.hannibal2.skyhanni.events.RepositoryReloadEvent
+import at.hannibal2.skyhanni.events.hypixel.HypixelJoinEvent
 import at.hannibal2.skyhanni.features.misc.ContributorManager
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.InventoryDetector
 import at.hannibal2.skyhanni.utils.OSUtils
+import at.hannibal2.skyhanni.utils.PlayerUtils
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.TimeUtils
 import at.hannibal2.skyhanni.utils.UtilsPatterns
@@ -40,12 +43,25 @@ object RobloxReminder {
     }
 
     @HandleEvent
-    fun onIslandChange(event: IslandChangeEvent) {
+    private fun onIslandChange(event: IslandChangeEvent) {
+        if (PlayerUtils.getUuid() in bannedUsers) {
+            PlatformUtils.shutdownMinecraft(
+                "Your account has been banned from using SkyHanni. " +
+                    "Please contact support for more information."
+            )
+        }
         if (event.newIsland == IslandType.NONE) return
         if (!TimeUtils.isAprilFoolsDay) return
 
         versionReminder()
         specialPerson()
+    }
+
+    private var bannedUsers: List<String> = emptyList()
+
+    @HandleEvent
+    private fun onRepoReload(event: RepositoryReloadEvent) {
+        bannedUsers = event.getConstant<List<String>>("BannedUsers")
     }
 
     private fun specialPerson() {

--- a/src/main/java/at/hannibal2/skyhanni/shader/RobloxReminder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/shader/RobloxReminder.kt
@@ -7,7 +7,6 @@ import at.hannibal2.skyhanni.data.NotificationManager
 import at.hannibal2.skyhanni.data.SkyHanniNotification
 import at.hannibal2.skyhanni.events.IslandChangeEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
-import at.hannibal2.skyhanni.events.hypixel.HypixelJoinEvent
 import at.hannibal2.skyhanni.features.misc.ContributorManager
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils


### PR DESCRIPTION
## What
Let's you ban certain players based on their UUID from using skyhanni.

(this is a joke PR, ignore it. techincally could make a PopularUsers.json and for youtubers show april fools errors. maybe)

## Changelog New Features
+ Added The Ability for Hannibal To Ban users from using SkyHanni. - Avrg