### PR TITLE
Fix: Glow breaking and stutter/crash on 26.1

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinLevelRenderer.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinLevelRenderer.java
@@ -32,4 +32,12 @@ public abstract class MixinLevelRenderer {
         if (!RenderLivingEntityHelper.isUsingCustomGlow()) return;
         SkyHanniOutlineHook.checkIfDepthAttachmentNeedsUpdating();
     }
+
+    //? if < 26.2 {
+    /*@Inject(method = "lambda$addMainPass$0", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/OutlineBufferSource;endOutlineBatch()V"))
+    private void renderSkyHanniGlow(CallbackInfo ci) {
+        if (!RenderLivingEntityHelper.isUsingCustomGlow()) return;
+        SkyHanniOutlineHook.getVertexConsumers().endOutlineBatch();
+    }
+    *///?}
 }


### PR DESCRIPTION
## What
Restores a mixin that was accidentally deleted in #6426. The missing mixin caused glow to sometimes not work, and worse, overflow the BufferBuilder, causing the game to sometimes stutter and eventually crash.

## Changelog Fixes
+ Fixed some glow/highlight features not working and causing stutters and crashes on Minecraft 26.1. - Luna