### PR TITLE
Feature: Trophy Frogs

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/fishing/FishingConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/fishing/FishingConfig.kt
@@ -3,6 +3,7 @@ package at.hannibal2.skyhanni.config.features.fishing
 import at.hannibal2.skyhanni.config.FeatureToggle
 import at.hannibal2.skyhanni.config.core.config.Position
 import at.hannibal2.skyhanni.config.features.fishing.trophyfishing.TrophyFishingConfig
+import at.hannibal2.skyhanni.config.features.fishing.trophyfrog.TrophyFrogsConfig
 import at.hannibal2.skyhanni.features.fishing.SeaCreatureManager.CompactDoubleHookPosition
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.Accordion
@@ -19,6 +20,10 @@ class FishingConfig {
     @Expose
     @Category(name = "Trophy Fishing", desc = "Trophy Fishing Settings")
     val trophyFishing: TrophyFishingConfig = TrophyFishingConfig()
+
+    @Expose
+    @Category(name = "Trophy Frogs", desc = "Trophy Frogs Settings")
+    val trophyFrogs: TrophyFrogsConfig = TrophyFrogsConfig()
 
     @Expose
     @ConfigOption(name = "Wormhole Finder", desc = "Settings for the Wormhole Finder on Lotus Atoll and Crimson Isle.")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/fishing/trophy/TrophyCollectionDisplayConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/fishing/trophy/TrophyCollectionDisplayConfig.kt
@@ -15,7 +15,7 @@ import io.github.notenoughupdates.moulconfig.observer.Property
 interface TrophyCollectionDisplayConfig {
     val enabled: Property<Boolean>
     val whenToShow: Property<WhenToShow>
-    val keybind: Int
+    var keybind: Int
     val requireArmor: Property<Boolean>
     val highlightNew: Property<Boolean>
     val extraSpace: Property<Int>

--- a/src/main/java/at/hannibal2/skyhanni/config/features/fishing/trophy/TrophyCollectionDisplayConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/fishing/trophy/TrophyCollectionDisplayConfig.kt
@@ -1,0 +1,78 @@
+package at.hannibal2.skyhanni.config.features.fishing.trophy
+
+import at.hannibal2.skyhanni.config.core.config.Position
+import io.github.notenoughupdates.moulconfig.observer.Property
+
+/**
+ * Shared config surface for the trophy collection displays (Trophy Fish, Trophy Frogs).
+ * Implemented by the concrete display configs so [TrophyCollectionDisplay] can read them generically.
+ *
+ * This is an interface rather than a base class on purpose: the config tooling iterates
+ * `javaClass.declaredFields` (non-inherited), so the `@Expose` fields must be declared on each
+ * concrete config. Sharing them via a base class would hide them from those passes.
+ */
+@Suppress("StorageNeedsExpose")
+interface TrophyCollectionDisplayConfig {
+    val enabled: Property<Boolean>
+    val whenToShow: Property<WhenToShow>
+    val keybind: Int
+    val requireArmor: Property<Boolean>
+    val highlightNew: Property<Boolean>
+    val extraSpace: Property<Int>
+    val sortingType: Property<TrophySorting>
+    val reverseOrder: Property<Boolean>
+    val textOrder: Property<MutableList<TextPart>>
+    val showCross: Property<Boolean>
+    val showCheckmark: Property<Boolean>
+    val onlyShowMissing: Property<HideCaught>
+    val showCaughtHigher: Property<Boolean>
+    val position: Position
+
+    enum class WhenToShow(private val displayName: String) {
+        ALWAYS("Always"),
+        ONLY_IN_INVENTORY("In inventory"),
+        ONLY_WITH_ROD_IN_HAND("Rod in hand"),
+        ONLY_WITH_KEYBIND("On keybind"),
+        ;
+
+        override fun toString() = displayName
+    }
+
+    enum class TrophySorting(private val displayName: String) {
+        ITEM_RARITY("Item Rarity"),
+        TOTAL_AMOUNT("Total Amount"),
+        BRONZE_AMOUNT("Bronze Amount"),
+        SILVER_AMOUNT("Silver Amount"),
+        GOLD_AMOUNT("Gold Amount"),
+        DIAMOND_AMOUNT("Diamond Amount"),
+        HIGHEST_RARITY("Highest Rarity"),
+        NAME("Name Alphabetical"),
+        ;
+
+        override fun toString() = displayName
+    }
+
+    enum class TextPart(private val displayName: String) {
+        ICON("Icon"),
+        NAME("Name"),
+        BRONZE("Amount Bronze"),
+        SILVER("Amount Silver"),
+        GOLD("Amount Gold"),
+        DIAMOND("Amount Diamond"),
+        TOTAL("Amount Total"),
+        ;
+
+        override fun toString() = displayName
+    }
+
+    enum class HideCaught(private val displayName: String) {
+        NONE("Show All"),
+        BRONZE("Bronze"),
+        SILVER("Silver"),
+        GOLD("Gold"),
+        DIAMOND("Diamond"),
+        ;
+
+        override fun toString() = displayName
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/features/fishing/trophyfishing/TrophyFishDisplayConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/fishing/trophyfishing/TrophyFishDisplayConfig.kt
@@ -2,6 +2,11 @@ package at.hannibal2.skyhanni.config.features.fishing.trophyfishing
 
 import at.hannibal2.skyhanni.config.FeatureToggle
 import at.hannibal2.skyhanni.config.core.config.Position
+import at.hannibal2.skyhanni.config.features.fishing.trophy.TrophyCollectionDisplayConfig
+import at.hannibal2.skyhanni.config.features.fishing.trophy.TrophyCollectionDisplayConfig.HideCaught
+import at.hannibal2.skyhanni.config.features.fishing.trophy.TrophyCollectionDisplayConfig.TextPart
+import at.hannibal2.skyhanni.config.features.fishing.trophy.TrophyCollectionDisplayConfig.TrophySorting
+import at.hannibal2.skyhanni.config.features.fishing.trophy.TrophyCollectionDisplayConfig.WhenToShow
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDraggableList
@@ -13,32 +18,22 @@ import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 import io.github.notenoughupdates.moulconfig.observer.Property
 import org.lwjgl.glfw.GLFW
 
-class TrophyFishDisplayConfig {
+class TrophyFishDisplayConfig : TrophyCollectionDisplayConfig {
     @Expose
     @ConfigOption(name = "Enabled", desc = "Show a display of all trophy fishes ever caught.")
     @ConfigEditorBoolean
     @FeatureToggle
-    val enabled: Property<Boolean> = Property.of(false)
+    override val enabled: Property<Boolean> = Property.of(false)
 
     @Expose
     @ConfigOption(name = "When Show", desc = "Change when the trophy fish display should be visible in Crimson Isle.")
     @ConfigEditorDropdown
-    val whenToShow: Property<WhenToShow> = Property.of(WhenToShow.ALWAYS)
-
-    enum class WhenToShow(private val displayName: String) {
-        ALWAYS("Always"),
-        ONLY_IN_INVENTORY("In inventory"),
-        ONLY_WITH_ROD_IN_HAND("Rod in hand"),
-        ONLY_WITH_KEYBIND("On keybind"),
-        ;
-
-        override fun toString() = displayName
-    }
+    override val whenToShow: Property<WhenToShow> = Property.of(WhenToShow.ALWAYS)
 
     @Expose
     @ConfigOption(name = "Keybind", desc = "")
     @ConfigEditorKeybind(defaultKey = GLFW.GLFW_KEY_UNKNOWN)
-    var keybind: Int = GLFW.GLFW_KEY_UNKNOWN
+    override var keybind: Int = GLFW.GLFW_KEY_UNKNOWN
 
     @Expose
     @ConfigOption(
@@ -47,46 +42,32 @@ class TrophyFishDisplayConfig {
             "or you're too low level to fish for sea creatures."
     )
     @ConfigEditorBoolean
-    val requireArmor: Property<Boolean> = Property.of(false)
+    override val requireArmor: Property<Boolean> = Property.of(false)
 
     @Expose
     @ConfigOption(name = "Highlight New", desc = "Highlight new trophies green for couple seconds.")
     @ConfigEditorBoolean
-    val highlightNew: Property<Boolean> = Property.of(true)
+    override val highlightNew: Property<Boolean> = Property.of(true)
 
     @Expose
     @ConfigOption(name = "Extra space", desc = "Space between each line of text.")
     @ConfigEditorSlider(minValue = 0f, maxValue = 10f, minStep = 1f)
-    val extraSpace: Property<Int> = Property.of(1)
+    override val extraSpace: Property<Int> = Property.of(1)
 
     @Expose
-    @ConfigOption(name = "Sorted By", desc = "Sorting type of items in sack.")
+    @ConfigOption(name = "Sorted By", desc = "Sorting type of trophy fish in the display.")
     @ConfigEditorDropdown
-    val sortingType: Property<TrophySorting> = Property.of(TrophySorting.ITEM_RARITY)
-
-    enum class TrophySorting(private val displayName: String) {
-        ITEM_RARITY("Item Rarity"),
-        TOTAL_AMOUNT("Total Amount"),
-        BRONZE_AMOUNT("Bronze Amount"),
-        SILVER_AMOUNT("Silver Amount"),
-        GOLD_AMOUNT("Gold Amount"),
-        DIAMOND_AMOUNT("Diamond Amount"),
-        HIGHEST_RARITY("Highest Rarity"),
-        NAME("Name Alphabetical"),
-        ;
-
-        override fun toString() = displayName
-    }
+    override val sortingType: Property<TrophySorting> = Property.of(TrophySorting.ITEM_RARITY)
 
     @Expose
     @ConfigOption(name = "Reverse Order", desc = "Reverse the sorting order.")
     @ConfigEditorBoolean
-    val reverseOrder: Property<Boolean> = Property.of(false)
+    override val reverseOrder: Property<Boolean> = Property.of(false)
 
     @Expose
     @ConfigOption(name = "Text Order", desc = "Drag text to change the line format.")
     @ConfigEditorDraggableList
-    val textOrder: Property<MutableList<TextPart>> = Property.of(
+    override val textOrder: Property<MutableList<TextPart>> = Property.of(
         mutableListOf(
             TextPart.NAME,
             TextPart.ICON,
@@ -98,44 +79,20 @@ class TrophyFishDisplayConfig {
         ),
     )
 
-    enum class TextPart(private val displayName: String) {
-        ICON("Item Icon"),
-        NAME("Item Name"),
-        BRONZE("Amount Bronze"),
-        SILVER("Amount Silver"),
-        GOLD("Amount Gold"),
-        DIAMOND("Amount Diamond"),
-        TOTAL("Amount Total"),
-        ;
-
-        override fun toString() = displayName
-    }
-
     @Expose
     @ConfigOption(name = "Show ✖", desc = "Instead of the number 0, show §c✖ §7if not found.")
     @ConfigEditorBoolean
-    val showCross: Property<Boolean> = Property.of(false)
+    override val showCross: Property<Boolean> = Property.of(false)
 
     @Expose
     @ConfigOption(name = "Show ✔", desc = "Instead of the exact numbers, show §e§l✔ §7if found.")
     @ConfigEditorBoolean
-    val showCheckmark: Property<Boolean> = Property.of(false)
+    override val showCheckmark: Property<Boolean> = Property.of(false)
 
     @Expose
     @ConfigOption(name = "Only Show Missing", desc = "Only show Trophy Fish that are still missing at this rarity.")
     @ConfigEditorDropdown
-    val onlyShowMissing: Property<HideCaught> = Property.of(HideCaught.NONE)
-
-    enum class HideCaught(private val displayName: String) {
-        NONE("Show All"),
-        BRONZE("Bronze"),
-        SILVER("Silver"),
-        GOLD("Gold"),
-        DIAMOND("Diamond"),
-        ;
-
-        override fun toString() = displayName
-    }
+    override val onlyShowMissing: Property<HideCaught> = Property.of(HideCaught.NONE)
 
     @Expose
     @ConfigOption(
@@ -143,9 +100,9 @@ class TrophyFishDisplayConfig {
         desc = "Show Trophy Fish missing at the chosen tier even if a higher tier has already been caught.",
     )
     @ConfigEditorBoolean
-    val showCaughtHigher: Property<Boolean> = Property.of(false)
+    override val showCaughtHigher: Property<Boolean> = Property.of(false)
 
     @Expose
     @ConfigLink(owner = TrophyFishDisplayConfig::class, field = "enabled")
-    val position: Position = Position(144, 139)
+    override val position: Position = Position(144, 139)
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/fishing/trophyfrog/ChatMessagesConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/fishing/trophyfrog/ChatMessagesConfig.kt
@@ -1,0 +1,87 @@
+package at.hannibal2.skyhanni.config.features.fishing.trophyfrog
+
+import at.hannibal2.skyhanni.config.FeatureToggle
+import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDropdown
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+
+class ChatMessagesConfig {
+    @Expose
+    @ConfigOption(
+        name = "Trophy Counter",
+        desc = "Count Trophy Frog messages from chat and tells you how many you have found."
+    )
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var enabled: Boolean = false
+
+    @Expose
+    @ConfigOption(
+        name = "Trophy Counter Design",
+        desc = "§fStyle 1: §72. §6§lGOLD §aLeap Frog\n" +
+            "§fStyle 2: §bYou caught a §aLeap Frog §6§lGOLD§b. §7(2)\n" +
+            "§fStyle 3: §bYou caught your 2nd §6§lGOLD §aLeap Frog§b."
+    )
+    @ConfigEditorDropdown
+    var design: DesignFormat = DesignFormat.STYLE_1
+
+    enum class DesignFormat(private val displayName: String) {
+        STYLE_1("Style 1"),
+        STYLE_2("Style 2"),
+        STYLE_3("Style 3"),
+        ;
+
+        override fun toString() = displayName
+    }
+
+    @Expose
+    @ConfigOption(
+        name = "Show Total Amount",
+        desc = "Show total amount of all rarities at the end of the chat message."
+    )
+    @ConfigEditorBoolean
+    var totalAmount: Boolean = false
+
+    @Expose
+    @ConfigOption(
+        name = "Trophy Frog Info",
+        desc = "Show information and stats about a Trophy Frog when hovering over a catch message in chat."
+    )
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var tooltip: Boolean = true
+
+    @Expose
+    @ConfigOption(name = "Hide Repeated Catches", desc = "Delete past catches of the same Trophy Frog from chat.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var duplicateHider: Boolean = false
+
+    @Expose
+    @ConfigOption(name = "Bronze Duplicates", desc = "Hide duplicate messages for bronze Trophy Frogs from chat.")
+    @ConfigEditorBoolean
+    var bronzeHider: Boolean = false
+
+    @Expose
+    @ConfigOption(name = "Silver Duplicates", desc = "Hide duplicate messages for silver Trophy Frogs from chat.")
+    @ConfigEditorBoolean
+    var silverHider: Boolean = false
+
+    @Expose
+    @ConfigOption(name = "Gold Alert", desc = "Send an alert upon catching a gold Trophy Frog.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var goldAlert: Boolean = false
+
+    @Expose
+    @ConfigOption(name = "Diamond Alert", desc = "Send an alert upon catching a diamond Trophy Frog.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var diamondAlert: Boolean = false
+
+    @Expose
+    @ConfigOption(name = "Play Sound Alert", desc = "Play a sound effect when rare Trophy Frogs are caught.")
+    @ConfigEditorBoolean
+    var playSound: Boolean = true
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/features/fishing/trophyfrog/TrophyFrogDisplayConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/fishing/trophyfrog/TrophyFrogDisplayConfig.kt
@@ -2,6 +2,11 @@ package at.hannibal2.skyhanni.config.features.fishing.trophyfrog
 
 import at.hannibal2.skyhanni.config.FeatureToggle
 import at.hannibal2.skyhanni.config.core.config.Position
+import at.hannibal2.skyhanni.config.features.fishing.trophy.TrophyCollectionDisplayConfig
+import at.hannibal2.skyhanni.config.features.fishing.trophy.TrophyCollectionDisplayConfig.HideCaught
+import at.hannibal2.skyhanni.config.features.fishing.trophy.TrophyCollectionDisplayConfig.TextPart
+import at.hannibal2.skyhanni.config.features.fishing.trophy.TrophyCollectionDisplayConfig.TrophySorting
+import at.hannibal2.skyhanni.config.features.fishing.trophy.TrophyCollectionDisplayConfig.WhenToShow
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDraggableList
@@ -13,31 +18,22 @@ import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
 import io.github.notenoughupdates.moulconfig.observer.Property
 import org.lwjgl.glfw.GLFW
 
-class TrophyFrogDisplayConfig {
+class TrophyFrogDisplayConfig : TrophyCollectionDisplayConfig {
     @Expose
     @ConfigOption(name = "Enabled", desc = "Show a display of all trophy frogs ever caught.")
     @ConfigEditorBoolean
     @FeatureToggle
-    val enabled: Property<Boolean> = Property.of(false)
+    override val enabled: Property<Boolean> = Property.of(false)
 
     @Expose
     @ConfigOption(name = "When Show", desc = "Change when the trophy frog display should be visible on Lotus Atoll.")
     @ConfigEditorDropdown
-    val whenToShow: Property<WhenToShow> = Property.of(WhenToShow.ALWAYS)
-
-    enum class WhenToShow(private val displayName: String) {
-        ALWAYS("Always"),
-        ONLY_IN_INVENTORY("In inventory"),
-        ONLY_WITH_KEYBIND("On keybind"),
-        ;
-
-        override fun toString() = displayName
-    }
+    override val whenToShow: Property<WhenToShow> = Property.of(WhenToShow.ALWAYS)
 
     @Expose
     @ConfigOption(name = "Keybind", desc = "")
     @ConfigEditorKeybind(defaultKey = GLFW.GLFW_KEY_UNKNOWN)
-    var keybind: Int = GLFW.GLFW_KEY_UNKNOWN
+    override var keybind: Int = GLFW.GLFW_KEY_UNKNOWN
 
     @Expose
     @ConfigOption(
@@ -45,46 +41,32 @@ class TrophyFrogDisplayConfig {
         desc = "Only show when wearing 2+ trophy Hunter armor pieces (any tier).",
     )
     @ConfigEditorBoolean
-    val requireArmor: Property<Boolean> = Property.of(true)
+    override val requireArmor: Property<Boolean> = Property.of(true)
 
     @Expose
     @ConfigOption(name = "Highlight New", desc = "Highlight new trophies green for couple seconds.")
     @ConfigEditorBoolean
-    val highlightNew: Property<Boolean> = Property.of(true)
+    override val highlightNew: Property<Boolean> = Property.of(true)
 
     @Expose
     @ConfigOption(name = "Extra space", desc = "Space between each line of text.")
     @ConfigEditorSlider(minValue = 0f, maxValue = 10f, minStep = 1f)
-    val extraSpace: Property<Int> = Property.of(1)
+    override val extraSpace: Property<Int> = Property.of(1)
 
     @Expose
-    @ConfigOption(name = "Sorted By", desc = "Sorting type of items in the display.")
+    @ConfigOption(name = "Sorted By", desc = "Sorting type of frogs in the display.")
     @ConfigEditorDropdown
-    val sortingType: Property<TrophySorting> = Property.of(TrophySorting.ITEM_RARITY)
-
-    enum class TrophySorting(private val displayName: String) {
-        ITEM_RARITY("Item Rarity"),
-        TOTAL_AMOUNT("Total Amount"),
-        BRONZE_AMOUNT("Bronze Amount"),
-        SILVER_AMOUNT("Silver Amount"),
-        GOLD_AMOUNT("Gold Amount"),
-        DIAMOND_AMOUNT("Diamond Amount"),
-        HIGHEST_RARITY("Highest Rarity"),
-        NAME("Name Alphabetical"),
-        ;
-
-        override fun toString() = displayName
-    }
+    override val sortingType: Property<TrophySorting> = Property.of(TrophySorting.ITEM_RARITY)
 
     @Expose
     @ConfigOption(name = "Reverse Order", desc = "Reverse the sorting order.")
     @ConfigEditorBoolean
-    val reverseOrder: Property<Boolean> = Property.of(false)
+    override val reverseOrder: Property<Boolean> = Property.of(false)
 
     @Expose
     @ConfigOption(name = "Text Order", desc = "Drag text to change the line format.")
     @ConfigEditorDraggableList
-    val textOrder: Property<MutableList<TextPart>> = Property.of(
+    override val textOrder: Property<MutableList<TextPart>> = Property.of(
         mutableListOf(
             TextPart.NAME,
             TextPart.ICON,
@@ -96,44 +78,20 @@ class TrophyFrogDisplayConfig {
         ),
     )
 
-    enum class TextPart(private val displayName: String) {
-        ICON("Frog Icon"),
-        NAME("Frog Name"),
-        BRONZE("Amount Bronze"),
-        SILVER("Amount Silver"),
-        GOLD("Amount Gold"),
-        DIAMOND("Amount Diamond"),
-        TOTAL("Amount Total"),
-        ;
-
-        override fun toString() = displayName
-    }
-
     @Expose
     @ConfigOption(name = "Show ✖", desc = "Instead of the number 0, show §c✖ §7if not found.")
     @ConfigEditorBoolean
-    val showCross: Property<Boolean> = Property.of(false)
+    override val showCross: Property<Boolean> = Property.of(false)
 
     @Expose
     @ConfigOption(name = "Show ✔", desc = "Instead of the exact numbers, show §e§l✔ §7if found.")
     @ConfigEditorBoolean
-    val showCheckmark: Property<Boolean> = Property.of(false)
+    override val showCheckmark: Property<Boolean> = Property.of(false)
 
     @Expose
     @ConfigOption(name = "Only Show Missing", desc = "Only show Trophy Frogs that are still missing at this rarity.")
     @ConfigEditorDropdown
-    val onlyShowMissing: Property<HideCaught> = Property.of(HideCaught.NONE)
-
-    enum class HideCaught(private val displayName: String) {
-        NONE("Show All"),
-        BRONZE("Bronze"),
-        SILVER("Silver"),
-        GOLD("Gold"),
-        DIAMOND("Diamond"),
-        ;
-
-        override fun toString() = displayName
-    }
+    override val onlyShowMissing: Property<HideCaught> = Property.of(HideCaught.NONE)
 
     @Expose
     @ConfigOption(
@@ -141,9 +99,9 @@ class TrophyFrogDisplayConfig {
         desc = "Show Trophy Frogs missing at the chosen tier even if a higher tier has already been caught.",
     )
     @ConfigEditorBoolean
-    val showCaughtHigher: Property<Boolean> = Property.of(false)
+    override val showCaughtHigher: Property<Boolean> = Property.of(false)
 
     @Expose
     @ConfigLink(owner = TrophyFrogDisplayConfig::class, field = "enabled")
-    val position: Position = Position(200, 139)
+    override val position: Position = Position(200, 139)
 }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/fishing/trophyfrog/TrophyFrogDisplayConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/fishing/trophyfrog/TrophyFrogDisplayConfig.kt
@@ -1,0 +1,149 @@
+package at.hannibal2.skyhanni.config.features.fishing.trophyfrog
+
+import at.hannibal2.skyhanni.config.FeatureToggle
+import at.hannibal2.skyhanni.config.core.config.Position
+import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDraggableList
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDropdown
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorKeybind
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider
+import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+import io.github.notenoughupdates.moulconfig.observer.Property
+import org.lwjgl.glfw.GLFW
+
+class TrophyFrogDisplayConfig {
+    @Expose
+    @ConfigOption(name = "Enabled", desc = "Show a display of all trophy frogs ever caught.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    val enabled: Property<Boolean> = Property.of(false)
+
+    @Expose
+    @ConfigOption(name = "When Show", desc = "Change when the trophy frog display should be visible on Lotus Atoll.")
+    @ConfigEditorDropdown
+    val whenToShow: Property<WhenToShow> = Property.of(WhenToShow.ALWAYS)
+
+    enum class WhenToShow(private val displayName: String) {
+        ALWAYS("Always"),
+        ONLY_IN_INVENTORY("In inventory"),
+        ONLY_WITH_KEYBIND("On keybind"),
+        ;
+
+        override fun toString() = displayName
+    }
+
+    @Expose
+    @ConfigOption(name = "Keybind", desc = "")
+    @ConfigEditorKeybind(defaultKey = GLFW.GLFW_KEY_UNKNOWN)
+    var keybind: Int = GLFW.GLFW_KEY_UNKNOWN
+
+    @Expose
+    @ConfigOption(
+        name = "Require Trophy Armor",
+        desc = "Only show when wearing 2+ trophy Hunter armor pieces (any tier).",
+    )
+    @ConfigEditorBoolean
+    val requireArmor: Property<Boolean> = Property.of(true)
+
+    @Expose
+    @ConfigOption(name = "Highlight New", desc = "Highlight new trophies green for couple seconds.")
+    @ConfigEditorBoolean
+    val highlightNew: Property<Boolean> = Property.of(true)
+
+    @Expose
+    @ConfigOption(name = "Extra space", desc = "Space between each line of text.")
+    @ConfigEditorSlider(minValue = 0f, maxValue = 10f, minStep = 1f)
+    val extraSpace: Property<Int> = Property.of(1)
+
+    @Expose
+    @ConfigOption(name = "Sorted By", desc = "Sorting type of items in the display.")
+    @ConfigEditorDropdown
+    val sortingType: Property<TrophySorting> = Property.of(TrophySorting.ITEM_RARITY)
+
+    enum class TrophySorting(private val displayName: String) {
+        ITEM_RARITY("Item Rarity"),
+        TOTAL_AMOUNT("Total Amount"),
+        BRONZE_AMOUNT("Bronze Amount"),
+        SILVER_AMOUNT("Silver Amount"),
+        GOLD_AMOUNT("Gold Amount"),
+        DIAMOND_AMOUNT("Diamond Amount"),
+        HIGHEST_RARITY("Highest Rarity"),
+        NAME("Name Alphabetical"),
+        ;
+
+        override fun toString() = displayName
+    }
+
+    @Expose
+    @ConfigOption(name = "Reverse Order", desc = "Reverse the sorting order.")
+    @ConfigEditorBoolean
+    val reverseOrder: Property<Boolean> = Property.of(false)
+
+    @Expose
+    @ConfigOption(name = "Text Order", desc = "Drag text to change the line format.")
+    @ConfigEditorDraggableList
+    val textOrder: Property<MutableList<TextPart>> = Property.of(
+        mutableListOf(
+            TextPart.NAME,
+            TextPart.ICON,
+            TextPart.TOTAL,
+            TextPart.BRONZE,
+            TextPart.SILVER,
+            TextPart.GOLD,
+            TextPart.DIAMOND,
+        ),
+    )
+
+    enum class TextPart(private val displayName: String) {
+        ICON("Frog Icon"),
+        NAME("Frog Name"),
+        BRONZE("Amount Bronze"),
+        SILVER("Amount Silver"),
+        GOLD("Amount Gold"),
+        DIAMOND("Amount Diamond"),
+        TOTAL("Amount Total"),
+        ;
+
+        override fun toString() = displayName
+    }
+
+    @Expose
+    @ConfigOption(name = "Show ✖", desc = "Instead of the number 0, show §c✖ §7if not found.")
+    @ConfigEditorBoolean
+    val showCross: Property<Boolean> = Property.of(false)
+
+    @Expose
+    @ConfigOption(name = "Show ✔", desc = "Instead of the exact numbers, show §e§l✔ §7if found.")
+    @ConfigEditorBoolean
+    val showCheckmark: Property<Boolean> = Property.of(false)
+
+    @Expose
+    @ConfigOption(name = "Only Show Missing", desc = "Only show Trophy Frogs that are still missing at this rarity.")
+    @ConfigEditorDropdown
+    val onlyShowMissing: Property<HideCaught> = Property.of(HideCaught.NONE)
+
+    enum class HideCaught(private val displayName: String) {
+        NONE("Show All"),
+        BRONZE("Bronze"),
+        SILVER("Silver"),
+        GOLD("Gold"),
+        DIAMOND("Diamond"),
+        ;
+
+        override fun toString() = displayName
+    }
+
+    @Expose
+    @ConfigOption(
+        name = "Show If Caught Higher Tier",
+        desc = "Show Trophy Frogs missing at the chosen tier even if a higher tier has already been caught.",
+    )
+    @ConfigEditorBoolean
+    val showCaughtHigher: Property<Boolean> = Property.of(false)
+
+    @Expose
+    @ConfigLink(owner = TrophyFrogDisplayConfig::class, field = "enabled")
+    val position: Position = Position(200, 139)
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/features/fishing/trophyfrog/TrophyFrogsConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/fishing/trophyfrog/TrophyFrogsConfig.kt
@@ -1,0 +1,25 @@
+package at.hannibal2.skyhanni.config.features.fishing.trophyfrog
+
+import at.hannibal2.skyhanni.config.FeatureToggle
+import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.annotations.Accordion
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+
+class TrophyFrogsConfig {
+    @Expose
+    @ConfigOption(name = "Trophy Frog Chat Messages", desc = "")
+    @Accordion
+    val chatMessages: ChatMessagesConfig = ChatMessagesConfig()
+
+    @Expose
+    @ConfigOption(name = "Trophy Frog Display", desc = "")
+    @Accordion
+    val display: TrophyFrogDisplayConfig = TrophyFrogDisplayConfig()
+
+    @Expose
+    @ConfigOption(name = "Total Caught Tooltip", desc = "Show total Trophy Frogs caught in the Researcher Ribery menu tooltip.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var totalFrogsCaught: Boolean = true
+}

--- a/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/storage/ProfileSpecificStorage.kt
@@ -949,6 +949,21 @@ class ProfileSpecificStorage(
         var reputation: MutableMap<FactionType, Int> = mutableMapOf()
     }
 
+    // - lotus atoll
+    @Expose
+    var lotusAtoll: LotusAtollStorage = LotusAtollStorage()
+
+    class LotusAtollStorage {
+        // keyed by the clean (colourless) frog name, e.g. "Common Frog". Icon/name/rarity come from
+        // the NEU item (e.g. COMMON_FROG_BRONZE); only the cumulative counts live here.
+        @Expose
+        var trophyFrogs: MutableMap<String, MutableMap<TrophyRarity, Int>> = mutableMapOf()
+
+        // clean frog name -> "How to Catch" description, populated from Researcher Ribery's menu
+        @Expose
+        var trophyFrogDescriptions: MutableMap<String, String> = mutableMapOf()
+    }
+
     // - rift
     @Expose
     var rift: RiftStorage = RiftStorage()

--- a/src/main/java/at/hannibal2/skyhanni/events/fishing/TrophyFrogCaughtEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/fishing/TrophyFrogCaughtEvent.kt
@@ -1,0 +1,14 @@
+package at.hannibal2.skyhanni.events.fishing
+
+import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+import at.hannibal2.skyhanni.features.fishing.trophy.TrophyRarity
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
+
+/**
+ * Fired when the player catches a trophy frog.
+ *
+ * @param trophyFrogName The clean (colourless) display name of the caught trophy frog, e.g. "Common Frog".
+ * @param rarity The rarity of the caught trophy frog.
+ */
+@PrimaryFunction("onTrophyFrogCaught")
+class TrophyFrogCaughtEvent(val trophyFrogName: String, val rarity: TrophyRarity) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingApi.kt
@@ -374,6 +374,10 @@ object FishingApi {
             .eachCount()
             .any { (_, count) -> count >= 2 }
 
+    // Unlike isWearingTrophyArmor(), this counts pieces across all tiers (mixed tiers allowed).
+    fun isWearingAnyTrophyArmor(): Boolean =
+        InventoryUtils.getArmor().count { trophyArmorNames.matches(it?.getInternalName()?.asString()) } >= 2
+
     fun isWearingEmberArmor(): Boolean =
         InventoryUtils.getArmor().all {
             emberArmorNames.matches(it?.getInternalName()?.asString())

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/OdgerTotalCaught.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/OdgerTotalCaught.kt
@@ -3,14 +3,11 @@ package at.hannibal2.skyhanni.features.fishing.trophy
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.minecraft.ToolTipTextEvent
-import at.hannibal2.skyhanni.events.minecraft.add
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ItemUtils.cleanName
-import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 
 @SkyHanniModule
-object OdgerTotalCaught {
+object OdgerTotalCaught : TrophyTotalCaught() {
 
     private val config get() = SkyHanniMod.feature.fishing.trophyFishing
 
@@ -19,7 +16,7 @@ object OdgerTotalCaught {
     /**
      * REGEX-TEST: Discovered
      */
-    private val discoveredPattern by patternGroup.pattern(
+    override val discoveredPattern by patternGroup.pattern(
         "discovered.new",
         "Discovered",
     )
@@ -27,33 +24,20 @@ object OdgerTotalCaught {
     /**
      * REGEX-TEST: Bronze ✖
      * REGEX-TEST: Bronze ✔ (4)
-     * REGEX-TEST: Bronze ✔ (4)
      */
-    private val bronzePattern by patternGroup.pattern(
+    override val bronzePattern by patternGroup.pattern(
         "bronze.new",
         "^Bronze.*",
     )
 
+    override fun isInInventory() = TrophyFishManager.odgerInventory.isInside()
+    override fun isEnabled() = config.totalFishCaught
+    override fun countsFor(cleanName: String) =
+        TrophyFishManager.fish?.get(TrophyFishApi.getInternalName(cleanName))
+
     // Not island-gated because Odger has an Abiphone contact
     @HandleEvent(onlyOnSkyblock = true)
-    fun onToolTipEvent(event: ToolTipTextEvent) {
-        if (!TrophyFishManager.odgerInventory.isInside()) return
-        if (!config.totalFishCaught) return
-
-        if (event.toolTip.none { discoveredPattern.matcher(it.string).find() }) return
-
-        val trophyFishKey = TrophyFishApi.getInternalName(event.itemStack.cleanName)
-
-        val counts = TrophyFishManager.fish?.get(trophyFishKey) ?: return
-        val bestFishObtained = counts.filter { it.value > 0 }.keys.maxOrNull() ?: TrophyRarity.BRONZE
-        val bronzeLineIndex = event.toolTip.indexOfFirst { bronzePattern.matcher(it.string).find() }
-
-        if (bronzeLineIndex > 0) {
-            event.toolTip.add(bronzeLineIndex + 1, "")
-            event.toolTip.add(
-                bronzeLineIndex + 2,
-                "§7Total: ${bestFishObtained.formatCode}${counts.values.sum().addSeparators()}",
-            )
-        }
+    private fun onToolTipEvent(event: ToolTipTextEvent) {
+        handleToolTip(event)
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/TrophyCollectionDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/TrophyCollectionDisplay.kt
@@ -1,0 +1,277 @@
+package at.hannibal2.skyhanni.features.fishing.trophy
+
+import at.hannibal2.skyhanni.config.features.fishing.trophy.TrophyCollectionDisplayConfig
+import at.hannibal2.skyhanni.config.features.fishing.trophy.TrophyCollectionDisplayConfig.HideCaught
+import at.hannibal2.skyhanni.config.features.fishing.trophy.TrophyCollectionDisplayConfig.TextPart
+import at.hannibal2.skyhanni.config.features.fishing.trophy.TrophyCollectionDisplayConfig.TrophySorting
+import at.hannibal2.skyhanni.config.features.fishing.trophy.TrophyCollectionDisplayConfig.WhenToShow
+import at.hannibal2.skyhanni.features.misc.items.EstimatedItemValue
+import at.hannibal2.skyhanni.utils.ConditionalUtils
+import at.hannibal2.skyhanni.utils.DelayedRun
+import at.hannibal2.skyhanni.utils.InventoryUtils
+import at.hannibal2.skyhanni.utils.ItemUtils.getItemRarityOrNull
+import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
+import at.hannibal2.skyhanni.utils.NeuInternalName
+import at.hannibal2.skyhanni.utils.NeuItems.getItemStack
+import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
+import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sumAllValues
+import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addSingleString
+import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
+import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
+import at.hannibal2.skyhanni.utils.compat.InventoryGuiScaleCompat
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
+import at.hannibal2.skyhanni.utils.renderables.Renderable
+import at.hannibal2.skyhanni.utils.renderables.container.table.TableRenderable.Companion.table
+import at.hannibal2.skyhanni.utils.renderables.primitives.ItemStackRenderable.Companion.item
+import at.hannibal2.skyhanni.utils.renderables.primitives.text
+import net.minecraft.client.gui.screens.inventory.InventoryScreen
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Generic on-screen collection display shared by Trophy Fish and Trophy Frogs. Subclasses are the
+ * [at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule] objects that hold the event handlers and
+ * provide the collection-specific details below.
+ */
+@Suppress("TooManyFunctions")
+abstract class TrophyCollectionDisplay {
+
+    protected abstract val config: TrophyCollectionDisplayConfig
+
+    /** The saved counts, keyed by the same raw name used by [getInternalName]/[getDisplayName]. */
+    protected abstract val data: Map<String, MutableMap<TrophyRarity, Int>>?
+
+    protected abstract val header: String
+    protected abstract val posLabel: String
+    protected abstract val collectionName: String
+    protected abstract val dataSourceName: String
+
+    protected abstract fun getInternalName(rawName: String): NeuInternalName
+    protected abstract fun getDisplayName(rawName: String): String
+    protected abstract fun hoverInfo(rawName: String): String?
+    protected abstract fun isOnIsland(): Boolean
+    protected abstract fun holdingRod(): Boolean
+
+    /** Whether the required trophy gear is worn. Only checked when [config].requireArmor is on. */
+    protected abstract fun passesGearCheck(): Boolean
+
+    /** Extra always-on render guard (e.g. hide while a treasure hook is active). */
+    protected open fun canRenderExtra(): Boolean = true
+
+    private val recentlyDropped = TimeLimitedCache<String, TrophyRarity>(5.seconds)
+    private var display = emptyList<Renderable>()
+
+    private fun markRecentlyDropped(rawName: String, rarity: TrophyRarity) {
+        recentlyDropped[rawName] = rarity
+    }
+
+    /** Call from the island-join handler: rebuilds shortly after joining, once data has loaded. */
+    protected fun delayedIslandJoinUpdate() {
+        DelayedRun.runDelayed(200.milliseconds) {
+            update()
+        }
+    }
+
+    /** Call from the trophy-caught handler: highlights the catch and rebuilds now and after the highlight expires. */
+    protected fun onCaught(rawName: String, rarity: TrophyRarity) {
+        markRecentlyDropped(rawName, rarity)
+        update()
+        DelayedRun.runDelayed(5.1.seconds) {
+            update()
+        }
+    }
+
+    /** Call from the profile-join handler: drops the stale display before rebuilding for the new profile. */
+    protected fun resetAndUpdate() {
+        display = emptyList()
+        update()
+    }
+
+    /** Hook run before every rebuild (e.g. to backfill missing entries). */
+    protected open fun beforeUpdate() {}
+
+    fun update() {
+        beforeUpdate()
+        if (!isEnabled()) return
+        val list = mutableListOf<Renderable>()
+        list.addString(header)
+        list.add(Renderable.table(createTable(), ySpacing = config.extraSpace.get()))
+        display = list
+    }
+
+    private fun createTable(): List<List<Renderable>> {
+        val entries = data ?: return emptyList()
+        val table = mutableListOf<List<Renderable>>()
+
+        if (entries.isEmpty()) {
+            table.addSingleString("§cNo Trophy data found!")
+            table.addSingleString("§eTalk to $dataSourceName to load the data!")
+            return table
+        }
+
+        for ((rawName, counts) in getOrder(entries)) {
+            addRow(rawName, counts, table)
+        }
+        if (table.isNotEmpty()) return table
+
+        get(config.onlyShowMissing.get())?.let { rarity ->
+            val name = rarity.formattedString
+            table.addSingleString("§eYou caught all $name $collectionName")
+            if (rarity != TrophyRarity.DIAMOND) {
+                table.addSingleString("§cChange §eOnly Show Missing §cin the config to show more.")
+            }
+        }
+        return table
+    }
+
+    private fun addRow(
+        rawName: String,
+        data: MutableMap<TrophyRarity, Int>,
+        table: MutableList<List<Renderable>>,
+    ) {
+        get(config.onlyShowMissing.get())?.let { atLeast ->
+            val list = TrophyRarity.entries.filter { it == atLeast || (!config.showCaughtHigher.get() && it > atLeast) }
+            if (list.any { (data[it] ?: 0) > 0 }) {
+                return
+            }
+        }
+
+        val hover = hoverInfo(rawName)
+        fun string(string: String): Renderable = hover?.let {
+            Renderable.hoverTips(
+                Renderable.text(string),
+                tips = it.split("\n"),
+            )
+        } ?: Renderable.text(string)
+
+        val row = mutableMapOf<TextPart, Renderable>()
+        row[TextPart.NAME] = string(getDisplayName(rawName))
+        row[TextPart.ICON] = Renderable.item(getInternalName(rawName))
+
+        val recentlyDroppedRarity = recentlyDropped[rawName]?.takeIf { config.highlightNew.get() }
+
+        for (rarity in TrophyRarity.entries) {
+            val amount = data[rarity] ?: 0
+            val recentlyDropped = rarity == recentlyDroppedRarity
+            val format = if (config.showCross.get() && amount == 0) "§c✖" else {
+                val color = if (recentlyDropped) "§a" else rarity.formatCode
+                val numberFormat = if (config.showCheckmark.get() && amount >= 1) "§l✔" else amount.addSeparators()
+                "$color$numberFormat"
+            }
+            row[get(rarity)] = string(format)
+        }
+        val total = data.sumAllValues()
+        val color = if (recentlyDroppedRarity != null) "§a" else "§5"
+        row[TextPart.TOTAL] = string("$color${total.addSeparators()}")
+
+        table.add(config.textOrder.get().mapNotNull { row[it] })
+    }
+
+    private fun get(value: TrophyRarity) = when (value) {
+        TrophyRarity.BRONZE -> TextPart.BRONZE
+        TrophyRarity.SILVER -> TextPart.SILVER
+        TrophyRarity.GOLD -> TextPart.GOLD
+        TrophyRarity.DIAMOND -> TextPart.DIAMOND
+    }
+
+    private fun get(value: HideCaught) = when (value) {
+        HideCaught.NONE -> null
+        HideCaught.BRONZE -> TrophyRarity.BRONZE
+        HideCaught.SILVER -> TrophyRarity.SILVER
+        HideCaught.GOLD -> TrophyRarity.GOLD
+        HideCaught.DIAMOND -> TrophyRarity.DIAMOND
+    }
+
+    private fun getOrder(entries: Map<String, MutableMap<TrophyRarity, Int>>) = sort(entries).let {
+        if (config.reverseOrder.get()) it.reversed() else it
+    }
+
+    private fun sort(entries: Map<String, MutableMap<TrophyRarity, Int>>): List<Map.Entry<String, MutableMap<TrophyRarity, Int>>> =
+        when (config.sortingType.get()!!) {
+            TrophySorting.TOTAL_AMOUNT -> entries.entries.sortedBy { it.value.sumAllValues() }
+
+            TrophySorting.BRONZE_AMOUNT -> count(entries, TrophyRarity.BRONZE)
+            TrophySorting.SILVER_AMOUNT -> count(entries, TrophyRarity.SILVER)
+            TrophySorting.GOLD_AMOUNT -> count(entries, TrophyRarity.GOLD)
+            TrophySorting.DIAMOND_AMOUNT -> count(entries, TrophyRarity.DIAMOND)
+
+            TrophySorting.ITEM_RARITY -> {
+                entries.entries.sortedBy { data ->
+                    getInternalName(data.key).getItemStack().getItemRarityOrNull()
+                }
+            }
+
+            TrophySorting.HIGHEST_RARITY -> {
+                entries.entries.sortedBy { data ->
+                    TrophyRarity.entries.filter {
+                        data.value.contains(it)
+                    }.maxByOrNull { it.ordinal }
+                }
+            }
+
+            TrophySorting.NAME -> {
+                entries.entries.sortedBy { data ->
+                    getDisplayName(data.key).removeColor()
+                }
+            }
+        }
+
+    private fun count(
+        entries: Map<String, MutableMap<TrophyRarity, Int>>, rarity: TrophyRarity,
+    ) = entries.entries.sortedBy { it.value[rarity] ?: 0 }
+
+    protected fun render() {
+        if (InventoryUtils.inAnyInventory()) {
+            InventoryGuiScaleCompat.withOriginalHudScale {
+                renderDisplay()
+            }
+        } else {
+            renderDisplay()
+        }
+    }
+
+    private fun renderDisplay() {
+        if (!isEnabled() || !canRender()) return
+        if (EstimatedItemValue.isCurrentlyShowing()) return
+        if (!canRenderExtra()) return
+        if (config.requireArmor.get() && !passesGearCheck()) return
+
+        config.position.renderRenderables(
+            display,
+            extraSpace = config.extraSpace.get(),
+            posLabel = posLabel,
+        )
+    }
+
+    private fun canRender(): Boolean = when (config.whenToShow.get()!!) {
+        WhenToShow.ALWAYS -> true
+        WhenToShow.ONLY_IN_INVENTORY -> MinecraftCompat.screen is InventoryScreen
+        WhenToShow.ONLY_WITH_ROD_IN_HAND -> holdingRod()
+        WhenToShow.ONLY_WITH_KEYBIND -> config.keybind.isKeyHeld()
+    }
+
+    /** Registers config listeners; call from the subclass's onConfigLoad handler. */
+    protected fun watchConfig() {
+        with(config) {
+            ConditionalUtils.onToggle(
+                enabled,
+                highlightNew,
+                extraSpace,
+                sortingType,
+                reverseOrder,
+                textOrder,
+                showCross,
+                showCheckmark,
+                onlyShowMissing,
+                showCaughtHigher,
+                requireArmor,
+            ) {
+                update()
+            }
+        }
+    }
+
+    private fun isEnabled() = isOnIsland() && config.enabled.get()
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/TrophyFishDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/TrophyFishDisplay.kt
@@ -3,249 +3,47 @@ package at.hannibal2.skyhanni.features.fishing.trophy
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
-import at.hannibal2.skyhanni.config.features.fishing.trophyfishing.TrophyFishDisplayConfig.HideCaught
-import at.hannibal2.skyhanni.config.features.fishing.trophyfishing.TrophyFishDisplayConfig.TextPart
-import at.hannibal2.skyhanni.config.features.fishing.trophyfishing.TrophyFishDisplayConfig.TrophySorting
-import at.hannibal2.skyhanni.config.features.fishing.trophyfishing.TrophyFishDisplayConfig.WhenToShow
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.fishing.TrophyFishCaughtEvent
 import at.hannibal2.skyhanni.features.fishing.FishingApi
-import at.hannibal2.skyhanni.features.misc.items.EstimatedItemValue
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
-import at.hannibal2.skyhanni.utils.ConditionalUtils
-import at.hannibal2.skyhanni.utils.DelayedRun
-import at.hannibal2.skyhanni.utils.InventoryUtils
-import at.hannibal2.skyhanni.utils.ItemUtils.getItemRarityOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.repoItemName
-import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NeuItems
-import at.hannibal2.skyhanni.utils.NeuItems.getItemStack
-import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
-import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
-import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sumAllValues
-import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addSingleString
-import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
-import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
-import at.hannibal2.skyhanni.utils.compat.InventoryGuiScaleCompat
-import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
-import at.hannibal2.skyhanni.utils.renderables.Renderable
-import at.hannibal2.skyhanni.utils.renderables.container.table.TableRenderable.Companion.table
-import at.hannibal2.skyhanni.utils.renderables.primitives.ItemStackRenderable.Companion.item
-import at.hannibal2.skyhanni.utils.renderables.primitives.text
-import net.minecraft.client.gui.screens.inventory.InventoryScreen
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
-object TrophyFishDisplay {
-    private val config get() = SkyHanniMod.feature.fishing.trophyFishing.display
+object TrophyFishDisplay : TrophyCollectionDisplay() {
+    override val config get() = SkyHanniMod.feature.fishing.trophyFishing.display
+    override val data get() = TrophyFishManager.fish
+    override val header = "§e§lTrophy Fish Display"
+    override val posLabel = "Trophy Fishing Display"
+    override val collectionName = "Trophy Fish"
+    override val dataSourceName = "Odger"
 
-    private val recentlyDroppedTrophies = TimeLimitedCache<NeuInternalName, TrophyRarity>(5.seconds)
     private val itemNameCache = mutableMapOf<String, NeuInternalName>()
 
-    private var display = emptyList<Renderable>()
-
-    @HandleEvent(onlyOnIsland = CRIMSON_ISLE)
-    fun onIslandJoin() {
-        DelayedRun.runDelayed(200.milliseconds) {
-            TrophyFishManager.loadMissingTrophyFish()
-            update()
-        }
-    }
-
-    @HandleEvent
-    fun onTrophyFishCaught(event: TrophyFishCaughtEvent) {
-        TrophyFishManager.loadMissingTrophyFish()
-        recentlyDroppedTrophies[getInternalName(event.trophyFishName)] = event.rarity
-        update()
-        DelayedRun.runDelayed(5.1.seconds) {
-            update()
-        }
-    }
-
-    @HandleEvent
-    fun onProfileJoin() {
-        display = emptyList()
-        TrophyFishManager.loadMissingTrophyFish()
-        update()
-    }
-
-    @HandleEvent
-    fun onConfigLoad() {
-        with(config) {
-            ConditionalUtils.onToggle(
-                enabled,
-                highlightNew,
-                extraSpace,
-                sortingType,
-                reverseOrder,
-                textOrder,
-                showCross,
-                showCheckmark,
-                onlyShowMissing,
-                showCaughtHigher,
-                requireArmor,
-            ) {
-                TrophyFishManager.loadMissingTrophyFish()
-                update()
-            }
-        }
-    }
-
-    fun update() {
-        if (!isEnabled()) return
-        val list = mutableListOf<Renderable>()
-        list.addString("§e§lTrophy Fish Display")
-        list.add(Renderable.table(createTable(), ySpacing = config.extraSpace.get()))
-        display = list
-    }
-
-    private fun createTable(): List<List<Renderable>> {
-        val trophyFishes = TrophyFishManager.fish ?: return emptyList()
-        val table = mutableListOf<List<Renderable>>()
-
-        if (trophyFishes.isEmpty()) {
-            table.addSingleString("§cNo Trophy data found!")
-            table.addSingleString("§eTalk to Odger to load the data!")
-            return table
-        }
-
-        for ((rawName, data) in getOrder(trophyFishes)) {
-            addRow(rawName, data, table)
-        }
-        if (table.isNotEmpty()) return table
-
-        get(config.onlyShowMissing.get())?.let { rarity ->
-            val name = rarity.formattedString
-            table.addSingleString("§eYou caught all $name Trophy Fishes")
-            if (rarity != TrophyRarity.DIAMOND) {
-                table.addSingleString("§cChange §eOnly Show Missing §cin the config to show more.")
-            }
-        }
-        return table
-    }
-
-    private fun addRow(
-        rawName: String,
-        data: MutableMap<TrophyRarity, Int>,
-        table: MutableList<List<Renderable>>,
-    ) {
-        get(config.onlyShowMissing.get())?.let { atLeast ->
-            val list = TrophyRarity.entries.filter { it == atLeast || (!config.showCaughtHigher.get() && it > atLeast) }
-            if (list.any { (data[it] ?: 0) > 0 }) {
-                return
-            }
-        }
-        val hover = TrophyFishApi.hoverInfo(rawName)
-        fun string(string: String): Renderable = hover?.let {
-            Renderable.hoverTips(
-                Renderable.text(string),
-                tips = it.split("\n"),
-            )
-        } ?: Renderable.text(string)
-
-        val row = mutableMapOf<TextPart, Renderable>()
-        row[TextPart.NAME] = string(getItemName(rawName))
-
-        val internalName = getInternalName(rawName)
-        row[TextPart.ICON] = Renderable.item(internalName)
-
-        val recentlyDroppedRarity = recentlyDroppedTrophies[internalName]?.takeIf { config.highlightNew.get() }
-
-        for (rarity in TrophyRarity.entries) {
-            val amount = data[rarity] ?: 0
-            val recentlyDropped = rarity == recentlyDroppedRarity
-            val format = if (config.showCross.get() && amount == 0) "§c✖" else {
-                val color = if (recentlyDropped) "§a" else rarity.formatCode
-                val numberFormat = if (config.showCheckmark.get() && amount >= 1) "§l✔" else amount.addSeparators()
-                "$color$numberFormat"
-            }
-            row[get(rarity)] = string(format)
-        }
-        val total = data.sumAllValues()
-        val color = if (recentlyDroppedRarity != null) "§a" else "§5"
-        row[TextPart.TOTAL] = string("$color${total.addSeparators()}")
-
-        table.add(config.textOrder.get().mapNotNull { row[it] })
-    }
-
-    private fun get(value: TrophyRarity) = when (value) {
-        TrophyRarity.BRONZE -> TextPart.BRONZE
-        TrophyRarity.SILVER -> TextPart.SILVER
-        TrophyRarity.GOLD -> TextPart.GOLD
-        TrophyRarity.DIAMOND -> TextPart.DIAMOND
-    }
-
-    private fun get(value: HideCaught) = when (value) {
-        HideCaught.NONE -> null
-        HideCaught.BRONZE -> TrophyRarity.BRONZE
-        HideCaught.SILVER -> TrophyRarity.SILVER
-        HideCaught.GOLD -> TrophyRarity.GOLD
-        HideCaught.DIAMOND -> TrophyRarity.DIAMOND
-    }
-
-    private fun getOrder(trophyFishes: Map<String, MutableMap<TrophyRarity, Int>>) = sort(trophyFishes).let {
-        if (config.reverseOrder.get()) it.reversed() else it
-    }
-
-    private fun sort(trophyFishes: Map<String, MutableMap<TrophyRarity, Int>>): List<Map.Entry<String, MutableMap<TrophyRarity, Int>>> =
-        when (config.sortingType.get()!!) {
-            TrophySorting.TOTAL_AMOUNT -> trophyFishes.entries.sortedBy { it.value.sumAllValues() }
-
-            TrophySorting.BRONZE_AMOUNT -> count(trophyFishes, TrophyRarity.BRONZE)
-            TrophySorting.SILVER_AMOUNT -> count(trophyFishes, TrophyRarity.SILVER)
-            TrophySorting.GOLD_AMOUNT -> count(trophyFishes, TrophyRarity.GOLD)
-            TrophySorting.DIAMOND_AMOUNT -> count(trophyFishes, TrophyRarity.DIAMOND)
-
-            TrophySorting.ITEM_RARITY -> {
-                trophyFishes.entries.sortedBy { data ->
-                    val name = getInternalName(data.key)
-                    name.getItemStack().getItemRarityOrNull()
-                }
-            }
-
-            TrophySorting.HIGHEST_RARITY -> {
-                trophyFishes.entries.sortedBy { data ->
-                    TrophyRarity.entries.filter {
-                        data.value.contains(it)
-                    }.maxByOrNull { it.ordinal }
-                }
-            }
-
-            TrophySorting.NAME -> {
-                trophyFishes.entries.sortedBy { data ->
-                    getItemName(data.key).removeColor()
-                }
-            }
-        }
-
-    private fun count(
-        trophyFishes: Map<String, MutableMap<TrophyRarity, Int>>, rarity: TrophyRarity,
-    ) = trophyFishes.entries.sortedBy { it.value[rarity] ?: 0 }
-
-    private fun getItemName(rawName: String): String {
+    override fun getDisplayName(rawName: String): String {
         val name = getInternalName(rawName).repoItemName
         return name.split(" ").dropLast(1).joinToString(" ")
     }
 
-    private fun getInternalName(name: String): NeuInternalName {
-        itemNameCache[name]?.let {
+    override fun getInternalName(rawName: String): NeuInternalName {
+        itemNameCache[rawName]?.let {
             return it
         }
         // getOrPut does not support our null check
-        readInternalName(name)?.let {
-            itemNameCache[name] = it
+        readInternalName(rawName)?.let {
+            itemNameCache[rawName] = it
             return it
         }
 
         ErrorManager.skyHanniError(
             "No Trophy Fishing name found",
-            "name" to name,
+            "name" to rawName,
         )
     }
 
@@ -263,43 +61,42 @@ object TrophyFishDisplay {
         return null
     }
 
-    @HandleEvent
-    fun onGuiRenderTop() {
-        if (InventoryUtils.inAnyInventory()) {
-            InventoryGuiScaleCompat.withOriginalHudScale {
-                renderDisplay()
-            }
-        } else {
-            renderDisplay()
-        }
+    override fun hoverInfo(rawName: String) = TrophyFishApi.hoverInfo(rawName)
+    override fun isOnIsland() = IslandType.CRIMSON_ISLE.isInIsland() || SkyBlockUtils.isStrandedProfile
+    override fun holdingRod() = FishingApi.holdingLavaRod
+    override fun passesGearCheck() = FishingApi.isTrophyFishing()
+    override fun canRenderExtra() = !FishingApi.hasTreasureHook
+    override fun beforeUpdate() {
+        TrophyFishManager.loadMissingTrophyFish()
     }
 
-    private fun renderDisplay() {
-        if (!isEnabled() || !canRender()) return
-        if (EstimatedItemValue.isCurrentlyShowing()) return
-        if (FishingApi.hasTreasureHook) return
-        if (config.requireArmor.get()) {
-            if (!FishingApi.isTrophyFishing()) return
-        }
-
-        config.position.renderRenderables(
-            display,
-            extraSpace = config.extraSpace.get(),
-            posLabel = "Trophy Fishing Display",
-        )
+    @HandleEvent(onlyOnIsland = CRIMSON_ISLE)
+    private fun onIslandJoin() {
+        delayedIslandJoinUpdate()
     }
-
-    private fun canRender(): Boolean = when (config.whenToShow.get()!!) {
-        WhenToShow.ALWAYS -> true
-        WhenToShow.ONLY_IN_INVENTORY -> MinecraftCompat.screen is InventoryScreen
-        WhenToShow.ONLY_WITH_ROD_IN_HAND -> FishingApi.holdingLavaRod
-        WhenToShow.ONLY_WITH_KEYBIND -> config.keybind.isKeyHeld()
-    }
-
-    private fun isEnabled() = (IslandType.CRIMSON_ISLE.isInIsland() || SkyBlockUtils.isStrandedProfile) && config.enabled.get()
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onTrophyFishCaught(event: TrophyFishCaughtEvent) {
+        onCaught(event.trophyFishName, event.rarity)
+    }
+
+    @HandleEvent
+    private fun onProfileJoin() {
+        resetAndUpdate()
+    }
+
+    @HandleEvent
+    private fun onConfigLoad() {
+        watchConfig()
+    }
+
+    @HandleEvent
+    private fun onGuiRenderTop() {
+        render()
+    }
+
+    @HandleEvent
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         val base = "fishing.trophyFishing.display"
         event.move(94, "$base.requireHunterArmor", "$base.requireArmor")
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/TrophyTotalCaught.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/TrophyTotalCaught.kt
@@ -1,0 +1,40 @@
+package at.hannibal2.skyhanni.features.fishing.trophy
+
+import at.hannibal2.skyhanni.events.minecraft.ToolTipTextEvent
+import at.hannibal2.skyhanni.events.minecraft.add
+import at.hannibal2.skyhanni.utils.ItemUtils.cleanName
+import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
+import java.util.regex.Pattern
+
+/**
+ * Adds a "Total: X" line (coloured by highest rarity obtained) to a trophy item's tooltip inside its
+ * NPC menu, which Hypixel omits. Shared by Trophy Fish (Odger) and Trophy Frogs (Researcher Ribery).
+ */
+abstract class TrophyTotalCaught {
+
+    protected abstract val discoveredPattern: Pattern
+    protected abstract val bronzePattern: Pattern
+
+    protected abstract fun isInInventory(): Boolean
+    protected abstract fun isEnabled(): Boolean
+    protected abstract fun countsFor(cleanName: String): Map<TrophyRarity, Int>?
+
+    protected fun handleToolTip(event: ToolTipTextEvent) {
+        if (!isInInventory()) return
+        if (!isEnabled()) return
+
+        if (event.toolTip.none { discoveredPattern.matcher(it.string).find() }) return
+
+        val counts = countsFor(event.itemStack.cleanName) ?: return
+        val bestObtained = counts.filter { it.value > 0 }.keys.maxOrNull() ?: TrophyRarity.BRONZE
+        val bronzeLineIndex = event.toolTip.indexOfFirst { bronzePattern.matcher(it.string).find() }
+
+        if (bronzeLineIndex > 0) {
+            event.toolTip.add(bronzeLineIndex + 1, "")
+            event.toolTip.add(
+                bronzeLineIndex + 2,
+                "§7Total: ${bestObtained.formatCode}${counts.values.sum().addSeparators()}",
+            )
+        }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophyfrog/RiberyTotalCaught.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophyfrog/RiberyTotalCaught.kt
@@ -1,0 +1,56 @@
+package at.hannibal2.skyhanni.features.fishing.trophyfrog
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.events.minecraft.ToolTipTextEvent
+import at.hannibal2.skyhanni.events.minecraft.add
+import at.hannibal2.skyhanni.features.fishing.trophy.TrophyRarity
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ItemUtils.cleanName
+import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+
+@SkyHanniModule
+object RiberyTotalCaught {
+
+    private val config get() = SkyHanniMod.feature.fishing.trophyFrogs
+
+    private val patternGroup = RepoPattern.group("fishing.trophy.ribery")
+
+    /**
+     * REGEX-TEST: Discovered
+     */
+    private val discoveredPattern by patternGroup.pattern(
+        "discovered",
+        "Discovered",
+    )
+
+    /**
+     * REGEX-TEST: Bronze ✔ (615)
+     * REGEX-TEST: Bronze ✖
+     */
+    private val bronzePattern by patternGroup.pattern(
+        "bronze",
+        "^Bronze.*",
+    )
+
+    @HandleEvent(onlyOnSkyblock = true)
+    private fun onToolTipEvent(event: ToolTipTextEvent) {
+        if (!TrophyFrogManager.riberyInventory.isInside()) return
+        if (!config.totalFrogsCaught) return
+
+        if (event.toolTip.none { discoveredPattern.matcher(it.string).find() }) return
+
+        val counts = TrophyFrogManager.frog?.get(event.itemStack.cleanName) ?: return
+        val bestObtained = counts.filter { it.value > 0 }.keys.maxOrNull() ?: TrophyRarity.BRONZE
+        val bronzeLineIndex = event.toolTip.indexOfFirst { bronzePattern.matcher(it.string).find() }
+
+        if (bronzeLineIndex > 0) {
+            event.toolTip.add(bronzeLineIndex + 1, "")
+            event.toolTip.add(
+                bronzeLineIndex + 2,
+                "§7Total: ${bestObtained.formatCode}${counts.values.sum().addSeparators()}",
+            )
+        }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophyfrog/RiberyTotalCaught.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophyfrog/RiberyTotalCaught.kt
@@ -3,15 +3,12 @@ package at.hannibal2.skyhanni.features.fishing.trophyfrog
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.events.minecraft.ToolTipTextEvent
-import at.hannibal2.skyhanni.events.minecraft.add
-import at.hannibal2.skyhanni.features.fishing.trophy.TrophyRarity
+import at.hannibal2.skyhanni.features.fishing.trophy.TrophyTotalCaught
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ItemUtils.cleanName
-import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 
 @SkyHanniModule
-object RiberyTotalCaught {
+object RiberyTotalCaught : TrophyTotalCaught() {
 
     private val config get() = SkyHanniMod.feature.fishing.trophyFrogs
 
@@ -20,7 +17,7 @@ object RiberyTotalCaught {
     /**
      * REGEX-TEST: Discovered
      */
-    private val discoveredPattern by patternGroup.pattern(
+    override val discoveredPattern by patternGroup.pattern(
         "discovered",
         "Discovered",
     )
@@ -29,28 +26,17 @@ object RiberyTotalCaught {
      * REGEX-TEST: Bronze ✔ (615)
      * REGEX-TEST: Bronze ✖
      */
-    private val bronzePattern by patternGroup.pattern(
+    override val bronzePattern by patternGroup.pattern(
         "bronze",
         "^Bronze.*",
     )
 
+    override fun isInInventory() = TrophyFrogManager.riberyInventory.isInside()
+    override fun isEnabled() = config.totalFrogsCaught
+    override fun countsFor(cleanName: String) = TrophyFrogManager.frog?.get(cleanName)
+
     @HandleEvent(onlyOnSkyblock = true)
     private fun onToolTipEvent(event: ToolTipTextEvent) {
-        if (!TrophyFrogManager.riberyInventory.isInside()) return
-        if (!config.totalFrogsCaught) return
-
-        if (event.toolTip.none { discoveredPattern.matcher(it.string).find() }) return
-
-        val counts = TrophyFrogManager.frog?.get(event.itemStack.cleanName) ?: return
-        val bestObtained = counts.filter { it.value > 0 }.keys.maxOrNull() ?: TrophyRarity.BRONZE
-        val bronzeLineIndex = event.toolTip.indexOfFirst { bronzePattern.matcher(it.string).find() }
-
-        if (bronzeLineIndex > 0) {
-            event.toolTip.add(bronzeLineIndex + 1, "")
-            event.toolTip.add(
-                bronzeLineIndex + 2,
-                "§7Total: ${bestObtained.formatCode}${counts.values.sum().addSeparators()}",
-            )
-        }
+        handleToolTip(event)
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophyfrog/TrophyFrogApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophyfrog/TrophyFrogApi.kt
@@ -1,0 +1,38 @@
+package at.hannibal2.skyhanni.features.fishing.trophyfrog
+
+import at.hannibal2.skyhanni.features.fishing.trophy.TrophyRarity
+import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
+import at.hannibal2.skyhanni.utils.StringUtils.splitLines
+import at.hannibal2.skyhanni.utils.compat.defaultStyleConstructor
+import at.hannibal2.skyhanni.utils.compat.setHoverShowText
+import net.minecraft.network.chat.Style
+
+object TrophyFrogApi {
+
+    fun hoverInfo(rawName: String): String? {
+        val counts = TrophyFrogManager.frog?.get(rawName) ?: return null
+        val coloredName = TrophyFrogManager.getDisplayName(rawName)
+        val bestObtained = counts.filter { it.value > 0 }.keys.maxOrNull() ?: TrophyRarity.BRONZE
+
+        val lines = mutableListOf(coloredName)
+        TrophyFrogManager.frogDescriptions?.get(rawName)?.let { lines.add("§7${it.splitLines(150)}") }
+        lines.add("")
+        lines.add("${TrophyRarity.DIAMOND.formattedString}: ${formatCount(counts, TrophyRarity.DIAMOND)}")
+        lines.add("${TrophyRarity.GOLD.formattedString}: ${formatCount(counts, TrophyRarity.GOLD)}")
+        lines.add("${TrophyRarity.SILVER.formattedString}: ${formatCount(counts, TrophyRarity.SILVER)}")
+        lines.add("${TrophyRarity.BRONZE.formattedString}: ${formatCount(counts, TrophyRarity.BRONZE)}")
+        lines.add("")
+        lines.add("§7Total: ${bestObtained.formatCode}${counts.values.sum().addSeparators()}")
+        return lines.joinToString("\n")
+    }
+
+    fun getTooltip(rawName: String): Style? {
+        val display = hoverInfo(rawName) ?: return null
+        return defaultStyleConstructor.setHoverShowText(display)
+    }
+
+    private fun formatCount(counts: Map<TrophyRarity, Int>, rarity: TrophyRarity): String {
+        val count = counts.getOrDefault(rarity, 0)
+        return if (count > 0) "§6${count.addSeparators()}" else "§c✖"
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophyfrog/TrophyFrogDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophyfrog/TrophyFrogDisplay.kt
@@ -2,247 +2,50 @@ package at.hannibal2.skyhanni.features.fishing.trophyfrog
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.config.features.fishing.trophyfrog.TrophyFrogDisplayConfig.HideCaught
-import at.hannibal2.skyhanni.config.features.fishing.trophyfrog.TrophyFrogDisplayConfig.TextPart
-import at.hannibal2.skyhanni.config.features.fishing.trophyfrog.TrophyFrogDisplayConfig.TrophySorting
-import at.hannibal2.skyhanni.config.features.fishing.trophyfrog.TrophyFrogDisplayConfig.WhenToShow
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.fishing.TrophyFrogCaughtEvent
 import at.hannibal2.skyhanni.features.fishing.FishingApi
-import at.hannibal2.skyhanni.features.fishing.trophy.TrophyRarity
-import at.hannibal2.skyhanni.features.misc.items.EstimatedItemValue
+import at.hannibal2.skyhanni.features.fishing.trophy.TrophyCollectionDisplay
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ConditionalUtils
-import at.hannibal2.skyhanni.utils.DelayedRun
-import at.hannibal2.skyhanni.utils.InventoryUtils
-import at.hannibal2.skyhanni.utils.ItemUtils.getItemRarityOrNull
-import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
-import at.hannibal2.skyhanni.utils.NeuItems.getItemStack
-import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
-import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
-import at.hannibal2.skyhanni.utils.StringUtils.removeColor
-import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sumAllValues
-import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addSingleString
-import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
-import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
-import at.hannibal2.skyhanni.utils.compat.InventoryGuiScaleCompat
-import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
-import at.hannibal2.skyhanni.utils.renderables.Renderable
-import at.hannibal2.skyhanni.utils.renderables.container.table.TableRenderable.Companion.table
-import at.hannibal2.skyhanni.utils.renderables.primitives.ItemStackRenderable.Companion.item
-import at.hannibal2.skyhanni.utils.renderables.primitives.text
-import net.minecraft.client.gui.screens.inventory.InventoryScreen
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
-object TrophyFrogDisplay {
-    private val config get() = SkyHanniMod.feature.fishing.trophyFrogs.display
+object TrophyFrogDisplay : TrophyCollectionDisplay() {
+    override val config get() = SkyHanniMod.feature.fishing.trophyFrogs.display
+    override val data get() = TrophyFrogManager.frog
+    override val header = "§e§lTrophy Frog Display"
+    override val posLabel = "Trophy Frog Display"
+    override val collectionName = "Trophy Frogs"
+    override val dataSourceName = "Researcher Ribery"
 
-    private val recentlyDroppedFrogs = TimeLimitedCache<String, TrophyRarity>(5.seconds)
-
-    private var display = emptyList<Renderable>()
+    override fun getInternalName(rawName: String) = TrophyFrogManager.getInternalName(rawName)
+    override fun getDisplayName(rawName: String) = TrophyFrogManager.getDisplayName(rawName)
+    override fun hoverInfo(rawName: String) = TrophyFrogApi.hoverInfo(rawName)
+    override fun isOnIsland() = IslandType.LOTUS_ATOLL.isInIsland()
+    override fun holdingRod() = FishingApi.holdingWaterRod
+    override fun passesGearCheck() = FishingApi.isWearingAnyTrophyArmor()
 
     @HandleEvent(onlyOnIsland = LOTUS_ATOLL)
     private fun onIslandJoin() {
-        DelayedRun.runDelayed(200.milliseconds) {
-            update()
-        }
+        delayedIslandJoinUpdate()
     }
 
     @HandleEvent
     private fun onTrophyFrogCaught(event: TrophyFrogCaughtEvent) {
-        recentlyDroppedFrogs[event.trophyFrogName] = event.rarity
-        update()
-        DelayedRun.runDelayed(5.1.seconds) {
-            update()
-        }
+        onCaught(event.trophyFrogName, event.rarity)
     }
 
     @HandleEvent
     private fun onProfileJoin() {
-        display = emptyList()
-        update()
+        resetAndUpdate()
     }
 
     @HandleEvent
     private fun onConfigLoad() {
-        with(config) {
-            ConditionalUtils.onToggle(
-                enabled,
-                highlightNew,
-                extraSpace,
-                sortingType,
-                reverseOrder,
-                textOrder,
-                showCross,
-                showCheckmark,
-                onlyShowMissing,
-                showCaughtHigher,
-                requireArmor,
-            ) {
-                update()
-            }
-        }
+        watchConfig()
     }
-
-    fun update() {
-        if (!isEnabled()) return
-        val list = mutableListOf<Renderable>()
-        list.addString("§e§lTrophy Frog Display")
-        list.add(Renderable.table(createTable(), ySpacing = config.extraSpace.get()))
-        display = list
-    }
-
-    private fun createTable(): List<List<Renderable>> {
-        val trophyFrogs = TrophyFrogManager.frog ?: return emptyList()
-        val table = mutableListOf<List<Renderable>>()
-
-        if (trophyFrogs.isEmpty()) {
-            table.addSingleString("§cNo Trophy data found!")
-            table.addSingleString("§eTalk to Researcher Ribery to load the data!")
-            return table
-        }
-
-        for ((rawName, data) in getOrder(trophyFrogs)) {
-            addRow(rawName, data, table)
-        }
-        if (table.isNotEmpty()) return table
-
-        get(config.onlyShowMissing.get())?.let { rarity ->
-            val name = rarity.formattedString
-            table.addSingleString("§eYou caught all $name Trophy Frogs")
-            if (rarity != TrophyRarity.DIAMOND) {
-                table.addSingleString("§cChange §eOnly Show Missing §cin the config to show more.")
-            }
-        }
-        return table
-    }
-
-    private fun addRow(
-        rawName: String,
-        data: MutableMap<TrophyRarity, Int>,
-        table: MutableList<List<Renderable>>,
-    ) {
-        get(config.onlyShowMissing.get())?.let { atLeast ->
-            val list = TrophyRarity.entries.filter { it == atLeast || (!config.showCaughtHigher.get() && it > atLeast) }
-            if (list.any { (data[it] ?: 0) > 0 }) {
-                return
-            }
-        }
-
-        val hover = TrophyFrogApi.hoverInfo(rawName)
-        fun string(string: String): Renderable = hover?.let {
-            Renderable.hoverTips(
-                Renderable.text(string),
-                tips = it.split("\n"),
-            )
-        } ?: Renderable.text(string)
-
-        val row = mutableMapOf<TextPart, Renderable>()
-        row[TextPart.NAME] = string(TrophyFrogManager.getDisplayName(rawName))
-        row[TextPart.ICON] = Renderable.item(TrophyFrogManager.getInternalName(rawName))
-
-        val recentlyDroppedRarity = recentlyDroppedFrogs[rawName]?.takeIf { config.highlightNew.get() }
-
-        for (rarity in TrophyRarity.entries) {
-            val amount = data[rarity] ?: 0
-            val recentlyDropped = rarity == recentlyDroppedRarity
-            val format = if (config.showCross.get() && amount == 0) "§c✖" else {
-                val color = if (recentlyDropped) "§a" else rarity.formatCode
-                val numberFormat = if (config.showCheckmark.get() && amount >= 1) "§l✔" else amount.addSeparators()
-                "$color$numberFormat"
-            }
-            row[get(rarity)] = string(format)
-        }
-        val total = data.sumAllValues()
-        val color = if (recentlyDroppedRarity != null) "§a" else "§5"
-        row[TextPart.TOTAL] = string("$color${total.addSeparators()}")
-
-        table.add(config.textOrder.get().mapNotNull { row[it] })
-    }
-
-    private fun get(value: TrophyRarity) = when (value) {
-        TrophyRarity.BRONZE -> TextPart.BRONZE
-        TrophyRarity.SILVER -> TextPart.SILVER
-        TrophyRarity.GOLD -> TextPart.GOLD
-        TrophyRarity.DIAMOND -> TextPart.DIAMOND
-    }
-
-    private fun get(value: HideCaught) = when (value) {
-        HideCaught.NONE -> null
-        HideCaught.BRONZE -> TrophyRarity.BRONZE
-        HideCaught.SILVER -> TrophyRarity.SILVER
-        HideCaught.GOLD -> TrophyRarity.GOLD
-        HideCaught.DIAMOND -> TrophyRarity.DIAMOND
-    }
-
-    private fun getOrder(trophyFrogs: Map<String, MutableMap<TrophyRarity, Int>>) = sort(trophyFrogs).let {
-        if (config.reverseOrder.get()) it.reversed() else it
-    }
-
-    private fun sort(trophyFrogs: Map<String, MutableMap<TrophyRarity, Int>>): List<Map.Entry<String, MutableMap<TrophyRarity, Int>>> =
-        when (config.sortingType.get()!!) {
-            TrophySorting.TOTAL_AMOUNT -> trophyFrogs.entries.sortedBy { it.value.sumAllValues() }
-
-            TrophySorting.BRONZE_AMOUNT -> count(trophyFrogs, TrophyRarity.BRONZE)
-            TrophySorting.SILVER_AMOUNT -> count(trophyFrogs, TrophyRarity.SILVER)
-            TrophySorting.GOLD_AMOUNT -> count(trophyFrogs, TrophyRarity.GOLD)
-            TrophySorting.DIAMOND_AMOUNT -> count(trophyFrogs, TrophyRarity.DIAMOND)
-
-            TrophySorting.ITEM_RARITY -> {
-                trophyFrogs.entries.sortedBy { data ->
-                    TrophyFrogManager.getInternalName(data.key).getItemStack().getItemRarityOrNull()
-                }
-            }
-
-            TrophySorting.HIGHEST_RARITY -> {
-                trophyFrogs.entries.sortedBy { data ->
-                    TrophyRarity.entries.filter {
-                        data.value.contains(it)
-                    }.maxByOrNull { it.ordinal }
-                }
-            }
-
-            TrophySorting.NAME -> {
-                trophyFrogs.entries.sortedBy { data ->
-                    TrophyFrogManager.getDisplayName(data.key).removeColor()
-                }
-            }
-        }
-
-    private fun count(
-        trophyFrogs: Map<String, MutableMap<TrophyRarity, Int>>, rarity: TrophyRarity,
-    ) = trophyFrogs.entries.sortedBy { it.value[rarity] ?: 0 }
 
     @HandleEvent
     private fun onGuiRenderTop() {
-        if (InventoryUtils.inAnyInventory()) {
-            InventoryGuiScaleCompat.withOriginalHudScale {
-                renderDisplay()
-            }
-        } else {
-            renderDisplay()
-        }
+        render()
     }
-
-    private fun renderDisplay() {
-        if (!isEnabled() || !canRender()) return
-        if (EstimatedItemValue.isCurrentlyShowing()) return
-        if (config.requireArmor.get() && !FishingApi.isWearingAnyTrophyArmor()) return
-
-        config.position.renderRenderables(
-            display,
-            extraSpace = config.extraSpace.get(),
-            posLabel = "Trophy Frog Display",
-        )
-    }
-
-    private fun canRender(): Boolean = when (config.whenToShow.get()!!) {
-        WhenToShow.ALWAYS -> true
-        WhenToShow.ONLY_IN_INVENTORY -> MinecraftCompat.screen is InventoryScreen
-        WhenToShow.ONLY_WITH_KEYBIND -> config.keybind.isKeyHeld()
-    }
-
-    private fun isEnabled() = IslandType.LOTUS_ATOLL.isInIsland() && config.enabled.get()
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophyfrog/TrophyFrogDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophyfrog/TrophyFrogDisplay.kt
@@ -1,0 +1,248 @@
+package at.hannibal2.skyhanni.features.fishing.trophyfrog
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.features.fishing.trophyfrog.TrophyFrogDisplayConfig.HideCaught
+import at.hannibal2.skyhanni.config.features.fishing.trophyfrog.TrophyFrogDisplayConfig.TextPart
+import at.hannibal2.skyhanni.config.features.fishing.trophyfrog.TrophyFrogDisplayConfig.TrophySorting
+import at.hannibal2.skyhanni.config.features.fishing.trophyfrog.TrophyFrogDisplayConfig.WhenToShow
+import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.events.fishing.TrophyFrogCaughtEvent
+import at.hannibal2.skyhanni.features.fishing.FishingApi
+import at.hannibal2.skyhanni.features.fishing.trophy.TrophyRarity
+import at.hannibal2.skyhanni.features.misc.items.EstimatedItemValue
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ConditionalUtils
+import at.hannibal2.skyhanni.utils.DelayedRun
+import at.hannibal2.skyhanni.utils.InventoryUtils
+import at.hannibal2.skyhanni.utils.ItemUtils.getItemRarityOrNull
+import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
+import at.hannibal2.skyhanni.utils.NeuItems.getItemStack
+import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
+import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderables
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sumAllValues
+import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addSingleString
+import at.hannibal2.skyhanni.utils.collection.RenderableCollectionUtils.addString
+import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
+import at.hannibal2.skyhanni.utils.compat.InventoryGuiScaleCompat
+import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
+import at.hannibal2.skyhanni.utils.renderables.Renderable
+import at.hannibal2.skyhanni.utils.renderables.container.table.TableRenderable.Companion.table
+import at.hannibal2.skyhanni.utils.renderables.primitives.ItemStackRenderable.Companion.item
+import at.hannibal2.skyhanni.utils.renderables.primitives.text
+import net.minecraft.client.gui.screens.inventory.InventoryScreen
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+@SkyHanniModule
+object TrophyFrogDisplay {
+    private val config get() = SkyHanniMod.feature.fishing.trophyFrogs.display
+
+    private val recentlyDroppedFrogs = TimeLimitedCache<String, TrophyRarity>(5.seconds)
+
+    private var display = emptyList<Renderable>()
+
+    @HandleEvent(onlyOnIsland = LOTUS_ATOLL)
+    private fun onIslandJoin() {
+        DelayedRun.runDelayed(200.milliseconds) {
+            update()
+        }
+    }
+
+    @HandleEvent
+    private fun onTrophyFrogCaught(event: TrophyFrogCaughtEvent) {
+        recentlyDroppedFrogs[event.trophyFrogName] = event.rarity
+        update()
+        DelayedRun.runDelayed(5.1.seconds) {
+            update()
+        }
+    }
+
+    @HandleEvent
+    private fun onProfileJoin() {
+        display = emptyList()
+        update()
+    }
+
+    @HandleEvent
+    private fun onConfigLoad() {
+        with(config) {
+            ConditionalUtils.onToggle(
+                enabled,
+                highlightNew,
+                extraSpace,
+                sortingType,
+                reverseOrder,
+                textOrder,
+                showCross,
+                showCheckmark,
+                onlyShowMissing,
+                showCaughtHigher,
+                requireArmor,
+            ) {
+                update()
+            }
+        }
+    }
+
+    fun update() {
+        if (!isEnabled()) return
+        val list = mutableListOf<Renderable>()
+        list.addString("§e§lTrophy Frog Display")
+        list.add(Renderable.table(createTable(), ySpacing = config.extraSpace.get()))
+        display = list
+    }
+
+    private fun createTable(): List<List<Renderable>> {
+        val trophyFrogs = TrophyFrogManager.frog ?: return emptyList()
+        val table = mutableListOf<List<Renderable>>()
+
+        if (trophyFrogs.isEmpty()) {
+            table.addSingleString("§cNo Trophy data found!")
+            table.addSingleString("§eTalk to Researcher Ribery to load the data!")
+            return table
+        }
+
+        for ((rawName, data) in getOrder(trophyFrogs)) {
+            addRow(rawName, data, table)
+        }
+        if (table.isNotEmpty()) return table
+
+        get(config.onlyShowMissing.get())?.let { rarity ->
+            val name = rarity.formattedString
+            table.addSingleString("§eYou caught all $name Trophy Frogs")
+            if (rarity != TrophyRarity.DIAMOND) {
+                table.addSingleString("§cChange §eOnly Show Missing §cin the config to show more.")
+            }
+        }
+        return table
+    }
+
+    private fun addRow(
+        rawName: String,
+        data: MutableMap<TrophyRarity, Int>,
+        table: MutableList<List<Renderable>>,
+    ) {
+        get(config.onlyShowMissing.get())?.let { atLeast ->
+            val list = TrophyRarity.entries.filter { it == atLeast || (!config.showCaughtHigher.get() && it > atLeast) }
+            if (list.any { (data[it] ?: 0) > 0 }) {
+                return
+            }
+        }
+
+        val hover = TrophyFrogApi.hoverInfo(rawName)
+        fun string(string: String): Renderable = hover?.let {
+            Renderable.hoverTips(
+                Renderable.text(string),
+                tips = it.split("\n"),
+            )
+        } ?: Renderable.text(string)
+
+        val row = mutableMapOf<TextPart, Renderable>()
+        row[TextPart.NAME] = string(TrophyFrogManager.getDisplayName(rawName))
+        row[TextPart.ICON] = Renderable.item(TrophyFrogManager.getInternalName(rawName))
+
+        val recentlyDroppedRarity = recentlyDroppedFrogs[rawName]?.takeIf { config.highlightNew.get() }
+
+        for (rarity in TrophyRarity.entries) {
+            val amount = data[rarity] ?: 0
+            val recentlyDropped = rarity == recentlyDroppedRarity
+            val format = if (config.showCross.get() && amount == 0) "§c✖" else {
+                val color = if (recentlyDropped) "§a" else rarity.formatCode
+                val numberFormat = if (config.showCheckmark.get() && amount >= 1) "§l✔" else amount.addSeparators()
+                "$color$numberFormat"
+            }
+            row[get(rarity)] = string(format)
+        }
+        val total = data.sumAllValues()
+        val color = if (recentlyDroppedRarity != null) "§a" else "§5"
+        row[TextPart.TOTAL] = string("$color${total.addSeparators()}")
+
+        table.add(config.textOrder.get().mapNotNull { row[it] })
+    }
+
+    private fun get(value: TrophyRarity) = when (value) {
+        TrophyRarity.BRONZE -> TextPart.BRONZE
+        TrophyRarity.SILVER -> TextPart.SILVER
+        TrophyRarity.GOLD -> TextPart.GOLD
+        TrophyRarity.DIAMOND -> TextPart.DIAMOND
+    }
+
+    private fun get(value: HideCaught) = when (value) {
+        HideCaught.NONE -> null
+        HideCaught.BRONZE -> TrophyRarity.BRONZE
+        HideCaught.SILVER -> TrophyRarity.SILVER
+        HideCaught.GOLD -> TrophyRarity.GOLD
+        HideCaught.DIAMOND -> TrophyRarity.DIAMOND
+    }
+
+    private fun getOrder(trophyFrogs: Map<String, MutableMap<TrophyRarity, Int>>) = sort(trophyFrogs).let {
+        if (config.reverseOrder.get()) it.reversed() else it
+    }
+
+    private fun sort(trophyFrogs: Map<String, MutableMap<TrophyRarity, Int>>): List<Map.Entry<String, MutableMap<TrophyRarity, Int>>> =
+        when (config.sortingType.get()!!) {
+            TrophySorting.TOTAL_AMOUNT -> trophyFrogs.entries.sortedBy { it.value.sumAllValues() }
+
+            TrophySorting.BRONZE_AMOUNT -> count(trophyFrogs, TrophyRarity.BRONZE)
+            TrophySorting.SILVER_AMOUNT -> count(trophyFrogs, TrophyRarity.SILVER)
+            TrophySorting.GOLD_AMOUNT -> count(trophyFrogs, TrophyRarity.GOLD)
+            TrophySorting.DIAMOND_AMOUNT -> count(trophyFrogs, TrophyRarity.DIAMOND)
+
+            TrophySorting.ITEM_RARITY -> {
+                trophyFrogs.entries.sortedBy { data ->
+                    TrophyFrogManager.getInternalName(data.key).getItemStack().getItemRarityOrNull()
+                }
+            }
+
+            TrophySorting.HIGHEST_RARITY -> {
+                trophyFrogs.entries.sortedBy { data ->
+                    TrophyRarity.entries.filter {
+                        data.value.contains(it)
+                    }.maxByOrNull { it.ordinal }
+                }
+            }
+
+            TrophySorting.NAME -> {
+                trophyFrogs.entries.sortedBy { data ->
+                    TrophyFrogManager.getDisplayName(data.key).removeColor()
+                }
+            }
+        }
+
+    private fun count(
+        trophyFrogs: Map<String, MutableMap<TrophyRarity, Int>>, rarity: TrophyRarity,
+    ) = trophyFrogs.entries.sortedBy { it.value[rarity] ?: 0 }
+
+    @HandleEvent
+    private fun onGuiRenderTop() {
+        if (InventoryUtils.inAnyInventory()) {
+            InventoryGuiScaleCompat.withOriginalHudScale {
+                renderDisplay()
+            }
+        } else {
+            renderDisplay()
+        }
+    }
+
+    private fun renderDisplay() {
+        if (!isEnabled() || !canRender()) return
+        if (EstimatedItemValue.isCurrentlyShowing()) return
+        if (config.requireArmor.get() && !FishingApi.isWearingAnyTrophyArmor()) return
+
+        config.position.renderRenderables(
+            display,
+            extraSpace = config.extraSpace.get(),
+            posLabel = "Trophy Frog Display",
+        )
+    }
+
+    private fun canRender(): Boolean = when (config.whenToShow.get()!!) {
+        WhenToShow.ALWAYS -> true
+        WhenToShow.ONLY_IN_INVENTORY -> MinecraftCompat.screen is InventoryScreen
+        WhenToShow.ONLY_WITH_KEYBIND -> config.keybind.isKeyHeld()
+    }
+
+    private fun isEnabled() = IslandType.LOTUS_ATOLL.isInIsland() && config.enabled.get()
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophyfrog/TrophyFrogManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophyfrog/TrophyFrogManager.kt
@@ -1,0 +1,136 @@
+package at.hannibal2.skyhanni.features.fishing.trophyfrog
+
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.ProfileStorageData
+import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
+import at.hannibal2.skyhanni.features.fishing.trophy.TrophyRarity
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.test.command.ErrorManager
+import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.InventoryDetector
+import at.hannibal2.skyhanni.utils.ItemUtils.cleanName
+import at.hannibal2.skyhanni.utils.ItemUtils.getCleanLore
+import at.hannibal2.skyhanni.utils.ItemUtils.repoItemName
+import at.hannibal2.skyhanni.utils.NeuInternalName
+import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
+import at.hannibal2.skyhanni.utils.NumberUtil.formatInt
+import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+
+@SkyHanniModule
+object TrophyFrogManager {
+
+    private val patternGroup = RepoPattern.group("fishing.trophyfrog")
+
+    /**
+     * REGEX-TEST: Diamond ✔ (2)
+     * REGEX-TEST: Bronze ✔ (615)
+     */
+    private val riberyRankPattern by patternGroup.pattern(
+        "ribery.rank.colorless",
+        "(?: +)?(?<rarity>.*) ✔ \\((?<amount>.*)\\)",
+    )
+
+    /**
+     * REGEX-TEST: Diamond ✖
+     * REGEX-TEST: Gold ✖
+     */
+    private val riberyRankEmptyPattern by patternGroup.pattern(
+        "ribery.rank.empty.colorless",
+        "(?: +)?(?<rarity>.*) ✖",
+    )
+
+    /**
+     * REGEX-TEST: Trophy Frogs
+     */
+    private val riberyInventoryNamePattern by patternGroup.pattern(
+        "ribery.inventory",
+        "Trophy Frogs",
+    )
+
+    val riberyInventory = InventoryDetector { riberyInventoryNamePattern }
+
+    /**
+     * REGEX-TEST: How to Catch
+     */
+    private val howToCatchPattern by patternGroup.pattern(
+        "ribery.howtocatch",
+        "How to Catch",
+    )
+
+    // keyed by the clean frog name, e.g. "Common Frog"
+    val frog: MutableMap<String, MutableMap<TrophyRarity, Int>>?
+        get() = ProfileStorageData.profileSpecific?.lotusAtoll?.trophyFrogs
+
+    val frogDescriptions: MutableMap<String, String>?
+        get() = ProfileStorageData.profileSpecific?.lotusAtoll?.trophyFrogDescriptions
+
+    // Frogs are real NEU items (e.g. COMMON_FROG_BRONZE), so icon/name/rarity come from the repo.
+    // Bronze always exists and shares the frog's item rarity across all trophy tiers.
+    fun getInternalName(rawName: String): NeuInternalName =
+        "${rawName.uppercase().replace(" ", "_")}_BRONZE".toInternalName()
+
+    fun getDisplayName(rawName: String): String =
+        getInternalName(rawName).repoItemName.split(" ").dropLast(1).joinToString(" ")
+
+    // Fetch when talking with Researcher Ribery
+    @HandleEvent(onlyOnSkyblock = true)
+    private fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
+        if (!riberyInventoryNamePattern.matches(event.inventoryName)) return
+
+        val savedFrogs = frog ?: return
+        val savedDescriptions = frogDescriptions ?: return
+        var updatedFrogs = 0
+
+        for (stack in event.inventoryItems.values) {
+            val cleanName = stack.cleanName
+            val lore = stack.getCleanLore()
+
+            fun getRarity(rawRarity: String, line: String): TrophyRarity =
+                TrophyRarity.getByName(rawRarity) ?: ErrorManager.skyHanniError(
+                    "unknown trophy frog rarity in Ribery inventory",
+                    "rawRarity" to rawRarity,
+                    "line" to line,
+                    "stack.name" to cleanName,
+                )
+
+            val parsed = mutableMapOf<TrophyRarity, Int>()
+            for (line in lore) {
+                val (rarity, amount) = riberyRankPattern.matchMatcher(line) {
+                    getRarity(group("rarity"), line) to group("amount").formatInt()
+                } ?: riberyRankEmptyPattern.matchMatcher(line) {
+                    getRarity(group("rarity"), line) to 0
+                } ?: continue
+                parsed[rarity] = amount
+            }
+            // not a frog item (empty slot, filler, decoration)
+            if (parsed.isEmpty()) continue
+
+            readDescription(lore)?.let { savedDescriptions[cleanName] = it }
+
+            val counts = savedFrogs.getOrPut(cleanName) { mutableMapOf() }
+            var updated = false
+            for ((rarity, amount) in parsed) {
+                if (counts[rarity] != amount) {
+                    counts[rarity] = amount
+                    updated = true
+                }
+            }
+            if (updated) updatedFrogs++
+        }
+
+        if (updatedFrogs > 0) {
+            ChatUtils.chat("Updated $updatedFrogs Trophy Frogs from Researcher Ribery.")
+        }
+        TrophyFrogDisplay.update()
+    }
+
+    // Grabs the "How to Catch" description: the lines after that header until the next blank line.
+    private fun readDescription(lore: List<String>): String? {
+        val start = lore.indexOfFirst { howToCatchPattern.matches(it.trim()) }
+        if (start == -1) return null
+        val lines = lore.drop(start + 1).takeWhile { it.isNotBlank() }.map { it.trim() }
+        return lines.joinToString(" ").ifBlank { null }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophyfrog/TrophyFrogMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophyfrog/TrophyFrogMessages.kt
@@ -1,0 +1,122 @@
+package at.hannibal2.skyhanni.features.fishing.trophyfrog
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.features.fishing.trophyfrog.ChatMessagesConfig.DesignFormat
+import at.hannibal2.skyhanni.data.title.TitleManager
+import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
+import at.hannibal2.skyhanni.events.fishing.TrophyFrogCaughtEvent
+import at.hannibal2.skyhanni.features.fishing.trophy.TrophyRarity
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
+import at.hannibal2.skyhanni.utils.NumberUtil.ordinal
+import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.SoundUtils
+import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
+import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut
+import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sumAllValues
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+
+@SkyHanniModule
+object TrophyFrogMessages {
+    private val config get() = SkyHanniMod.feature.fishing.trophyFrogs.chatMessages
+
+    // Leading run only allows colour codes and non-word symbols/glyphs, never player-chat text, so a
+    // player typing a fake "TROPHY FROG!" line (with their [rank] name: prefix) can't be counted.
+    // TODO: verify the exact catch-message format in-game; overridable via the repo without a code change.
+    /**
+     * REGEX-TEST: TROPHY FROG! You caught a Common Frog BRONZE!
+     * REGEX-TEST: §2§lTROPHY FROG! §r§fYou caught a §r§9Common Frog §r§8§lBRONZE§r§f!
+     */
+    @Suppress("MaxLineLength")
+    private val trophyFrogPattern by RepoPattern.pattern(
+        "fishing.trophy.trophyfrog",
+        "(?:§.|\\W)*?TROPHY FROG! (?:§.)*You caught an? (?:§.)*(?<displayName>[\\w -]+?) (?:§.)*(?<displayRarity>BRONZE|SILVER|GOLD|DIAMOND)(?:§.)*!",
+    )
+
+    @HandleEvent(onlyOnSkyblock = true)
+    private fun onChat(event: SkyHanniChatEvent.Allow) {
+        val (displayName, displayRarity) = trophyFrogPattern.matchMatcher(event.message) {
+            group("displayName") to group("displayRarity")
+        } ?: return
+
+        val name = displayName.removeColor()
+        val rarity = TrophyRarity.getByName(displayRarity.lowercase().removeColor()) ?: return
+
+        val trophyFrogs = TrophyFrogManager.frog ?: return
+        val counts = trophyFrogs.getOrPut(name) { mutableMapOf() }
+        val amount = counts.addOrPut(rarity, 1)
+        TrophyFrogCaughtEvent(name, rarity).post()
+
+        if (shouldBlock(rarity, amount)) {
+            event.blockedReason = "low_trophy_frog"
+            return
+        }
+
+        if (config.duplicateHider) event.chatLineId = (name + rarity).hashCode()
+    }
+
+    @HandleEvent(onlyOnSkyblock = true)
+    private fun onChat(event: SkyHanniChatEvent.Modify) {
+        val (displayName, displayRarity) = trophyFrogPattern.matchMatcher(event.message) {
+            group("displayName") to group("displayRarity")
+        } ?: return
+
+        val name = displayName.removeColor()
+        val rarity = TrophyRarity.getByName(displayRarity.lowercase().removeColor()) ?: return
+
+        val trophyFrogs = TrophyFrogManager.frog ?: return
+        val counts = trophyFrogs.getOrPut(name) { mutableMapOf() }
+        val amount = counts[rarity] ?: 1
+
+        val coloredName = TrophyFrogManager.getDisplayName(name)
+        val rarityDisplay = "${rarity.formatCode}§l${rarity.name}"
+
+        if (config.goldAlert && rarity == TrophyRarity.GOLD) {
+            sendTitle(coloredName, rarityDisplay, amount)
+            if (config.playSound) SoundUtils.playBeepSound()
+        }
+
+        if (config.diamondAlert && rarity == TrophyRarity.DIAMOND) {
+            sendTitle(coloredName, rarityDisplay, amount)
+            if (config.playSound) SoundUtils.playBeepSound()
+        }
+
+        val edited = if (config.enabled) {
+            val designFormat = when (config.design) {
+                DesignFormat.STYLE_1 -> if (amount == 1) "§c§lFIRST §r$rarityDisplay $coloredName"
+                else "§7$amount${amount.ordinal()} §r$rarityDisplay $coloredName"
+
+                DesignFormat.STYLE_2 -> "§bYou caught a $coloredName $rarityDisplay§b. §7(${amount.addSeparators()})"
+                else -> "§bYou caught your ${amount.addSeparators()}${amount.ordinal()} $rarityDisplay $coloredName§b."
+            }
+            "§2§lTROPHY FROG! $designFormat".asComponent()
+        } else event.chatComponent.copy()
+
+        if (config.totalAmount) {
+            val total = counts.sumAllValues()
+            edited.append(" §7(${total.addSeparators()}${total.ordinal()} total)")
+        }
+
+        if (config.tooltip) {
+            TrophyFrogApi.getTooltip(name)?.let {
+                edited.toFlatList(it)
+            }
+        }
+
+        event.replaceComponent(edited, "TROPHY_FROG")
+    }
+
+    private fun sendTitle(displayName: String, displayRarity: String, amount: Int) {
+        TitleManager.sendTitle("$displayName $displayRarity §8$amount§c!")
+    }
+
+    private fun shouldBlock(rarity: TrophyRarity, amount: Int) =
+        config.bronzeHider &&
+            rarity == TrophyRarity.BRONZE &&
+            amount != 1 ||
+            config.silverHider &&
+            rarity == TrophyRarity.SILVER &&
+            amount != 1
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophyfrog/TrophyFrogMessages.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophyfrog/TrophyFrogMessages.kt
@@ -32,7 +32,7 @@ object TrophyFrogMessages {
     @Suppress("MaxLineLength")
     private val trophyFrogPattern by RepoPattern.pattern(
         "fishing.trophy.trophyfrog",
-        "(?:§.|\\W)*?TROPHY FROG! (?:§.)*You caught an? (?:§.)*(?<displayName>[\\w -]+?) (?:§.)*(?<displayRarity>BRONZE|SILVER|GOLD|DIAMOND)(?:§.)*!",
+        "(?<prefix>(?:§.|\\W)*?)TROPHY FROG! (?:§.)*You caught an? (?:§.)*(?<displayName>[\\w -]+?) (?:§.)*(?<displayRarity>BRONZE|SILVER|GOLD|DIAMOND)(?:§.)*!",
     )
 
     @HandleEvent(onlyOnSkyblock = true)
@@ -59,8 +59,8 @@ object TrophyFrogMessages {
 
     @HandleEvent(onlyOnSkyblock = true)
     private fun onChat(event: SkyHanniChatEvent.Modify) {
-        val (displayName, displayRarity) = trophyFrogPattern.matchMatcher(event.message) {
-            group("displayName") to group("displayRarity")
+        val (prefix, displayName, displayRarity) = trophyFrogPattern.matchMatcher(event.message) {
+            Triple(group("prefix"), group("displayName"), group("displayRarity"))
         } ?: return
 
         val name = displayName.removeColor()
@@ -91,7 +91,7 @@ object TrophyFrogMessages {
                 DesignFormat.STYLE_2 -> "§bYou caught a $coloredName $rarityDisplay§b. §7(${amount.addSeparators()})"
                 else -> "§bYou caught your ${amount.addSeparators()}${amount.ordinal()} $rarityDisplay $coloredName§b."
             }
-            "§2§lTROPHY FROG! $designFormat".asComponent()
+            "${prefix}TROPHY FROG! §r$designFormat".asComponent()
         } else event.chatComponent.copy()
 
         if (config.totalAmount) {


### PR DESCRIPTION
## What
Adds Trophy Frogs support for Lotus Atoll, similar to the existing Trophy Fish features. It tracks how many of each frog you've caught at every rarity, shown in an on-screen display, in chat when you catch one. It also adds a total-caught line to each frog's tooltip in the Researcher Ribery menu, which Hypixel doesn't show by default.

Since Trophy Frogs and Trophy Fish work almost the same way, the shared logic now lives in common base classes that both features build on, keeping the code in one place.

<details>
<summary>Images</summary>

Trophy Frog display:
<img width="297" height="257" alt="Trophy Frog Display" src="https://github.com/user-attachments/assets/694620b3-718f-4665-8988-02afe696c196" />

Catch message before and after (via `/shchathistory`):
<img width="965" height="40" alt="HEY TEXT" src="https://github.com/user-attachments/assets/e228cf7b-8b3f-4a05-a9f9-abe06549e968" />

Frog tooltip showing the total caught:
<img width="237" height="291" alt="Leap Frog" src="https://github.com/user-attachments/assets/e21936be-456d-454b-ac76-688fe614f3f7" />

</details>

## Changelog New Features
+ Added a Trophy Frog display showing how many of each frog you have caught. - RemainingDelta
+ Added a counter and rare-catch alerts to Trophy Frog catch messages. - RemainingDelta
+ Added the total amount caught to the Researcher Ribery menu tooltip. - RemainingDelta

## Changelog Technical Details
+ Deduplicated the Trophy Fish and Trophy Frog display and menu-tooltip logic into shared base classes. - RemainingDelta