### PR TITLE
Improvement: more Customizable Diana Rendering

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/diana/BurrowCustomization.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/diana/BurrowCustomization.kt
@@ -1,0 +1,52 @@
+package at.hannibal2.skyhanni.config.features.event.diana
+
+import at.hannibal2.skyhanni.utils.LorenzColor
+import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.ChromaColour
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorColour
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+
+class BurrowCustomization {
+
+    @Expose
+    @ConfigOption(
+        name = "Start Color",
+        desc = "Color of Start Burrow waypoints and lines"
+    )
+    @ConfigEditorColour
+    var startBurrowColor: ChromaColour = LorenzColor.GREEN.toChromaColor()
+
+    @Expose
+    @ConfigOption(
+        name = "Mob Color",
+        desc = "Color of Mob Burrow waypoints and lines"
+    )
+    @ConfigEditorColour
+    var mobBurrowColor: ChromaColour = LorenzColor.RED.toChromaColor()
+
+    @Expose
+    @ConfigOption(
+        name = "Treasure Color",
+        desc = "Color of Treasure Burrow waypoints and lines"
+    )
+    @ConfigEditorColour
+    var treasureBurrowColor: ChromaColour = LorenzColor.GOLD.toChromaColor()
+
+    @Expose
+    @ConfigOption(
+        name = "Waypoints Filled",
+        desc = "Whether to render Burrow Waypoints as a Full block (enabled) or Outline (Disabled)"
+    )
+    @ConfigEditorBoolean
+    var shouldRenderAsFullBlock: Boolean = true
+
+    @Expose
+    @ConfigOption(
+        name = "Outline Width",
+        desc = "Width of the outline of a Burrow if it is being rendered as an outline."
+    )
+    @ConfigEditorSlider(minValue = 1f, maxValue = 10f, minStep = 1f)
+    var burrowOutlineWidth: Float = 1f
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/diana/DianaConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/diana/DianaConfig.kt
@@ -99,7 +99,7 @@ class DianaConfig {
         desc = ""
     )
     @Accordion
-    var burrowColors: BurrowCustomization = BurrowCustomization()
+    val burrowCustomization: BurrowCustomization = BurrowCustomization()
 
     @Expose
     @ConfigOption(

--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/diana/DianaConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/diana/DianaConfig.kt
@@ -95,6 +95,14 @@ class DianaConfig {
 
     @Expose
     @ConfigOption(
+        name = "Burrow Waypoint & Line Customization",
+        desc = ""
+    )
+    @Accordion
+    var burrowColors: BurrowCustomization = BurrowCustomization()
+
+    @Expose
+    @ConfigOption(
         name = "Warn On Failure",
         desc = "Sends \"Use Spade\" title when arrow guess fails.",
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/BurrowType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/BurrowType.kt
@@ -18,7 +18,7 @@ enum class BurrowType(val text: String) {
     override fun toString() = text
 
     companion object {
-        val config get() = SkyHanniMod.feature.event.diana.burrowColors
+        val config get() = SkyHanniMod.feature.event.diana.burrowCustomization
 
         fun BurrowType.getBurrowColour(): ChromaColour =
             when (this) {

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/BurrowType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/BurrowType.kt
@@ -1,11 +1,35 @@
 package at.hannibal2.skyhanni.features.event.diana
 
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.utils.ColorUtils.toColor
 import at.hannibal2.skyhanni.utils.LorenzColor
+import at.hannibal2.skyhanni.utils.compat.appendWithColor
+import at.hannibal2.skyhanni.utils.compat.componentBuilder
 import io.github.notenoughupdates.moulconfig.ChromaColour
+import net.minecraft.network.chat.Component
 
-enum class BurrowType(val text: String, val color: ChromaColour) {
-    START("§aStart", LorenzColor.GREEN.toChromaColor()),
-    MOB("§cMob", LorenzColor.RED.toChromaColor()),
-    TREASURE("§6Treasure", LorenzColor.GOLD.toChromaColor()),
-    UNKNOWN("§fUnknown?!", LorenzColor.WHITE.toChromaColor()),
+enum class BurrowType(val text: String) {
+    START("Start"),
+    MOB("Mob"),
+    TREASURE("Treasure"),
+    UNKNOWN("Unknown?!"),
+    ;
+
+    override fun toString() = text
+
+    companion object {
+        val config get() = SkyHanniMod.feature.event.diana.burrowColors
+
+        fun BurrowType.getBurrowColour(): ChromaColour =
+            when (this) {
+                START -> config.startBurrowColor
+                MOB -> config.mobBurrowColor
+                TREASURE -> config.treasureBurrowColor
+                else -> LorenzColor.WHITE.toChromaColor()
+            }
+
+        fun BurrowType.getBurrowText(): Component = componentBuilder {
+            appendWithColor(this@getBurrowText.text, this@getBurrowText.getBurrowColour().toColor().rgb)
+        }
+    }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowHelper.kt
@@ -12,14 +12,14 @@ import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.title.TitleManager
 import at.hannibal2.skyhanni.events.BlockClickEvent
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
-import at.hannibal2.skyhanni.events.ProfileJoinEvent
-import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.diana.BurrowDetectEvent
 import at.hannibal2.skyhanni.events.diana.BurrowDugEvent
 import at.hannibal2.skyhanni.events.diana.BurrowGuessEvent
 import at.hannibal2.skyhanni.events.entity.EntityMoveEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
+import at.hannibal2.skyhanni.features.event.diana.BurrowType.Companion.getBurrowColour
+import at.hannibal2.skyhanni.features.event.diana.BurrowType.Companion.getBurrowText
 import at.hannibal2.skyhanni.features.event.diana.DianaApi.isDianaSpade
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.BlockUtils.getBlockAt
@@ -37,6 +37,7 @@ import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.TimeUtils.format
+import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedSet
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
 import at.hannibal2.skyhanni.utils.compat.addDoublePlant
@@ -46,6 +47,7 @@ import at.hannibal2.skyhanni.utils.compat.addRedFlower
 import at.hannibal2.skyhanni.utils.compat.addTallGrass
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.draw3DLine
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawColor
+import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawColorOrOutline
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawDynamicText
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToCrosshair
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
@@ -191,7 +193,7 @@ object GriffinBurrowHelper {
     }
 
     @HandleEvent
-    fun onDebugDataCollect(event: DebugDataCollectEvent) {
+    private fun onDebugDataCollect(event: DebugDataCollectEvent) {
         event.title("Griffin Burrow Helper")
 
         if (!DianaApi.isDoingDiana()) {
@@ -213,7 +215,7 @@ object GriffinBurrowHelper {
     }
 
     @HandleEvent
-    fun onSecondPassed(event: SecondPassedEvent) {
+    private fun onSecondPassed() {
         if (!isEnabled()) return
         update()
     }
@@ -267,7 +269,7 @@ object GriffinBurrowHelper {
     }
 
     @HandleEvent
-    fun onBurrowGuess(event: BurrowGuessEvent) {
+    private fun onBurrowGuess(event: BurrowGuessEvent) {
         EntityMovementData.addToTrack(MinecraftCompat.localPlayerOrThrow)
 
         val newLocation = event.guess.getCurrent()
@@ -282,7 +284,7 @@ object GriffinBurrowHelper {
     }
 
     @HandleEvent
-    fun onBurrowDetect(event: BurrowDetectEvent) {
+    private fun onBurrowDetect(event: BurrowDetectEvent) {
         EntityMovementData.addToTrack(MinecraftCompat.localPlayerOrThrow)
         val burrowLocation = event.burrowLocation
         val currentEntry = getGuess(burrowLocation)
@@ -303,7 +305,7 @@ object GriffinBurrowHelper {
 
     @Suppress("MaxLineLength")
     @HandleEvent
-    fun onBurrowDug(event: BurrowDugEvent) {
+    private fun onBurrowDug(event: BurrowDugEvent) {
         val location = event.burrowLocation
         mobAlive = false
         addDebug("Burrow dug event [${location.x}, ${location.y}, ${location.z}] recently removed burrows size: ${recentGuessesRemoved.size}")
@@ -333,7 +335,7 @@ object GriffinBurrowHelper {
     }
 
     @HandleEvent
-    fun onPlayerMove(event: EntityMoveEvent<LocalPlayer>) {
+    private fun onPlayerMove(event: EntityMoveEvent<LocalPlayer>) {
         if (!isEnabled()) return
         if (event.distance > 10) {
             update()
@@ -341,7 +343,7 @@ object GriffinBurrowHelper {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.HUB)
-    fun onChat(event: SkyHanniChatEvent.Allow) {
+    private fun onChat(event: SkyHanniChatEvent.Allow) {
         if (!isEnabled()) return
 
         BurrowApi.lastBurrowInteracted?.let {
@@ -404,7 +406,7 @@ object GriffinBurrowHelper {
     }
 
     @HandleEvent
-    fun onWorldChange() {
+    private fun onWorldChange() {
         DelayedRun.runOrNextTick {
             if (mobAlive) {
                 BurrowApi.lastBurrowInteracted?.let { removeGuess(it, "changed worlds while mob was alive") }
@@ -415,7 +417,7 @@ object GriffinBurrowHelper {
     }
 
     @HandleEvent
-    fun onProfileChange(event: ProfileJoinEvent) {
+    private fun onProfileJoin() {
         DelayedRun.runOrNextTick { resetAllData() }
     }
 
@@ -443,7 +445,7 @@ object GriffinBurrowHelper {
     }
 
     @HandleEvent
-    fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
+    private fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
         if (!isEnabled()) return
 
         val playerLocation = LocationUtils.playerLocation()
@@ -464,7 +466,7 @@ object GriffinBurrowHelper {
 
             val targetType = getGuess(targetLocation)?.burrowType
             val lineWidth = if (targetType != null && targetType != BurrowType.UNKNOWN) {
-                color = targetType.color
+                color = targetType.getBurrowColour()
                 3
             } else 2
             if (currentWarp == null) {
@@ -483,11 +485,11 @@ object GriffinBurrowHelper {
             val location = target.getCurrent()
             val distance = location.distance(playerLocation)
             val text = when (target.burrowType) {
-                BurrowType.UNKNOWN -> "${if (currentWarp != null) "§b" else "§f"}Guess"
-                else -> target.burrowType.text
+                BurrowType.UNKNOWN -> "${if (currentWarp != null) "§b" else "§f"}Guess".asComponent()
+                else -> target.burrowType.getBurrowText()
             }
 
-            event.drawColor(location, target.burrowType.color, config.beaconDistance != -1.0F && distance > config.beaconDistance)
+            event.drawColor(location, target.burrowType.getBurrowColour(), config.beaconDistance != -1.0F && distance > config.beaconDistance)
             event.drawDynamicText(location.up(), text, 1.5 * config.textScale)
         }
 
@@ -524,7 +526,7 @@ object GriffinBurrowHelper {
             val location = guess.getCurrent()
             val distance = location.distance(playerLocation)
             val burrowType = guess.burrowType
-            var text = burrowType.text
+            var text = burrowType.getBurrowText()
 
             if (!config.burrowsNearbyDetection) {
                 if (burrowType != BurrowType.UNKNOWN) return
@@ -534,7 +536,7 @@ object GriffinBurrowHelper {
                 if (!config.guess) return
                 else {
                     val textColor = if (BurrowWarpHelper.currentWarp != null && targetLocation == location) "§b" else "§f"
-                    text = "${textColor}Guess"
+                    text = "${textColor}Guess".asComponent()
                     if (distance > 5) {
                         val formattedDistance = distance.toInt().addSeparators()
                         event.drawDynamicText(location.up(), "§e${formattedDistance}m", 1.7 * config.textScale, yOff = 10f)
@@ -551,19 +553,24 @@ object GriffinBurrowHelper {
                 }
             }
 
-            // TODO add chroma color support via config
-            event.drawColor(location, burrowType.color, config.beaconDistance != -1.0F && distance > config.beaconDistance)
+            event.drawColorOrOutline(
+                location,
+                burrowType.getBurrowColour(),
+                config.beaconDistance != -1.0F && distance > config.beaconDistance,
+                config.burrowColors.burrowOutlineWidth.toInt(),
+                filled = config.burrowColors.shouldRenderAsFullBlock
+            )
             event.drawDynamicText(location.up(), text, 1.5 * config.textScale)
         }
     }
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(2, "diana", "event.diana")
     }
 
     @HandleEvent(onlyOnIsland = IslandType.HUB)
-    fun onBlockClick(event: BlockClickEvent) {
+    private fun onBlockClick(event: BlockClickEvent) {
         if (!isEnabled()) return
 
         val location = event.position
@@ -582,6 +589,8 @@ object GriffinBurrowHelper {
         val burrows = allGuesses.toList().flatMap { it.guesses }.union(recentGuessesRemoved)
         if (burrows.contains(location)) BurrowApi.setBurrowInteracted(location)
     }
+
+
 
     private fun isEnabled() = DianaApi.isDoingDiana()
 
@@ -627,7 +636,7 @@ object GriffinBurrowHelper {
     }
 
     @HandleEvent
-    fun onCommandRegistration(event: CommandRegistrationEvent) {
+    private fun onCommandRegistration(event: CommandRegistrationEvent) {
         event.registerBrigadier("shresetburrows") {
             description = "Resets all saved griffin burrow locations"
             category = CommandCategory.USERS_RESET

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/GriffinBurrowHelper.kt
@@ -489,7 +489,11 @@ object GriffinBurrowHelper {
                 else -> target.burrowType.getBurrowText()
             }
 
-            event.drawColor(location, target.burrowType.getBurrowColour(), config.beaconDistance != -1.0F && distance > config.beaconDistance)
+            event.drawColor(
+                location,
+                target.burrowType.getBurrowColour(),
+                config.beaconDistance != -1.0F && distance > config.beaconDistance,
+            )
             event.drawDynamicText(location.up(), text, 1.5 * config.textScale)
         }
 
@@ -557,8 +561,8 @@ object GriffinBurrowHelper {
                 location,
                 burrowType.getBurrowColour(),
                 config.beaconDistance != -1.0F && distance > config.beaconDistance,
-                config.burrowColors.burrowOutlineWidth.toInt(),
-                filled = config.burrowColors.shouldRenderAsFullBlock
+                config.burrowCustomization.burrowOutlineWidth.toInt(),
+                filled = config.burrowCustomization.shouldRenderAsFullBlock,
             )
             event.drawDynamicText(location.up(), text, 1.5 * config.textScale)
         }
@@ -589,7 +593,6 @@ object GriffinBurrowHelper {
         val burrows = allGuesses.toList().flatMap { it.guesses }.union(recentGuessesRemoved)
         if (burrows.contains(location)) BurrowApi.setBurrowInteracted(location)
     }
-
 
 
     private fun isEnabled() = DianaApi.isDoingDiana()

--- a/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/render/WorldRenderUtils.kt
@@ -984,6 +984,20 @@ object WorldRenderUtils {
         ) ?: aabb
     }
 
+    fun SkyHanniRenderWorldEvent.drawColorOrOutline(
+        location: LorenzVec,
+        color: ChromaColour,
+        beacon: Boolean = false,
+        width: Int = 1,
+        alpha: Float = -1f,
+        seeThroughBlocks: Boolean = true,
+        filled: Boolean = false,
+    ) {
+        if (filled) drawColor(location, color, false, alpha, seeThroughBlocks)
+        else drawEdges(location, color.toColor(), width, depth = !seeThroughBlocks)
+        if (beacon) renderBeaconBeam(location, color.toColor())
+    }
+
     fun SkyHanniRenderWorldEvent.exactPlayerEyeLocation(player: Entity): LorenzVec =
         exactLocation(player).up(player.getEyeHeight(player.pose))
 


### PR DESCRIPTION
## What
This PR is a TODO (customizable mob burrow colours for Start, Mob and Treasure) and a suggestion https://discord.com/channels/997079228510117908/1524209338548224081 for outline rendering for Burrows,
adding a WorldRenderUtils entry for this *specific* usage feels a bit weird since it's reasonably unlikely to end up reused anyway but it felt bad putting this into a specific feature file since there's world where someone *might* want to reuse this

## Changelog Improvements
+ Improved Diana Nearby Waypoints/LinetoWaypoints with customizable colours. - Fazfoxy
+ Added config option to render Diana Nearby Burrow Waypoints as block outlines. - Fazfoxy