### PR TITLE
Improvement + Fix: Carnival Tokens and cost lore reading

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/CurrencyApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/CurrencyApi.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
+import at.hannibal2.skyhanni.events.InventoryUpdatedEvent
 import at.hannibal2.skyhanni.events.ScoreboardUpdateEvent
 import at.hannibal2.skyhanni.events.WidgetUpdateEvent
 import at.hannibal2.skyhanni.events.inventory.NpcTradeEvent
@@ -18,6 +19,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLongOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SkyblockCurrency
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.StringUtils.removeResets
@@ -83,6 +85,24 @@ object CurrencyApi {
     private val safariTicketSignPattern by patternGroup.pattern(
         "safariticket.sign",
         "- (?<type>Basic|Economy|Premium|First-Class): (?<amount>[\\d,]+)",
+    )
+
+    /**
+     * The lore only writes "Tokens", the item this line belongs to is what makes it unambiguous.
+     *
+     * REGEX-TEST: Carnival Tokens
+     */
+    private val carnivalTokenItemPattern by patternGroup.pattern(
+        "carnivaltoken.item",
+        "Carnival Tokens",
+    )
+
+    /**
+     * REGEX-TEST: Your Tokens: 2,136
+     */
+    private val carnivalTokenAmountPattern by patternGroup.pattern(
+        "carnivaltoken.amount",
+        "Your Tokens: (?<amount>[\\d,]+)",
     )
 
     /**
@@ -199,6 +219,17 @@ object CurrencyApi {
             }
             for (line in item.getCleanLore()) {
                 readCleanLine(line)
+            }
+        }
+    }
+
+    // unlocking an upgrade sends no chat message, the new amount only shows in the updated item
+    @HandleEvent(onlyOnSkyblock = true)
+    private fun onInventoryUpdated(event: InventoryUpdatedEvent) {
+        val item = event.inventoryItems.values.firstOrNull { carnivalTokenItemPattern.matches(it.cleanName) } ?: return
+        for (line in item.getCleanLore()) {
+            carnivalTokenAmountPattern.matchMatcher(line) {
+                SkyblockCurrency.CARNIVAL_TOKEN.setAmount(group("amount").formatLong())
             }
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/LoreCostUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LoreCostUtils.kt
@@ -35,14 +35,19 @@ object LoreCostUtils {
      * into the header line is handed on as is, so that features can find that exact line again
      * in the tooltip. Matching without color would strip it and break that lookup.
      *
+     * Menus that list their costs below the header write it in singular or plural, with a colon
+     * or without one.
+     *
      * REGEX-TEST: §7Cost
      * REGEX-TEST: §5§o§7Cost
+     * REGEX-TEST: §7Costs
+     * REGEX-TEST: §7Cost:
      * REGEX-TEST: §7Cost: §b5,000 Bits
      * REGEX-TEST: §7Cost to unlock: §550 Tokens
      */
     private val costHeaderPattern by patternGroup.pattern(
         "cost.header",
-        "(?:§.)*Cost(?: to unlock)?(?:: (?<cost>.+))?",
+        "(?:§.)*Costs?(?: to unlock)?(?::(?: (?<cost>.+))?)?",
     )
 
     /**
@@ -81,7 +86,8 @@ object LoreCostUtils {
             groupOrNull("cost")?.let { return listOf(readCostLine(it, itemName)) }
         }
 
-        return drop(headerIndex + 1).takeWhile { it.isNotEmpty() }.map { readCostLine(it, itemName) }
+        // the blank line below the costs is not always empty, some menus write a color code into it
+        return drop(headerIndex + 1).takeWhile { it.removeColor().isNotEmpty() }.map { readCostLine(it, itemName) }
     }
 
     private fun readCostLine(rawLine: String, itemName: String): LoreCostEntry {

--- a/src/main/java/at/hannibal2/skyhanni/utils/LoreCostUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LoreCostUtils.kt
@@ -25,7 +25,7 @@ object LoreCostUtils {
 
     fun isCostHeader(line: String): Boolean = costHeaderPattern.matches(line)
 
-    /** True when the item can be bought right now, as opposed to a locked or already owned entry. */
+    /** True when the item is a purchase entry, as opposed to a locked or already owned one. */
     fun List<String>.hasTradeLine(): Boolean = any { tradeLinePattern.matches(it.removeColor()) }
 
     private val patternGroup = RepoPattern.group("utils.lore")
@@ -51,19 +51,19 @@ object LoreCostUtils {
     )
 
     /**
-     * Shops word this line differently, the essence perk shops unlock and the chip menu levels
-     * up, but all of them list their cost the same way. Kuudra names the mouse button, and its
-     * preview line uses the right button, which must not count as a trade.
+     * Shops word this line differently, and an entry the player cannot afford says so instead of
+     * asking for a click. Kuudra's preview line uses the right button and is no trade.
      *
      * REGEX-TEST: Click to trade!
      * REGEX-TEST: Click to unlock!
      * REGEX-TEST: Click to level up!
      * REGEX-TEST: Left Click to unlock!
+     * REGEX-TEST: You can't afford this upgrade!
      * REGEX-FAIL: Right Click to preview!
      */
     private val tradeLinePattern by patternGroup.pattern(
         "trade.click",
-        "(?:Left )?Click to (?:trade|unlock|level up)!",
+        "(?:Left )?Click to (?:trade|unlock|level up)!|You can't afford this upgrade!",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyblockCurrency.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyblockCurrency.kt
@@ -153,9 +153,15 @@ enum class SkyblockCurrency(
         ownedAmount = { getFromStorage() },
     ),
 
+    // Carnival upgrades in the Hub
+    CARNIVAL_TOKEN(
+        "SKYBLOCK_CARNIVAL_POINT".toInternalName(), "Carnival Token", YELLOW,
+        loreNames = setOf("carnival token", "carnival tokens"),
+        ownedAmount = { getFromStorage() },
+    ),
+
     // TODO add these currencies, each one needs a real cost line from its shop first
     //  - North Stars, waiting on the winter event
-    //  - Carnival Tokens, waiting on the carnival event, the item is SKYBLOCK_CARNIVAL_POINT
     //  - Bingo Points, waiting on the bingo event
     ;
 


### PR DESCRIPTION
## Changelog Improvements
+ Added Carnival Tokens to the NPC Trade features. - hannibal2

## Changelog Fixes
+ Fixed Cost Breakdown and Highlight Affordable not working in the Greenhouse and Carnival Upgrade menus. - hannibal2