### PR TITLE
Backend: Fix off-by-one loop bound when reading item boosters in Estimated Item Value

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -932,7 +932,7 @@ object EstimatedItemValueCalculator {
         val list = NbtCompat.getStringTagList(extraAttributes, "boosters")
         if (list.isEmpty) return emptyList()
         val boosters = mutableListOf<NeuInternalName>()
-        for (i in 0..list.size) {
+        for (i in 0 until list.size) {
             var internalName = list.getStringOrDefault(i)
             if (internalName.isBlank()) continue
             internalName += "_BOOSTER"


### PR DESCRIPTION
## What
Fixed an off-by-one loop bound in `EstimatedItemValueCalculator.readBoosters()` where `0..list.size` was used instead of `0 until list.size`.

The out-of-range read was already handled safely at runtime by `ListTag.getNullable()` returning null and `getStringOrDefault` returning an empty string skipped via `isBlank()`, so this is an internal cleanup.

## Changelog Technical Details
+ Fixed an off-by-one loop bound when reading item boosters in Estimated Item Value. - 3d3n-pyc