### PR TITLE
Fix: /shupdate stream argument never matching

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
@@ -245,7 +245,7 @@ object UpdateManager {
     private val betaStreamPattern = "(?i)(?:beta|latest)s?".toRegex()
 
     private fun updateCommand(arg: String) {
-        val currentStream = SkyHanniMod.feature.about.updateStream.get()
+        val currentStream = config.updateStream.get()
         val updateStream = when {
             arg.matches(releaseStreamPattern) -> UpdateStream.RELEASES
             arg.matches(betaStreamPattern) -> UpdateStream.BETA
@@ -257,15 +257,15 @@ object UpdateManager {
             ChatUtils.clickableChat(
                 "Are you sure you want to switch to beta? These versions may be less stable.",
                 onClick = {
-                    SkyHanniMod.feature.about.updateStream.set(UpdateStream.BETA)
-                    checkUpdate(true, UpdateStream.BETA)
+                    config.updateStream.set(updateStream)
+                    checkUpdate(true, updateStream)
                 },
                 "§eClick to confirm!",
                 oneTimeClick = true,
             )
         } else {
             if (updateStream != currentStream) {
-                SkyHanniMod.feature.about.updateStream.set(updateStream)
+                config.updateStream.set(updateStream)
             }
             checkUpdate(true, updateStream)
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
@@ -124,11 +124,6 @@ object UpdateManager {
 
         logger.log("Starting update check (source: ${context.source.javaClass.simpleName}")
 
-        val currentStream = config.updateStream.get()
-        if (forcedUpdateStream == UpdateStream.BETA && currentStream != UpdateStream.BETA) {
-            config.updateStream.set(UpdateStream.BETA)
-        }
-
         activePromise = context.checkUpdate(forcedUpdateStream.stream)
             .orTimeout(15, TimeUnit.SECONDS)
             .whenCompleteAsync(

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
@@ -241,11 +241,14 @@ object UpdateManager {
 
     private var potentialUpdate: PotentialUpdate? = null
 
+    private val releaseStreamPattern = "(?i)(?:full|release)s?".toRegex()
+    private val betaStreamPattern = "(?i)(?:beta|latest)s?".toRegex()
+
     private fun updateCommand(arg: String) {
         val currentStream = SkyHanniMod.feature.about.updateStream.get()
         val updateStream = when {
-            arg.matches("(?i)(?:full|release)s?".toRegex()) -> UpdateStream.RELEASES
-            arg.matches("(?i)(?:beta|latest)s?".toRegex()) -> UpdateStream.BETA
+            arg.matches(releaseStreamPattern) -> UpdateStream.RELEASES
+            arg.matches(betaStreamPattern) -> UpdateStream.BETA
             else -> currentStream
         }
 
@@ -254,14 +257,16 @@ object UpdateManager {
             ChatUtils.clickableChat(
                 "Are you sure you want to switch to beta? These versions may be less stable.",
                 onClick = {
-                    val newUpdateStream = SkyHanniMod.feature.about.updateStream
-                    newUpdateStream.set(UpdateStream.BETA)
-                    checkUpdate(true, newUpdateStream.get())
+                    SkyHanniMod.feature.about.updateStream.set(UpdateStream.BETA)
+                    checkUpdate(true, UpdateStream.BETA)
                 },
                 "§eClick to confirm!",
                 oneTimeClick = true,
             )
         } else {
+            if (updateStream != currentStream) {
+                SkyHanniMod.feature.about.updateStream.set(updateStream)
+            }
             checkUpdate(true, updateStream)
         }
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
@@ -252,7 +252,9 @@ object UpdateManager {
             ChatUtils.clickableChat(
                 "Are you sure you want to switch to beta? These versions may be less stable.",
                 onClick = {
-                    config.updateStream.set(updateStream)
+                    if (updateStream != currentStream) {
+                        config.updateStream.set(updateStream)
+                    }
                     checkUpdate(true, updateStream)
                 },
                 "§eClick to confirm!",

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/update/UpdateManager.kt
@@ -244,8 +244,8 @@ object UpdateManager {
     private fun updateCommand(arg: String) {
         val currentStream = SkyHanniMod.feature.about.updateStream.get()
         val updateStream = when {
-            arg.equals("(?i)(?:full|release)s?".toRegex()) -> UpdateStream.RELEASES
-            arg.equals("(?i)(?:beta|latest)s?".toRegex()) -> UpdateStream.BETA
+            arg.matches("(?i)(?:full|release)s?".toRegex()) -> UpdateStream.RELEASES
+            arg.matches("(?i)(?:beta|latest)s?".toRegex()) -> UpdateStream.BETA
             else -> currentStream
         }
 


### PR DESCRIPTION
## What
Fixed `/shupdate release` and `/shupdate beta` not switching the update stream.
- `String.equals(Regex)` always returns `false`, replaced with `String.matches(Regex)`.
- Moved regex patterns to class-level properties to avoid recompilation on every call.
- `/shupdate release` now persists the stream change in the config. Previously, only switching to BETA was saved.

## Changelog Fixes
+ Fixed /shupdate release and /shupdate beta not switching the update stream. - 3d3n-pyc