### PR TITLE
Feature: Beach Ball & Fishy Treats Tracker

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/BeachBallTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/BeachBallTrackerConfig.kt
@@ -23,7 +23,7 @@ class BeachBallTrackerConfig {
     @Expose
     @ConfigOption(
         name = "Hide After Inactivity",
-        desc = "Hide the tracker after this many minutes without bouncing a ball.",
+        desc = "Hide the tracker after this many minutes without using a ball.",
     )
     @ConfigEditorSlider(minValue = 1.0f, maxValue = 30.0f, minStep = 1.0f)
     @SearchTag("beach")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/BeachBallTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/BeachBallTrackerConfig.kt
@@ -1,0 +1,40 @@
+package at.hannibal2.skyhanni.config.features.event
+
+import at.hannibal2.skyhanni.config.FeatureToggle
+import at.hannibal2.skyhanni.config.core.config.Position
+import at.hannibal2.skyhanni.config.features.misc.tracker.individual.IndividualTrackerConfig
+import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.annotations.Accordion
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider
+import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+import io.github.notenoughupdates.moulconfig.annotations.SearchTag
+
+class BeachBallTrackerConfig {
+
+    @Expose
+    @ConfigOption(name = "Enabled", desc = "Track the §bBeach Balls §7you use and §dFishy Treats §7you earn.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    @SearchTag("beach")
+    var enabled: Boolean = true
+
+    @Expose
+    @ConfigOption(
+        name = "Hide After Inactivity",
+        desc = "Hide the tracker after this many minutes without bouncing a ball.",
+    )
+    @ConfigEditorSlider(minValue = 1.0f, maxValue = 30.0f, minStep = 1.0f)
+    @SearchTag("beach")
+    var hideAfterInactivity: Int = 5
+
+    @Expose
+    @ConfigOption(name = "Tracker Settings", desc = "")
+    @Accordion
+    val perTrackerConfig: IndividualTrackerConfig = IndividualTrackerConfig()
+
+    @Expose
+    @ConfigLink(owner = BeachBallTrackerConfig::class, field = "enabled")
+    val position: Position = Position(170, 170)
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/YearOfTheSealConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/YearOfTheSealConfig.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.config.FeatureToggle
 import at.hannibal2.skyhanni.config.core.config.Position
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.ChromaColour
+import io.github.notenoughupdates.moulconfig.annotations.Accordion
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorColour
 import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
@@ -43,4 +44,9 @@ class YearOfTheSealConfig {
     @ConfigEditorBoolean
     @SearchTag("beach")
     val bouncyBallLandingSpot: Property<Boolean> = Property.of(true)
+
+    @Expose
+    @Accordion
+    @ConfigOption(name = "Beach Ball Tracker", desc = "")
+    val beachBallTracker = BeachBallTrackerConfig()
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.kt
@@ -25,6 +25,7 @@ import at.hannibal2.skyhanni.features.event.hoppity.HoppityCollectionStats.Locat
 import at.hannibal2.skyhanni.features.event.hoppity.HoppityEggType
 import at.hannibal2.skyhanni.features.event.jerry.frozentreasure.FrozenTreasureTracker
 import at.hannibal2.skyhanni.features.event.yearofthepig.ShinyOrbTracker
+import at.hannibal2.skyhanni.features.event.yearoftheseal.BeachBallTracker
 import at.hannibal2.skyhanni.features.fame.UpgradeReminder.CommunityShopUpgrade
 import at.hannibal2.skyhanni.features.fishing.tracker.FishingProfitTracker
 import at.hannibal2.skyhanni.features.fishing.tracker.SeaCreatureTracker
@@ -230,6 +231,9 @@ class ProfileSpecificStorage(
     // -- year of the [___]
     @Expose
     var shinyOrbTracker: ShinyOrbTracker.ShinyOrbData = ShinyOrbTracker.ShinyOrbData()
+
+    @Expose
+    var beachBallTracker: BeachBallTracker.Data = BeachBallTracker.Data()
 
     // -- hoppity
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/features/event/yearoftheseal/BeachBallCatchHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/yearoftheseal/BeachBallCatchHelper.kt
@@ -43,7 +43,6 @@ object BeachBallCatchHelper {
     fun check(entity: ArmorStand) {
         if (entity.wearingSkullTexture(NORMAL_BEACH_BALL)) {
             predictors.putIfAbsent(entity.id, Predictor(entity.getLorenzVec(), Variant.NORMAL))
-            println("normal detected")
             return
         }
 //         if (entity.wearingSkullTexture(GIANT_BEACH_BALL)) {

--- a/src/main/java/at/hannibal2/skyhanni/features/event/yearoftheseal/BeachBallTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/yearoftheseal/BeachBallTracker.kt
@@ -40,7 +40,7 @@ import kotlin.time.Duration.Companion.seconds
 @SkyHanniModule
 object BeachBallTracker {
 
-    private val config get() = SkyHanniMod.feature.event.yearOfTheSeal
+    private val config get() = SkyHanniMod.feature.event.yearOfTheSeal.beachBallTracker
 
     private val FISHY_TREAT = "FISHY_TREAT".toInternalName()
     private val ENCHANTED_RAW_FISH = "ENCHANTED_RAW_FISH".toInternalName()
@@ -79,7 +79,7 @@ object BeachBallTracker {
         "Beach Ball Tracker",
         ::Data,
         { it.beachBallTracker },
-        trackerConfig = { config.beachBallTracker.perTrackerConfig },
+        trackerConfig = { config.perTrackerConfig },
     ) {
         drawDisplay(it)
     }
@@ -94,17 +94,17 @@ object BeachBallTracker {
     enum class BallType(
         val label: String,
         val item: NeuInternalName,
-        val resultPattern: Pattern,
+        val resultPattern: () -> Pattern,
     ) {
-        NORMAL("Beach Balls", "BOUNCY_BEACH_BALL".toInternalName(), normalResultPattern),
-        GIANT("Giant Beach Balls", "GIANT_BOUNCY_BEACH_BALL".toInternalName(), giantResultPattern),
+        NORMAL("Beach Balls", "BOUNCY_BEACH_BALL".toInternalName(), { normalResultPattern }),
+        GIANT("Giant Beach Balls", "GIANT_BOUNCY_BEACH_BALL".toInternalName(), { giantResultPattern }),
     }
 
     private val ballItems = BallType.entries.map { it.item }.toSet()
 
     @HandleEvent(onlyOnIsland = IslandType.HUB)
     private fun onChat(event: SkyHanniChatEvent.Allow) {
-        if (!config.beachBallTracker.enabled) return
+        if (!config.enabled) return
         val message = event.cleanMessage
 
         // A ball was just thrown: show the overlay immediately (before any result comes in).
@@ -114,7 +114,7 @@ object BeachBallTracker {
         }
 
         for (type in BallType.entries) {
-            type.resultPattern.matchMatcher(message) {
+            type.resultPattern().matchMatcher(message) {
                 val treats = group("treats").formatInt()
                 markActivity()
                 tracker.modify {
@@ -175,14 +175,14 @@ object BeachBallTracker {
             condition = { shouldShowDisplay() },
             onRender = {
                 if (isHoldingBeachBall()) tracker.firstUpdate()
-                tracker.renderDisplay(config.beachBallTracker.position)
+                tracker.renderDisplay(config.position)
             },
         )
     }
 
     private fun shouldShowDisplay(): Boolean {
-        if (!config.beachBallTracker.enabled) return false
-        val recentlyActive = lastBallActivity.passedSince() < config.beachBallTracker.hideAfterInactivity.minutes
+        if (!config.enabled) return false
+        val recentlyActive = lastBallActivity.passedSince() < config.hideAfterInactivity.minutes
         return recentlyActive || isHoldingBeachBall()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/yearoftheseal/BeachBallTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/yearoftheseal/BeachBallTracker.kt
@@ -1,0 +1,202 @@
+package at.hannibal2.skyhanni.features.event.yearoftheseal
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.commands.CommandCategory
+import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
+import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.InventoryUtils
+import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
+import at.hannibal2.skyhanni.utils.NeuInternalName
+import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
+import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
+import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
+import at.hannibal2.skyhanni.utils.NumberUtil.roundTo
+import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.RenderDisplayHelper
+import at.hannibal2.skyhanni.utils.RenderUtils
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut
+import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addSearchString
+import at.hannibal2.skyhanni.utils.inPartialHours
+import at.hannibal2.skyhanni.utils.renderables.Renderable
+import at.hannibal2.skyhanni.utils.renderables.Searchable
+import at.hannibal2.skyhanni.utils.renderables.container.HorizontalContainerRenderable.Companion.horizontal
+import at.hannibal2.skyhanni.utils.renderables.primitives.ItemStackRenderable.Companion.item
+import at.hannibal2.skyhanni.utils.renderables.primitives.text
+import at.hannibal2.skyhanni.utils.renderables.toSearchable
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import at.hannibal2.skyhanni.utils.tracker.SessionUptime
+import at.hannibal2.skyhanni.utils.tracker.SkyHanniTracker
+import at.hannibal2.skyhanni.utils.tracker.TrackerData
+import com.google.gson.annotations.Expose
+import java.util.regex.Pattern
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+@SkyHanniModule
+object BeachBallTracker {
+
+    private val config get() = SkyHanniMod.feature.event.yearOfTheSeal
+
+    private val FISHY_TREAT = "FISHY_TREAT".toInternalName()
+    private val ENCHANTED_RAW_FISH = "ENCHANTED_RAW_FISH".toInternalName()
+    private val WATCH = "WATCH".toInternalName()
+
+    private val patternGroup = RepoPattern.group("event.year-of-the-seal.beach-ball-tracker")
+
+    /**
+     * REGEX-TEST: AW MAN! You kept the Bouncy Beach Ball in the air for 0 bounces and earned 1 Fishy Treat!
+     * REGEX-TEST: INSANE! You kept the Bouncy Beach Ball in the air for 187 bounces and earned 20 Fishy Treats!
+     */
+    private val normalResultPattern by patternGroup.pattern(
+        "result.normal",
+        ".*You kept the Bouncy Beach Ball in the air for \\d+ bounces and earned (?<treats>\\d+) Fishy Treat.*",
+    )
+
+    /**
+     * REGEX-TEST: AW MAN! The Giant Bouncy Beach Ball was kept in the air for 0 bounces and 0 unique players have participated, rewarding you with 5 extra Fishy Treats!
+     */
+    private val giantResultPattern by patternGroup.pattern(
+        "result.giant",
+        ".*The Giant Bouncy Beach Ball was kept in the air for \\d+ bounces and " +
+            "\\d+ unique players have participated, rewarding you with (?<treats>\\d+) extra Fishy Treats.*",
+    )
+
+    /**
+     * REGEX-TEST: BOUNCE BONANZA! Keep the Bouncy Beach Ball in the air for as long as you can by bouncing it on your head!
+     * REGEX-TEST: BOUNCE BONANZA EX! Keep the Giant Bouncy Beach Ball in the air for 60 seconds by bouncing it on your and other players heads!
+     */
+    private val startPattern by patternGroup.pattern(
+        "start",
+        ".*BOUNCE BONANZA(?: EX)?! Keep the (?:Giant )?Bouncy Beach Ball in the air .*",
+    )
+
+    private val tracker = SkyHanniTracker(
+        "Beach Ball Tracker",
+        ::Data,
+        { it.beachBallTracker },
+        trackerConfig = { config.beachBallTracker.perTrackerConfig },
+    ) {
+        drawDisplay(it)
+    }
+
+    private var lastBallActivity = SimpleTimeMark.farPast()
+
+    data class Data(
+        @Expose var ballsUsed: MutableMap<BallType, Int> = mutableMapOf(),
+        @Expose var fishyTreats: Long = 0L,
+    ) : TrackerData<SessionUptime.Normal>(SessionUptime.Normal::class)
+
+    enum class BallType(
+        val label: String,
+        val item: NeuInternalName,
+        val resultPattern: Pattern,
+    ) {
+        NORMAL("Beach Balls", "BOUNCY_BEACH_BALL".toInternalName(), normalResultPattern),
+        GIANT("Giant Beach Balls", "GIANT_BOUNCY_BEACH_BALL".toInternalName(), giantResultPattern),
+    }
+
+    private val ballItems = BallType.entries.map { it.item }.toSet()
+
+    @HandleEvent(onlyOnIsland = IslandType.HUB)
+    private fun onChat(event: SkyHanniChatEvent.Allow) {
+        if (!config.beachBallTracker.enabled) return
+        val message = event.cleanMessage
+
+        // A ball was just thrown: show the overlay immediately (before any result comes in).
+        if (startPattern.matches(message)) {
+            markActivity()
+            return
+        }
+
+        for (type in BallType.entries) {
+            type.resultPattern.matchMatcher(message) {
+                val treats = group("treats").formatInt()
+                markActivity()
+                tracker.modify {
+                    it.ballsUsed.addOrPut(type, 1)
+                    it.fishyTreats += treats
+                }
+                return
+            }
+        }
+    }
+
+    private fun markActivity() {
+        lastBallActivity = SimpleTimeMark.now()
+        tracker.firstUpdate()
+    }
+
+    private fun drawDisplay(data: Data): List<Searchable> = buildList {
+        addSearchString("§6§lBeach Ball Tracker")
+
+        for (type in BallType.entries) {
+            val amount = data.ballsUsed[type] ?: continue
+            addIconLine(type.item, "§e${amount.addSeparators()}x §f${type.label}", type.label)
+        }
+
+        addIconLine(FISHY_TREAT, "§e${data.fishyTreats.addSeparators()} §dFishy Treats", "Fishy Treats")
+
+        val totalBalls = data.ballsUsed.values.sum()
+        if (totalBalls > 0) {
+            val avg = data.fishyTreats.toDouble() / totalBalls
+            addIconLine(ENCHANTED_RAW_FISH, "§e${avg.roundTo(1).addSeparators()} §7Treats per Ball", "Treats per Ball")
+        }
+
+        val duration = data.getTotalUptime()
+        if (duration != 0.seconds) {
+            val perHour = data.fishyTreats / duration.inPartialHours
+            addIconLine(WATCH, "§e${perHour.roundTo(0).addSeparators()} §7Treats per Hour", "Treats per Hour")
+        }
+    }
+
+    private fun MutableList<Searchable>.addIconLine(icon: NeuInternalName, text: String, searchText: String) {
+        add(
+            Renderable.horizontal(
+                listOf(
+                    Renderable.item(icon),
+                    Renderable.text(text),
+                ),
+                spacing = 2,
+                verticalAlign = RenderUtils.VerticalAlignment.CENTER,
+            ).toSearchable(searchText),
+        )
+    }
+
+    init {
+        RenderDisplayHelper(
+            outsideInventory = true,
+            inOwnInventory = true,
+            onlyOnIsland = IslandType.HUB,
+            condition = { shouldShowDisplay() },
+            onRender = {
+                if (isHoldingBeachBall()) tracker.firstUpdate()
+                tracker.renderDisplay(config.beachBallTracker.position)
+            },
+        )
+    }
+
+    private fun shouldShowDisplay(): Boolean {
+        if (!config.beachBallTracker.enabled) return false
+        val recentlyActive = lastBallActivity.passedSince() < config.beachBallTracker.hideAfterInactivity.minutes
+        return recentlyActive || isHoldingBeachBall()
+    }
+
+    private fun isHoldingBeachBall(): Boolean {
+        val held = InventoryUtils.getItemInHand()?.getInternalNameOrNull() ?: return false
+        return held in ballItems
+    }
+
+    @HandleEvent
+    private fun onCommandRegistration(event: CommandRegistrationEvent) {
+        event.registerBrigadier("shresetbeachballtracker") {
+            description = "Resets the Beach Ball Tracker"
+            category = CommandCategory.USERS_RESET
+            simpleCallback { tracker.resetCommand() }
+        }
+    }
+}


### PR DESCRIPTION
## What
Adds a tracker for the Year of the Seal event. It shows how many Beach Balls you've used (normal and giant), the total Fishy Treats you've earned, and your treats per ball and per hour. The overlay shows up in the Hub while you're holding a Beach Ball or bouncing one, and hides after a bit of inactivity.

<details>
<summary>Images</summary>

Tracker showing your total Beach Balls used and Fishy Treats earned
<img width="287" height="154" alt="Beach Ball Tracker" src="https://github.com/user-attachments/assets/3fcb34d5-b5d5-4f14-a2c2-b1fc5b3360ee" /> 

Open your inventory to switch between Total and Session, or reset and pause
<img width="304" height="231" alt="Beach Ball Tracker" src="https://github.com/user-attachments/assets/f28f58d5-b8f8-487b-8b18-fdf543b65f34" />

Config: Events → Year of the Seal → Beach Ball Tracker
<img width="621" height="325" alt="7 Beach Ball Tracker" src="https://github.com/user-attachments/assets/0a4e6b1d-98a7-4102-a304-51c5d4bb92b6" />

</details>

## Changelog New Features
+ Added a tracker for Beach Balls used and Fishy Treats earned during the Year of the Seal. - RemainingDelta