### PR TITLE
Fix: Error when clicking fast in the HotM and HotF trees

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/OtherInventoryData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/OtherInventoryData.kt
@@ -30,24 +30,26 @@ object OtherInventoryData {
         get() = currentInventory?.title.orEmpty()
 
     @HandleEvent
-    fun onCloseWindow(event: GuiContainerEvent.CloseWindowEvent) {
+    private fun onCloseWindow(event: GuiContainerEvent.CloseWindowEvent) {
         close()
     }
 
     @HandleEvent
-    fun onPacketSent(event: PacketSentEvent) {
+    private fun onPacketSent(event: PacketSentEvent) {
         if (event.packet is ServerboundContainerClosePacket) {
             close()
         }
     }
 
     fun close(title: String = currentInventoryName, reopenSameName: Boolean = false) {
+        // handlers reset their state on the close event, a queued update would arrive after that
+        lateEvent = null
         InventoryCloseEvent(title, reopenSameName).post()
         currentInventory = null
     }
 
     @HandleEvent
-    fun onTick() {
+    private fun onTick() {
         lateEvent?.let {
             it.post()
             lateEvent = null
@@ -83,7 +85,7 @@ object OtherInventoryData {
     )
 
     @HandleEvent
-    fun onInventoryDataReceiveEvent(event: PacketReceivedEvent) {
+    private fun onInventoryDataReceiveEvent(event: PacketReceivedEvent) {
         val packet = event.packet
 
         if (packet is ClientboundContainerClosePacket) {

--- a/src/main/java/at/hannibal2/skyhanni/events/InventoryFullyOpenedEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/InventoryFullyOpenedEvent.kt
@@ -62,6 +62,9 @@ class InventoryFullyOpenedEvent(inventory: OtherInventoryData.Inventory) : Inven
  * and again on any subsequent slot update while the inventory remains open.
  * Updates after the initial open are delayed by one tick and therefore run on the main thread,
  * only the initial post comes from the packet handler.
+ *
+ * An update still pending when the inventory closes is dropped, so this never fires after the
+ * [InventoryCloseEvent] of that inventory.
  */
 @PrimaryFunction("onInventoryUpdated")
 class InventoryUpdatedEvent(inventory: OtherInventoryData.Inventory) : InventoryOpenEvent(inventory)


### PR DESCRIPTION
## What
`OtherInventoryData` parks slot updates in `lateEvent` and posts them one tick later, but `close()` did not clear that field. A menu closed within that tick still got its update, after every handler had already reset on the `InventoryCloseEvent`.

That is how HotM perk items reached `NpcTradeApi`, whose guard relies on `HotmData.inInventory`. Hypixel opens a new gui on every click in the perk trees, so clicking fast hits the window often.

## Changelog Fixes
+ Fixed an error when clicking fast in the Heart of the Mountain and Heart of the Forest menus. - hannibal2
