### PR TITLE
Improvement: Hover delay for Estimated Item Value

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/EstimatedItemValueConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/EstimatedItemValueConfig.kt
@@ -37,6 +37,15 @@ class EstimatedItemValueConfig {
     var alwaysEnabled: Boolean = true
 
     @Expose
+    @ConfigOption(
+        name = "Hover Delay",
+        desc = "How long to hover over the same slot before the value shows up, in milliseconds. " +
+            "Only applies to the first item after opening an inventory. Set to 0 to disable."
+    )
+    @ConfigEditorSlider(minValue = 0f, maxValue = 2000f, minStep = 50f)
+    var hoverDelay: Int = 500
+
+    @Expose
     @ConfigOption(name = "Enchantments Cap", desc = "Only show the top # most expensive enchantments.")
     @ConfigEditorSlider(minValue = 1f, maxValue = 30f, minStep = 1f)
     val enchantmentsCap: Property<Int> = Property.of(7)

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
@@ -53,7 +53,7 @@ object EstimatedItemValue {
     private val tooltipTimeout = 200.milliseconds
 
     // dwell time on the same slot before the first display of an inventory session
-    private val hoverDelay = 500.milliseconds
+    private val hoverDelay get() = config.hoverDelay.milliseconds
 
     private var display = emptyList<Renderable>()
     private val cache = mutableMapOf<SafeItemStack, List<Renderable>>()
@@ -156,6 +156,7 @@ object EstimatedItemValue {
 
     private fun passHoverDelay(): Boolean {
         if (hoverDelayOver) return true
+        if (!hoverDelay.isPositive()) return true
         // null before the first hover of an inventory session
         if (hoveredItem == null) return false
         // measured on the tooltip stream, so the linger time after leaving a slot does not count

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValue.kt
@@ -29,6 +29,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.shortFormat
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.SafeItemStack
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessResets
@@ -37,6 +38,7 @@ import at.hannibal2.skyhanni.utils.renderables.Renderable
 import at.hannibal2.skyhanni.utils.renderables.primitives.StringRenderable
 import org.lwjgl.glfw.GLFW
 import kotlin.math.roundToLong
+import kotlin.time.Duration.Companion.milliseconds
 
 private typealias NeuGemstoneCostJson = HashMap<NeuInternalName, HashMap<String, List<String>>>
 
@@ -48,9 +50,18 @@ object EstimatedItemValue {
     private val repoReloadCoroutine = CoroutineSettings("estimated item value repo reload")
     private val neuRepoReloadCoroutine = CoroutineSettings("estimated item value neu repo reload")
 
+    private val tooltipTimeout = 200.milliseconds
+
+    // dwell time on the same slot before the first display of an inventory session
+    private val hoverDelay = 500.milliseconds
+
     private var display = emptyList<Renderable>()
     private val cache = mutableMapOf<SafeItemStack, List<Renderable>>()
-    private var lastToolTipTime = 0L
+    private var lastToolTipTime = SimpleTimeMark.farPast()
+    private var hoveredItem: SafeItemStack? = null
+    private var hoverStart = SimpleTimeMark.farPast()
+    private var hoverDelayOver = false
+
     var gemstoneUnlockCosts = NeuGemstoneCostJson()
     var hasLegacyGemstoneSlots = emptyList<NeuInternalName>()
     var bookBundleAmount = mapOf<String, Int>()
@@ -66,12 +77,12 @@ object EstimatedItemValue {
     fun isCurrentlyShowing() = currentlyShowing && MinecraftCompat.screen != null
 
     @HandleEvent
-    fun onNeuRepoReload(event: NeuRepositoryReloadEvent) = neuRepoReloadCoroutine.launch {
+    private fun onNeuRepoReload(event: NeuRepositoryReloadEvent) = neuRepoReloadCoroutine.launch {
         gemstoneUnlockCosts = event.getConstantAsync<NeuGemstoneCostJson>("gemstonecosts")
     }
 
     @HandleEvent
-    fun onRepoReload(event: RepositoryReloadEvent) = repoReloadCoroutine.launch {
+    private fun onRepoReload(event: RepositoryReloadEvent) = repoReloadCoroutine.launch {
         val data = event.getConstantAsync<ItemsJson>("Items")
         bookBundleAmount = data.bookBundleAmount
         itemValueCalculationData = data.valueCalculationData
@@ -90,7 +101,7 @@ object EstimatedItemValue {
     private var renderedItems = 0
 
     @HandleEvent
-    fun onGuiRenderOverlay() {
+    private fun onGuiRenderOverlay() {
         renderedItems = 0
     }
 
@@ -125,28 +136,44 @@ object EstimatedItemValue {
     }
 
     @HandleEvent
-    fun onChestGuiRender() {
+    private fun onChestGuiRender() {
         tryRendering()
     }
 
     private fun checkCurrentlyVisible(): Boolean {
         if (!SkyBlockUtils.inSkyBlock) return false
         if (!config.enabled) return false
-        if (!config.hotkey.isKeyHeld() && !config.alwaysEnabled) return false
-        if (System.currentTimeMillis() > lastToolTipTime + 200) return false
+        val hotkeyHeld = config.hotkey.isKeyHeld()
+        if (!hotkeyHeld && !config.alwaysEnabled) return false
+        if (lastToolTipTime.passedSince() > tooltipTimeout) return false
 
         if (display.isEmpty()) return false
+        if (hotkeyHeld) return true
 
+        // after the display check on purpose, an empty display must not end the delay
+        return passHoverDelay()
+    }
+
+    private fun passHoverDelay(): Boolean {
+        if (hoverDelayOver) return true
+        // null before the first hover of an inventory session
+        if (hoveredItem == null) return false
+        // measured on the tooltip stream, so the linger time after leaving a slot does not count
+        if (lastToolTipTime - hoverStart < hoverDelay) return false
+
+        hoverDelayOver = true
         return true
     }
 
     @HandleEvent
-    fun onInventoryClose() {
+    private fun onInventoryClose() {
         cache.clear()
+        hoveredItem = null
+        hoverDelayOver = false
     }
 
     @HandleEvent
-    fun onConfigLoad() {
+    private fun onConfigLoad() {
         with(config) {
             ConditionalUtils.onToggle(
                 enchantmentsCap,
@@ -162,16 +189,24 @@ object EstimatedItemValue {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onRenderItemTooltip(event: RenderItemTooltipEvent) {
+    private fun onRenderItemTooltip(event: RenderItemTooltipEvent) {
         if (!config.enabled) return
 
         updateItem(event.stack)
     }
 
+    private fun updateHoverTime(item: SafeItemStack) {
+        // also restarts when the tooltip stream was interrupted, e.g. by moving over an empty area
+        if (item === hoveredItem && lastToolTipTime.passedSince() <= tooltipTimeout) return
+        hoveredItem = item
+        hoverStart = SimpleTimeMark.now()
+    }
+
     fun updateItem(item: SafeItemStack) {
+        updateHoverTime(item)
         cache[item]?.let {
             display = it
-            lastToolTipTime = System.currentTimeMillis()
+            lastToolTipTime = SimpleTimeMark.now()
             return
         }
 
@@ -203,7 +238,7 @@ object EstimatedItemValue {
 
         cache[item] = newDisplay
         display = newDisplay
-        lastToolTipTime = System.currentTimeMillis()
+        lastToolTipTime = SimpleTimeMark.now()
     }
 
     private fun SafeItemStack.shouldIgnoreDraw(): Boolean {
@@ -249,7 +284,7 @@ object EstimatedItemValue {
     }
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(3, "misc.estimatedIemValueEnabled", "misc.estimatedItemValues.enabled")
         event.move(3, "misc.estimatedItemValueHotkey", "misc.estimatedItemValues.hotkey")
         event.move(3, "misc.estimatedIemValueAlwaysEnabled", "misc.estimatedItemValues.alwaysEnabled")


### PR DESCRIPTION
## Changelog Improvements
+ Improved Estimated Item Value to only show up after hovering over the same slot for half a second. - hannibal2
    * Only for the first item after opening an inventory.
    * The delay can be changed or disabled in the config.