### PR TITLE
Fix: Use submit-based world rendering on 26.1 + see-through text dimming fix

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/ClientEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/ClientEvents.kt
@@ -34,6 +34,10 @@ import net.minecraft.resources.Identifier
 import net.minecraft.server.packs.PackType
 import java.util.concurrent.CompletableFuture
 
+//? if < 26.2 {
+/*import at.hannibal2.skyhanni.utils.render.WorldRenderUtils
+*///?}
+
 @SkyHanniModule
 object ClientEvents {
     var totalTicks = 0
@@ -67,6 +71,12 @@ object ClientEvents {
                 Minecraft.getInstance().deltaTracker.getGameTimeDeltaPartialTick(true),
             ).post()
         }
+
+        //? if < 26.2 {
+        /*LevelRenderEvents.AFTER_TRANSLUCENT_TERRAIN.register { ctx ->
+            WorldRenderUtils.drawQueuedSeeThroughText(ctx.bufferSource())
+        }
+        *///?}
 
         ResourceLoader.get(PackType.CLIENT_RESOURCES).registerReloadListener(
             Identifier.fromNamespaceAndPath("skyhanni", "resources"),

--- a/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/ClientEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/ClientEvents.kt
@@ -35,7 +35,7 @@ import net.minecraft.server.packs.PackType
 import java.util.concurrent.CompletableFuture
 
 //? if < 26.2 {
-/*import at.hannibal2.skyhanni.utils.render.WorldRenderUtils
+/*import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEventLegacy
 *///?}
 
 @SkyHanniModule
@@ -74,7 +74,7 @@ object ClientEvents {
 
         //? if < 26.2 {
         /*LevelRenderEvents.AFTER_TRANSLUCENT_TERRAIN.register { ctx ->
-            WorldRenderUtils.drawQueuedSeeThroughText(ctx.bufferSource())
+            SkyHanniRenderWorldEventLegacy(ctx.bufferSource()).post()
         }
         *///?}
 

--- a/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/ClientEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/minecraftevents/ClientEvents.kt
@@ -59,14 +59,11 @@ object ClientEvents {
             WorldChangeEvent.post()
         }
 
-        //~ if < 26.2 'COLLECT_SUBMITS' -> 'AFTER_TRANSLUCENT_TERRAIN'
         LevelRenderEvents.COLLECT_SUBMITS.register { ctx ->
             SkyHanniRenderWorldEvent(
                 ctx.poseStack(),
                 ctx.levelState().cameraRenderState,
                 ctx.submitNodeCollector(),
-                //? if < 26.2
-                //ctx.bufferSource(),
                 Minecraft.getInstance().deltaTracker.getGameTimeDeltaPartialTick(true),
             ).post()
         }

--- a/src/main/java/at/hannibal2/skyhanni/events/minecraft/SkyHanniRenderWorldEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/minecraft/SkyHanniRenderWorldEvent.kt
@@ -6,6 +6,14 @@ import com.mojang.blaze3d.vertex.PoseStack
 import net.minecraft.client.renderer.SubmitNodeCollector
 import net.minecraft.client.renderer.state.level.CameraRenderState
 
+//? if < 26.2 {
+/*import net.minecraft.client.renderer.MultiBufferSource
+*///?}
+
+/**
+ * Posted at Fabric API's `LevelRenderEvents.COLLECT_SUBMITS`. This is the preferred render event.
+ * It provides callers with a [SubmitNodeCollector] that can be used to submit renderable elements.
+ */
 @PrimaryFunction("onRenderWorld")
 class SkyHanniRenderWorldEvent(
     val matrices: PoseStack,
@@ -15,3 +23,15 @@ class SkyHanniRenderWorldEvent(
 ) : SkyHanniEvent() {
     var isCurrentlyDeferring: Boolean = true
 }
+
+//? if < 26.2 {
+/*/**
+ * Posted at Fabric API's `LevelRenderEvents.AFTER_TRANSLUCENT_TERRAIN`. This should only be used
+ * in cases where the [SubmitNodeCollector]-based API does not provide the necessary functionality.
+ * It provides callers with a [MultiBufferSource.BufferSource] that can be used to render elements.
+ */
+@PrimaryFunction("onRenderWorldLegacy")
+class SkyHanniRenderWorldEventLegacy(
+    val bufferSource: MultiBufferSource.BufferSource,
+) : SkyHanniEvent()
+*///?}

--- a/src/main/java/at/hannibal2/skyhanni/events/minecraft/SkyHanniRenderWorldEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/minecraft/SkyHanniRenderWorldEvent.kt
@@ -6,17 +6,11 @@ import com.mojang.blaze3d.vertex.PoseStack
 import net.minecraft.client.renderer.SubmitNodeCollector
 import net.minecraft.client.renderer.state.level.CameraRenderState
 
-//? if < 26.2 {
-/*import net.minecraft.client.renderer.MultiBufferSource
-*///?}
-
 @PrimaryFunction("onRenderWorld")
 class SkyHanniRenderWorldEvent(
     val matrices: PoseStack,
     val camera: CameraRenderState,
     val submitNodeCollector: SubmitNodeCollector,
-    //? if < 26.2
-    //val bufferSource: MultiBufferSource.BufferSource,
     val partialTicks: Float,
 ) : SkyHanniEvent() {
     var isCurrentlyDeferring: Boolean = true

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinScreenEffectRenderer.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinScreenEffectRenderer.java
@@ -8,15 +8,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-//? if >= 26.2 {
-import net.minecraft.client.renderer.SubmitNodeCollector;
-//?} else {
-/*import net.minecraft.client.renderer.MultiBufferSource;
-*///?}
-
 @Mixin(ScreenEffectRenderer.class)
 public abstract class MixinScreenEffectRenderer {
-
     //~ if < 26.2 'submitFire' -> 'renderFire'
     @Inject(method = "submitFire", at = @At("HEAD"), cancellable = true)
     private static void renderFire(CallbackInfo ci) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/LineDrawer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/LineDrawer.kt
@@ -22,13 +22,16 @@ class LineDrawer @PublishedApi internal constructor(
         val layer = SkyHanniRenderLayers.getLines(!depth)
         val lines = queuedLines.toList()
         event.submitCustomGeometry(layer) { pose, buf ->
+            fun QueuedLine.addVertexForPoint(point: LorenzVec) {
+                buf.addVertex(pose.pose(), point.x.toFloat(), point.y.toFloat(), point.z.toFloat())
+                    .setNormal(pose, normal.x.toFloat(), normal.y.toFloat(), normal.z.toFloat())
+                    .setColor(color.red, color.green, color.blue, color.alpha)
+                    .setLineWidth(lineWidth.toFloat())
+            }
+
             for (line in lines) {
-                for (point in arrayOf(line.p1, line.p2)) {
-                    buf.addVertex(pose.pose(), point.x.toFloat(), point.y.toFloat(), point.z.toFloat())
-                        .setNormal(pose, line.normal.x.toFloat(), line.normal.y.toFloat(), line.normal.z.toFloat())
-                        .setColor(line.color.red, line.color.green, line.color.blue, line.color.alpha)
-                        .setLineWidth(lineWidth.toFloat())
-                }
+                line.addVertexForPoint(line.p1)
+                line.addVertexForPoint(line.p2)
             }
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/LineDrawer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/LineDrawer.kt
@@ -4,47 +4,33 @@ import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.utils.LocationUtils.calculateEdges
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.collection.CollectionUtils.zipWithNext3
+import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.submitCustomGeometry
 import net.minecraft.world.phys.AABB
 import java.awt.Color
 
-//? if >= 26.2 {
-import net.minecraft.client.renderer.gizmos.DrawableGizmoPrimitives
-//?} else {
-/*import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.submitCustomGeometry
-*///?}
-
-class LineDrawer @PublishedApi internal constructor(val event: SkyHanniRenderWorldEvent, val lineWidth: Int, val depth: Boolean) {
+class LineDrawer @PublishedApi internal constructor(
+    val event: SkyHanniRenderWorldEvent,
+    val lineWidth: Int,
+    val depth: Boolean,
+) {
     private val queuedLines = mutableListOf<QueuedLine>()
 
     @PublishedApi
     internal fun drawQueuedLines() {
         if (queuedLines.isEmpty()) return
 
-        //? if >= 26.2 {
-        val gizmos = DrawableGizmoPrimitives()
-        for (line in queuedLines) {
-            gizmos.addLine(line.p1.toVec3(), line.p2.toVec3(), line.color.rgb, lineWidth.toFloat())
-        }
-        gizmos.submit(event.submitNodeCollector, event.camera, !depth)
-        //?} else {
-        /*val layer = SkyHanniRenderLayers.getLines(!depth)
-        event.submitCustomGeometry(layer) { buf ->
-            val matrix = event.matrices.last()
-
-            // TODO reshape to avoid code duplication
-            for (line in queuedLines) {
-                buf.addVertex(matrix.pose(), line.p1.x.toFloat(), line.p1.y.toFloat(), line.p1.z.toFloat())
-                    .setNormal(matrix, line.normal.x.toFloat(), line.normal.y.toFloat(), line.normal.z.toFloat())
-                    .setColor(line.color.red, line.color.green, line.color.blue, line.color.alpha)
-                    .setLineWidth(lineWidth.toFloat())
-
-                buf.addVertex(matrix.pose(), line.p2.x.toFloat(), line.p2.y.toFloat(), line.p2.z.toFloat())
-                    .setNormal(matrix, line.normal.x.toFloat(), line.normal.y.toFloat(), line.normal.z.toFloat())
-                    .setColor(line.color.red, line.color.green, line.color.blue, line.color.alpha)
-                    .setLineWidth(lineWidth.toFloat())
+        val layer = SkyHanniRenderLayers.getLines(!depth)
+        val lines = queuedLines.toList()
+        event.submitCustomGeometry(layer) { pose, buf ->
+            for (line in lines) {
+                for (point in arrayOf(line.p1, line.p2)) {
+                    buf.addVertex(pose.pose(), point.x.toFloat(), point.y.toFloat(), point.z.toFloat())
+                        .setNormal(pose, line.normal.x.toFloat(), line.normal.y.toFloat(), line.normal.z.toFloat())
+                        .setColor(line.color.red, line.color.green, line.color.blue, line.color.alpha)
+                        .setLineWidth(lineWidth.toFloat())
+                }
             }
         }
-        *///?}
 
         queuedLines.clear()
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.utils.render
 import at.hannibal2.skyhanni.data.mob.Mob
 import at.hannibal2.skyhanni.data.model.graph.Graph
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ColorUtils.addAlpha
 import at.hannibal2.skyhanni.utils.ColorUtils.getFirstColorCode
 import at.hannibal2.skyhanni.utils.ColorUtils.rgb
@@ -47,9 +48,11 @@ import kotlin.math.sqrt
 import net.fabricmc.fabric.api.client.rendering.v1.SubmitRenderPhases
 import net.minecraft.client.renderer.feature.TextFeatureRenderer
 //?} else {
-/*import net.minecraft.client.renderer.MultiBufferSource
+/*import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEventLegacy
 *///?}
 
+@SkyHanniModule
 @Suppress("LargeClass")
 object WorldRenderUtils {
     private val beaconBeam = createResourceLocation("textures/entity/beacon/beacon_beam.png")
@@ -123,7 +126,8 @@ object WorldRenderUtils {
     )
 
     // See the MC-298659 note in submitOrderedText.
-    fun drawQueuedSeeThroughText(bufferSource: MultiBufferSource.BufferSource) {
+    @HandleEvent
+    private fun onRenderWorldLegacy(event: SkyHanniRenderWorldEventLegacy) {
         if (queuedSeeThroughText.isEmpty()) return
         val fr = Minecraft.getInstance().font
         for (entry in queuedSeeThroughText) {
@@ -134,7 +138,7 @@ object WorldRenderUtils {
                 entry.color,
                 entry.shadow,
                 entry.pose,
-                bufferSource,
+                event.bufferSource,
                 DisplayMode.SEE_THROUGH,
                 entry.backgroundColor,
                 entry.light,

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
@@ -112,7 +112,7 @@ object WorldRenderUtils {
     //? if < 26.2 {
     /*private val queuedSeeThroughText = mutableListOf<SeeThroughText>()
 
-    private class SeeThroughText(
+    private data class SeeThroughText(
         val pose: Matrix4f,
         val x: Float,
         val y: Float,

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
@@ -71,7 +71,6 @@ object WorldRenderUtils {
         if (displayMode == SEE_THROUGH) {
             // MC-298659: the vanilla text phase renders before translucent terrain, letting water
             // draw over see-through text. Render only our own text after translucent terrain instead.
-            // This also makes it render after our custom geometry, so order(1) is not needed here.
             //? if >= 26.2 {
             submitNodeCollector.submitCustom(
                 SubmitRenderPhases.AFTER_TERRAIN,
@@ -96,8 +95,7 @@ object WorldRenderUtils {
             return
         }
 
-        // The order ensures the text renders over our custom geometry.
-        submitNodeCollector.order(1).submitText(
+        submitNodeCollector.submitText(
             matrices,
             x,
             y,
@@ -303,11 +301,9 @@ object WorldRenderUtils {
         }
 
         val layer = SkyHanniRenderLayers.getFilled(throughWalls = seeThroughBlocks)
-        submitCustomGeometry(layer) { buf ->
-            matrices.pushPose()
-
+        submitCustomGeometry(layer) { pose, buf ->
             addChainedFilledBoxVertices(
-                matrices,
+                pose,
                 buf,
                 effectiveAABB.minX, effectiveAABB.minY, effectiveAABB.minZ,
                 effectiveAABB.maxX, effectiveAABB.maxY, effectiveAABB.maxZ,
@@ -316,7 +312,6 @@ object WorldRenderUtils {
                 c.blue / 255f * 0.9f,
                 c.alpha / 255f * alphaMultiplier,
             )
-            matrices.popPose()
         }
     }
 
@@ -994,7 +989,7 @@ object WorldRenderUtils {
         exactLocation(player).up(player.getEyeHeight(player.pose))
 
     private fun addChainedFilledBoxVertices(
-        matrices: PoseStack,
+        matrix4f: PoseStack.Pose,
         vertexConsumer: VertexConsumer,
         d: Double,
         e: Double,
@@ -1007,7 +1002,7 @@ object WorldRenderUtils {
         l: Float,
         m: Float,
     ) = addChainedFilledBoxVertices(
-        matrices,
+        matrix4f,
         vertexConsumer,
         d.toFloat(),
         e.toFloat(),
@@ -1022,7 +1017,7 @@ object WorldRenderUtils {
     )
 
     private fun addChainedFilledBoxVertices(
-        matrices: PoseStack,
+        matrix4f: PoseStack.Pose,
         vertexConsumer: VertexConsumer,
         f: Float,
         g: Float,
@@ -1035,7 +1030,6 @@ object WorldRenderUtils {
         n: Float,
         o: Float,
     ) {
-        val matrix4f = matrices.last().pose()
         vertexConsumer.addVertex(matrix4f, f, g, h).setColor(l, m, n, o)
         vertexConsumer.addVertex(matrix4f, f, g, h).setColor(l, m, n, o)
         vertexConsumer.addVertex(matrix4f, f, g, h).setColor(l, m, n, o)

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
@@ -66,7 +66,6 @@ object WorldRenderUtils {
         light: Int,
         color: Int,
         backgroundColor: Int,
-        outlineColor: Int,
     ) {
         if (displayMode == SEE_THROUGH) {
             // MC-298659: the vanilla text phase renders before translucent terrain, letting water
@@ -84,7 +83,7 @@ object WorldRenderUtils {
                     light,
                     color,
                     backgroundColor,
-                    outlineColor,
+                    0,
                 ),
             )
             //?} else {
@@ -105,7 +104,7 @@ object WorldRenderUtils {
             light,
             color,
             backgroundColor,
-            outlineColor,
+            0,
         )
     }
 
@@ -381,7 +380,6 @@ object WorldRenderUtils {
             FULL_BRIGHT,
             color?.rgb ?: LorenzColor.WHITE.toColor().rgb,
             backgroundColor,
-            0,
         )
         matrices.popPose()
     }

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
@@ -31,6 +31,7 @@ import net.minecraft.client.renderer.blockentity.BeaconRenderer
 import net.minecraft.client.renderer.rendertype.RenderType
 import net.minecraft.core.Direction
 import net.minecraft.network.chat.Component
+import net.minecraft.util.FormattedCharSequence
 import net.minecraft.util.LightCoordsUtil.FULL_BRIGHT
 import net.minecraft.world.entity.Entity
 import net.minecraft.world.level.material.FogType
@@ -41,18 +42,10 @@ import kotlin.math.cos
 import kotlin.math.sin
 import kotlin.math.sqrt
 
-//? if >= 26.2 {
-import net.minecraft.util.FormattedCharSequence
-//?} else {
-/*import net.minecraft.client.renderer.MultiBufferSource
-import org.joml.Matrix4f
-*///?}
-
 @Suppress("LargeClass")
 object WorldRenderUtils {
     private val beaconBeam = createResourceLocation("textures/entity/beacon/beacon_beam.png")
 
-    //? if >= 26.2 {
     private fun SkyHanniRenderWorldEvent.submitOrderedText(
         x: Float,
         y: Float,
@@ -64,7 +57,7 @@ object WorldRenderUtils {
         backgroundColor: Int,
         outlineColor: Int,
     ) {
-        // The order ensures see-through text renders over our custom geometry, like on 26.1.
+        // The order ensures see-through text renders over our custom geometry.
         submitNodeCollector.order(1).submitText(
             matrices,
             x,
@@ -78,18 +71,18 @@ object WorldRenderUtils {
             outlineColor,
         )
     }
-    //?}
 
     inline fun SkyHanniRenderWorldEvent.submitCustomGeometry(
         layer: RenderType,
         crossinline render: (VertexConsumer) -> Unit,
-    ) {
-        //? if >= 26.2 {
-        submitNodeCollector.submitCustomGeometry(matrices, layer) { _, buffer -> render(buffer) }
-        //?} else {
-        /*render(bufferSource.getBuffer(layer))
-        *///?}
-    }
+    ) = submitCustomGeometry(layer) { _, buf -> render(buf) }
+
+    // The render callback runs deferred, after the current pose is popped again.
+    // Anything needing the submit-time pose must use the callback's pose copy.
+    inline fun SkyHanniRenderWorldEvent.submitCustomGeometry(
+        layer: RenderType,
+        crossinline render: (PoseStack.Pose, VertexConsumer) -> Unit,
+    ) = submitNodeCollector.submitCustomGeometry(matrices, layer) { pose, buf -> render(pose, buf) }
 
     fun SkyHanniRenderWorldEvent.renderBeaconBeam(vec: LorenzVec, rgb: Int) {
         this.renderBeaconBeam(vec.x, vec.y, vec.z, rgb)
@@ -296,7 +289,6 @@ object WorldRenderUtils {
         val adjustedScale = (scale * 0.05).toFloat()
         val x = -fr.width(text) / 2f
 
-        //? if >= 26.2 {
         matrices.pushPose()
         matrices.translate(
             (location.x - cameraPos.x()).toFloat(),
@@ -318,29 +310,6 @@ object WorldRenderUtils {
             0,
         )
         matrices.popPose()
-        //?} else {
-        /*val matrix = Matrix4f()
-        matrix.translate(
-            (location.x - cameraPos.x()).toFloat(),
-            (location.y - cameraPos.y()).toFloat(),
-            (location.z - cameraPos.z()).toFloat(),
-        ).rotate(camera.rotation())
-            .translate(0f, -yOffset * adjustedScale, 0f)
-            .scale(adjustedScale, -adjustedScale, adjustedScale)
-
-        fr.drawInBatch(
-            text,
-            x,
-            0f,
-            color?.rgb ?: LorenzColor.WHITE.toColor().rgb,
-            shadow,
-            matrix,
-            bufferSource,
-            if (seeThroughBlocks) SEE_THROUGH else POLYGON_OFFSET,
-            backgroundColor,
-            FULL_BRIGHT,
-        )
-        *///?}
     }
 
     fun SkyHanniRenderWorldEvent.drawCircleWireframe(entity: Entity, rad: Double, color: Color) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
@@ -129,22 +129,25 @@ object WorldRenderUtils {
     @HandleEvent
     private fun onRenderWorldLegacy(event: SkyHanniRenderWorldEventLegacy) {
         if (queuedSeeThroughText.isEmpty()) return
-        val fr = Minecraft.getInstance().font
-        for (entry in queuedSeeThroughText) {
-            fr.drawInBatch(
-                entry.text,
-                entry.x,
-                entry.y,
-                entry.color,
-                entry.shadow,
-                entry.pose,
-                event.bufferSource,
-                DisplayMode.SEE_THROUGH,
-                entry.backgroundColor,
-                entry.light,
-            )
+        try {
+            val fr = Minecraft.getInstance().font
+            for (entry in queuedSeeThroughText) {
+                fr.drawInBatch(
+                    entry.text,
+                    entry.x,
+                    entry.y,
+                    entry.color,
+                    entry.shadow,
+                    entry.pose,
+                    event.bufferSource,
+                    DisplayMode.SEE_THROUGH,
+                    entry.backgroundColor,
+                    entry.light,
+                )
+            }
+        } finally {
+            queuedSeeThroughText.clear()
         }
-        queuedSeeThroughText.clear()
     }
     *///?}
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
@@ -986,78 +986,96 @@ object WorldRenderUtils {
     fun SkyHanniRenderWorldEvent.exactPlayerEyeLocation(player: Entity): LorenzVec =
         exactLocation(player).up(player.getEyeHeight(player.pose))
 
+    /**
+     * Convenience overload for [addChainedFilledBoxVertices] that takes Double arguments,
+     * which AABB bounds are, and converts them to Float ahead of time.
+     */
     private fun addChainedFilledBoxVertices(
-        matrix4f: PoseStack.Pose,
+        pose: PoseStack.Pose,
         vertexConsumer: VertexConsumer,
-        d: Double,
-        e: Double,
-        f: Double,
-        g: Double,
-        h: Double,
-        i: Double,
-        j: Float,
-        k: Float,
-        l: Float,
-        m: Float,
+        minX: Double,
+        minY: Double,
+        minZ: Double,
+        maxX: Double,
+        maxY: Double,
+        maxZ: Double,
+        r: Float,
+        g: Float,
+        b: Float,
+        a: Float,
     ) = addChainedFilledBoxVertices(
-        matrix4f,
+        pose,
         vertexConsumer,
-        d.toFloat(),
-        e.toFloat(),
-        f.toFloat(),
-        g.toFloat(),
-        h.toFloat(),
-        i.toFloat(),
-        j,
-        k,
-        l,
-        m,
+        minX.toFloat(),
+        minY.toFloat(),
+        minZ.toFloat(),
+        maxX.toFloat(),
+        maxY.toFloat(),
+        maxZ.toFloat(),
+        r,
+        g,
+        b,
+        a,
     )
 
+    /**
+     * Adds the vertices for a filled axis-aligned box as a single chained triangle strip.
+     *
+     * Some vertices are intentionally duplicated to insert degenerate triangles between
+     * faces, allowing the entire box to be rendered as one continuous strip without
+     * producing visible geometry between otherwise disconnected faces.
+     */
     private fun addChainedFilledBoxVertices(
-        matrix4f: PoseStack.Pose,
+        pose: PoseStack.Pose,
         vertexConsumer: VertexConsumer,
-        f: Float,
+        minX: Float,
+        minY: Float,
+        minZ: Float,
+        maxX: Float,
+        maxY: Float,
+        maxZ: Float,
+        r: Float,
         g: Float,
-        h: Float,
-        i: Float,
-        j: Float,
-        k: Float,
-        l: Float,
-        m: Float,
-        n: Float,
-        o: Float,
+        b: Float,
+        a: Float,
     ) {
-        vertexConsumer.addVertex(matrix4f, f, g, h).setColor(l, m, n, o)
-        vertexConsumer.addVertex(matrix4f, f, g, h).setColor(l, m, n, o)
-        vertexConsumer.addVertex(matrix4f, f, g, h).setColor(l, m, n, o)
-        vertexConsumer.addVertex(matrix4f, f, g, k).setColor(l, m, n, o)
-        vertexConsumer.addVertex(matrix4f, f, j, h).setColor(l, m, n, o)
-        vertexConsumer.addVertex(matrix4f, f, j, k).setColor(l, m, n, o)
-        vertexConsumer.addVertex(matrix4f, f, j, k).setColor(l, m, n, o)
-        vertexConsumer.addVertex(matrix4f, f, g, k).setColor(l, m, n, o)
-        vertexConsumer.addVertex(matrix4f, i, j, k).setColor(l, m, n, o)
-        vertexConsumer.addVertex(matrix4f, i, g, k).setColor(l, m, n, o)
-        vertexConsumer.addVertex(matrix4f, i, g, k).setColor(l, m, n, o)
-        vertexConsumer.addVertex(matrix4f, i, g, h).setColor(l, m, n, o)
-        vertexConsumer.addVertex(matrix4f, i, j, k).setColor(l, m, n, o)
-        vertexConsumer.addVertex(matrix4f, i, j, h).setColor(l, m, n, o)
-        vertexConsumer.addVertex(matrix4f, i, j, h).setColor(l, m, n, o)
-        vertexConsumer.addVertex(matrix4f, i, g, h).setColor(l, m, n, o)
-        vertexConsumer.addVertex(matrix4f, f, j, h).setColor(l, m, n, o)
-        vertexConsumer.addVertex(matrix4f, f, g, h).setColor(l, m, n, o)
-        vertexConsumer.addVertex(matrix4f, f, g, h).setColor(l, m, n, o)
-        vertexConsumer.addVertex(matrix4f, i, g, h).setColor(l, m, n, o)
-        vertexConsumer.addVertex(matrix4f, f, g, k).setColor(l, m, n, o)
-        vertexConsumer.addVertex(matrix4f, i, g, k).setColor(l, m, n, o)
-        vertexConsumer.addVertex(matrix4f, i, g, k).setColor(l, m, n, o)
-        vertexConsumer.addVertex(matrix4f, f, j, h).setColor(l, m, n, o)
-        vertexConsumer.addVertex(matrix4f, f, j, h).setColor(l, m, n, o)
-        vertexConsumer.addVertex(matrix4f, f, j, k).setColor(l, m, n, o)
-        vertexConsumer.addVertex(matrix4f, i, j, h).setColor(l, m, n, o)
-        vertexConsumer.addVertex(matrix4f, i, j, k).setColor(l, m, n, o)
-        vertexConsumer.addVertex(matrix4f, i, j, k).setColor(l, m, n, o)
-        vertexConsumer.addVertex(matrix4f, i, j, k).setColor(l, m, n, o)
+        fun vertex(x: Float, y: Float, z: Float) {
+            vertexConsumer.addVertex(pose, x, y, z).setColor(r, g, b, a)
+        }
+
+        vertex(minX, minY, minZ)
+        vertex(minX, minY, minZ)
+        vertex(minX, minY, minZ)
+        vertex(minX, minY, maxZ)
+        vertex(minX, maxY, minZ)
+        vertex(minX, maxY, maxZ)
+        vertex(minX, maxY, maxZ)
+        vertex(minX, minY, maxZ)
+
+        vertex(maxX, maxY, maxZ)
+        vertex(maxX, minY, maxZ)
+        vertex(maxX, minY, maxZ)
+        vertex(maxX, minY, minZ)
+        vertex(maxX, maxY, maxZ)
+        vertex(maxX, maxY, minZ)
+        vertex(maxX, maxY, minZ)
+        vertex(maxX, minY, minZ)
+
+        vertex(minX, maxY, minZ)
+        vertex(minX, minY, minZ)
+        vertex(minX, minY, minZ)
+        vertex(maxX, minY, minZ)
+        vertex(minX, minY, maxZ)
+        vertex(maxX, minY, maxZ)
+        vertex(maxX, minY, maxZ)
+
+        vertex(minX, maxY, minZ)
+        vertex(minX, maxY, minZ)
+        vertex(minX, maxY, maxZ)
+        vertex(maxX, maxY, minZ)
+        vertex(maxX, maxY, maxZ)
+        vertex(maxX, maxY, maxZ)
+        vertex(maxX, maxY, maxZ)
     }
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
@@ -36,11 +36,19 @@ import net.minecraft.util.LightCoordsUtil.FULL_BRIGHT
 import net.minecraft.world.entity.Entity
 import net.minecraft.world.level.material.FogType
 import net.minecraft.world.phys.AABB
+import org.joml.Matrix4f
 import org.joml.Vector3f
 import java.awt.Color
 import kotlin.math.cos
 import kotlin.math.sin
 import kotlin.math.sqrt
+
+//? if >= 26.2 {
+import net.fabricmc.fabric.api.client.rendering.v1.SubmitRenderPhases
+import net.minecraft.client.renderer.feature.TextFeatureRenderer
+//?} else {
+/*import net.minecraft.client.renderer.MultiBufferSource
+*///?}
 
 @Suppress("LargeClass")
 object WorldRenderUtils {
@@ -57,7 +65,35 @@ object WorldRenderUtils {
         backgroundColor: Int,
         outlineColor: Int,
     ) {
-        // The order ensures see-through text renders over our custom geometry.
+        if (displayMode == SEE_THROUGH) {
+            // MC-298659: the vanilla text phase renders before translucent terrain, letting water
+            // draw over see-through text. Render only our own text after translucent terrain instead.
+            // This also makes it render after our custom geometry, so order(1) is not needed here.
+            //? if >= 26.2 {
+            submitNodeCollector.submitCustom(
+                SubmitRenderPhases.AFTER_TERRAIN,
+                TextFeatureRenderer.Submit(
+                    Matrix4f(matrices.last().pose()),
+                    x,
+                    y,
+                    text,
+                    shadow,
+                    SEE_THROUGH,
+                    light,
+                    color,
+                    backgroundColor,
+                    outlineColor,
+                ),
+            )
+            //?} else {
+            /*queuedSeeThroughText.add(
+                SeeThroughText(Matrix4f(matrices.last().pose()), x, y, text, shadow, light, color, backgroundColor),
+            )
+            *///?}
+            return
+        }
+
+        // The order ensures the text renders over our custom geometry.
         submitNodeCollector.order(1).submitText(
             matrices,
             x,
@@ -71,6 +107,42 @@ object WorldRenderUtils {
             outlineColor,
         )
     }
+
+    //? if < 26.2 {
+    /*private val queuedSeeThroughText = mutableListOf<SeeThroughText>()
+
+    private class SeeThroughText(
+        val pose: Matrix4f,
+        val x: Float,
+        val y: Float,
+        val text: FormattedCharSequence,
+        val shadow: Boolean,
+        val light: Int,
+        val color: Int,
+        val backgroundColor: Int,
+    )
+
+    // See the MC-298659 note in submitOrderedText.
+    fun drawQueuedSeeThroughText(bufferSource: MultiBufferSource.BufferSource) {
+        if (queuedSeeThroughText.isEmpty()) return
+        val fr = Minecraft.getInstance().font
+        for (entry in queuedSeeThroughText) {
+            fr.drawInBatch(
+                entry.text,
+                entry.x,
+                entry.y,
+                entry.color,
+                entry.shadow,
+                entry.pose,
+                bufferSource,
+                DisplayMode.SEE_THROUGH,
+                entry.backgroundColor,
+                entry.light,
+            )
+        }
+        queuedSeeThroughText.clear()
+    }
+    *///?}
 
     inline fun SkyHanniRenderWorldEvent.submitCustomGeometry(
         layer: RenderType,


### PR DESCRIPTION
## What
On 26.1, SkyHanni currently uses a mix of `MultiBufferSource` and `SubmitNodeCollector`-based rendering for `SkyHanniRenderWorldEvent`, but unconditionally submits at `AFTER_TRANSLUCENT_TERRAIN` – which, while not known to cause any practical issues today, is technically incorrect.

I took the opportunity to migrate all users of `SkyHanniRenderWorldEvent` to `COLLECT_SUBMITS` / `SubmitNodeCollector`-based rendering.

Some things like the picture-in-picture renderer still use `MultiBufferSource` on 26.1 because that's the only API vanilla exposes for it there.

Also, there's a vanilla bug [MC-298659](https://mojira.dev/MC-298659) with the submit-based text path (fixed in 26.3) that makes certain things such as water render over it. SkyHanni's 26.2 rendering already suffers from this bug today, and changing 26.1 to submit-based rendering would have introduced the bug there as well – so I made sure it doesn't happen on 26.1 while also fixing the bug on 26.2 along the way, but it needed two different ways to fix it:
* On 26.2, we use Fabric's new `SubmitRenderPhases` API to submit it in the `AFTER_TERRAIN` phase.
* On 26.1, we defer rendering to the old `MultiBufferSource`-based `LevelRenderEvents.AFTER_TRANSLUCENT_TERRAIN` because `SubmitRenderPhases` does not exist. This is essentially the same as today, just with correct injection points (no known user-facing issues this fixes today, but potentially prevents further issues in the future).

This refactor also happened to fix a rendering bug on 26.1 where lines such as the pathfinding line would just cut off whenever they pass a water boundary.

## Changelog Fixes
+ Fixed pathfinding lines cutting off when touching water on Minecraft 26.1. - Luna
+ Fixed text shown by SkyHanni in the world being dimmed by water and stained glass on Minecraft 26.2. - Luna
    * Example: Fishing and Lily Pad Minion name tags, depending on placement.

## Changelog Technical Details
+ Changed SkyHanniRenderWorldEvent to fire on COLLECT_SUBMITS instead of AFTER_TRANSLUCENT_TERRAIN on Minecraft 26.1, and changed the remaining MultiBufferSource-based rendering in this event to be SubmitNodeCollector-based. - Luna
+ Unified LineDrawer to use vertex-based rendering on all versions. - Luna
+ Made submitOrderedText defer rendering to after terrain to work around MC-298659. - Luna
+ Fixed drawFilledBoundingBox using the wrong PoseStack, making custom ordering for text submissions no longer necessary. - Luna