### PR TITLE
Fix: Player Rank Hider not hiding ranks for players with an emblem

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerChatManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerChatManager.kt
@@ -35,10 +35,14 @@ object PlayerChatManager {
      * REGEX-TEST: [58] §7nea89o§7: haiiiii
      * REGEX-TEST: [266] ♫ §b[MVP§d+§b] lrg89§f: a
      * REGEX-TEST: [302] ♫ [MVP+] lrg89: problematic
+     * REGEX-TEST: [233] §6✿ §a[VIP] dawnbound§f: thats not mine too
+     * REGEX-TEST: [323] §b[MVP§2+§b] xatarna§f: can somebody get these beggars out of here
+     * REGEX-FAIL: [BOSS] Bonzo: Show time!
+     * REGEX-FAIL: Finding player...
      */
     private val globalPattern by patternGroup.pattern(
         "global",
-        "^(?:\\[(?<level>\\d+)] )?(?<author>(?:(?:§.)*[^ ]+ )?(?:(?:§.)*\\[[^\\]]+\\] )?[^ ]+?)(?<chatColor>§f|§7|): (?<message>.*)\$",
+        "^(?:\\[(?<level>\\d+)] )?(?<author>(?:(?:§.)*[^ ] )?(?:(?:§.)*\\[[^\\]]+\\] )?[^ ]+?)(?<chatColor>§f|§7|): (?<message>.*)\$",
     )
 
     /**
@@ -229,6 +233,10 @@ object PlayerChatManager {
     private fun ComponentMatcher.isGlobalChat(event: SkyHanniChatEvent.Allow): Boolean {
         var author = groupOrThrow("author")
         val chatColor = groupOrThrow("chatColor")
+        if (chatColor.length == 0 && !author.getText().removeColor().endsWith(PlayerUtils.getName())) {
+            // The last format string is always present, unless this is the players own message
+            return false
+        }
         val message = groupOrThrow("message").removePrefix("§f")
         if (author.getText().contains("[NPC]")) {
             NpcChatEvent.Allow(author, message, event.chatComponent).postChat(event)
@@ -267,6 +275,10 @@ object PlayerChatManager {
     private fun ComponentMatcher.isGlobalChat(event: SkyHanniChatEvent.Modify): Boolean {
         var author = groupOrThrow("author")
         val chatColor = groupOrThrow("chatColor")
+        if (chatColor.length == 0 && !author.getText().removeColor().endsWith(PlayerUtils.getName())) {
+            // The last format string is always present, unless this is the players own message
+            return false
+        }
         val message = groupOrThrow("message").removePrefix("§f")
         if (author.getText().contains("[NPC]")) {
             NpcChatEvent.Modify(author, message, event.chatComponent).postChat(event)

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerChatManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerChatManager.kt
@@ -38,7 +38,7 @@ object PlayerChatManager {
      */
     private val globalPattern by patternGroup.pattern(
         "global",
-        "^(?:\\[(?<level>\\d+)] )?(?<author>(?:[^ ] )?(?:(?:§.)?\\[[^\\]]+\\] )?[^ ]+?)(?<chatColor>§f|§7|): (?<message>.*)\$",
+        "^(?:\\[(?<level>\\d+)] )?(?<author>(?:(?:§.)*[^ ]+ )?(?:(?:§.)*\\[[^\\]]+\\] )?[^ ]+?)(?<chatColor>§f|§7|): (?<message>.*)\$",
     )
 
     /**
@@ -229,10 +229,6 @@ object PlayerChatManager {
     private fun ComponentMatcher.isGlobalChat(event: SkyHanniChatEvent.Allow): Boolean {
         var author = groupOrThrow("author")
         val chatColor = groupOrThrow("chatColor")
-        if (chatColor.length == 0 && !author.getText().removeColor().endsWith(PlayerUtils.getName())) {
-            // The last format string is always present, unless this is the players own message
-            return false
-        }
         val message = groupOrThrow("message").removePrefix("§f")
         if (author.getText().contains("[NPC]")) {
             NpcChatEvent.Allow(author, message, event.chatComponent).postChat(event)
@@ -271,10 +267,6 @@ object PlayerChatManager {
     private fun ComponentMatcher.isGlobalChat(event: SkyHanniChatEvent.Modify): Boolean {
         var author = groupOrThrow("author")
         val chatColor = groupOrThrow("chatColor")
-        if (chatColor.length == 0 && !author.getText().removeColor().endsWith(PlayerUtils.getName())) {
-            // The last format string is always present, unless this is the players own message
-            return false
-        }
         val message = groupOrThrow("message").removePrefix("§f")
         if (author.getText().contains("[NPC]")) {
             NpcChatEvent.Modify(author, message, event.chatComponent).postChat(event)

--- a/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerChatManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/hypixel/chat/PlayerChatManager.kt
@@ -37,7 +37,6 @@ object PlayerChatManager {
      * REGEX-TEST: [302] ♫ [MVP+] lrg89: problematic
      * REGEX-TEST: [233] §6✿ §a[VIP] dawnbound§f: thats not mine too
      * REGEX-TEST: [323] §b[MVP§2+§b] xatarna§f: can somebody get these beggars out of here
-     * REGEX-FAIL: [BOSS] Bonzo: Show time!
      * REGEX-FAIL: Finding player...
      */
     private val globalPattern by patternGroup.pattern(

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/playerchat/PlayerChatModifier.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/playerchat/PlayerChatModifier.kt
@@ -23,6 +23,9 @@ object PlayerChatModifier {
         patterns.add("§[7ab6](\\w{2,16})§r(?!§7x)(?!\$)".toRegex()) // all players without rank prefix in notification messages
     }
 
+    private val possessivePattern = "§[7ab6]((?:\\w+){2,16})'s".toRegex()
+    private val colorFollowPattern = "§[7ab6]((?:\\w+){2,16}) (§.)".toRegex()
+
     @HandleEvent
     fun onChat(event: SystemMessageEvent.Modify) {
         event.applyIfPossible("PLAYER_CHAT") { cutMessage(it) }
@@ -53,8 +56,8 @@ object PlayerChatModifier {
             for (pattern in patterns) {
                 string = string.replace(pattern, "§b$1")
             }
-            string = string.replace("§[7ab6]((?:\\w+){2,16})'s", "§b$1's")
-            string = string.replace("§[7ab6]((?:\\w+){2,16}) (§.)", "§b$1 $2")
+            string = string.replace(possessivePattern, "§b$1's")
+            string = string.replace(colorFollowPattern, "§b$1 $2")
         }
 
         string = MarkedPlayerManager.replaceInChat(string)

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/playerchat/PlayerChatModifier.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/playerchat/PlayerChatModifier.kt
@@ -23,9 +23,6 @@ object PlayerChatModifier {
         patterns.add("§[7ab6](\\w{2,16})§r(?!§7x)(?!\$)".toRegex()) // all players without rank prefix in notification messages
     }
 
-    private val possessivePattern = "§[7ab6]((?:\\w+){2,16})'s".toRegex()
-    private val colorFollowPattern = "§[7ab6]((?:\\w+){2,16}) (§.)".toRegex()
-
     @HandleEvent
     fun onChat(event: SystemMessageEvent.Modify) {
         event.applyIfPossible("PLAYER_CHAT") { cutMessage(it) }
@@ -56,8 +53,8 @@ object PlayerChatModifier {
             for (pattern in patterns) {
                 string = string.replace(pattern, "§b$1")
             }
-            string = string.replace(possessivePattern, "§b$1's")
-            string = string.replace(colorFollowPattern, "§b$1 $2")
+            string = string.replace("§[7ab6]((?:\\w+){2,16})'s", "§b$1's")
+            string = string.replace("§[7ab6]((?:\\w+){2,16}) (§.)", "§b$1 $2")
         }
 
         string = MarkedPlayerManager.replaceInChat(string)


### PR DESCRIPTION
## What
Fixed `Player Rank Hider` not hiding ranks for other players in chat.
- Updated `globalPattern` in `PlayerChatManager` to support colored SkyBlock emblems before player names.
- Removed outdated `chatColor.length == 0` check in `isGlobalChat` that caused other players' chat messages to be rejected.
- Fixed `String.replace` calls in `PlayerChatModifier` using literal string replacement instead of `.toRegex()`.

## Changelog Fixes
+ Fixed Player Rank Hider not hiding ranks for players with a SkyBlock emblem in front of their name. - 3d3n-pyc