### PR TITLE
Fix: Custom Wardrobe Menu wrong inventory name

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/MenuScreensHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/MenuScreensHook.kt
@@ -50,7 +50,7 @@ object MenuScreensHook {
         client.player?.containerMenu = menu
 
         when (val screen = MinecraftCompat.screen) {
-            is CustomWardrobeScreen -> screen.changeHandler(menu)
+            is CustomWardrobeScreen -> screen.changeHandler(menu, name)
             is CustomWardrobeEditScreen ->
                 MinecraftCompat.screen = CustomWardrobeEditScreen(menu, inventory, name)
             else ->

--- a/src/main/java/at/hannibal2/skyhanni/utils/AbstractCustomMenuScreen.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/AbstractCustomMenuScreen.kt
@@ -28,11 +28,12 @@ abstract class AbstractCustomMenuScreen(
         ToolTipData.lastSlot = null
     }
 
-    fun changeHandler(newMenu: ChestMenu) {
+    fun changeHandler(newMenu: ChestMenu, inventoryName: Component) {
         menu.removeSlotListener(this)
         menu = newMenu
         menu.addSlotListener(this)
         ToolTipData.lastSlot = null
+        this.title = inventoryName
     }
 
     override fun getMenu(): ChestMenu {

--- a/src/main/resources/skyhanni.classtweaker
+++ b/src/main/resources/skyhanni.classtweaker
@@ -68,6 +68,7 @@ accessible method net/minecraft/client/gui/components/ChatComponent logChatMessa
 accessible method net/minecraft/client/gui/components/ChatComponent refreshTrimmedMessages ()V
 accessible method net/minecraft/client/gui/screens/inventory/AbstractContainerScreen slotClicked (Lnet/minecraft/world/inventory/Slot;IILnet/minecraft/world/inventory/ContainerInput;)V
 accessible method net/minecraft/client/gui/screens/inventory/AbstractSignEditScreen setMessage (Ljava/lang/String;)V
+mutable field net/minecraft/client/gui/screens/Screen title Lnet/minecraft/network/chat/Component;
 accessible method net/minecraft/client/renderer/rendertype/RenderType <init> (Ljava/lang/String;Lnet/minecraft/client/renderer/rendertype/RenderSetup;)V
 accessible method net/minecraft/network/chat/TextColor <init> (ILjava/lang/String;)V
 extendable class net/minecraft/world/item/ItemStack


### PR DESCRIPTION
## What
If you switched wardrobe screens it didn't update the screen title. which meant when it passed the title to the edit screen it was using the old title it started with instead of the new one.

## Changelog Fixes
+ Fixed Custom Wardrobe causing wrong inventory names in edit mode. - Avrg