### PR TITLE
Fix: Correct distance calculation in BeachBallCatchHelper target selection

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/yearoftheseal/BeachBallCatchHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/yearoftheseal/BeachBallCatchHelper.kt
@@ -218,9 +218,10 @@ object BeachBallCatchHelper {
             val xTarget = targets.mapKeys { it.key.x }.weightedAverage()
             val zTarget = targets.mapKeys { it.key.z }.weightedAverage()
 
+            val averageTarget = LorenzVec(xTarget, 0.0, zTarget)
             val target = predictions.minBy {
                 val last = it.key.last()
-                xTarget - last.x + zTarget - last.z
+                last.distanceSqIgnoreY(averageTarget)
             }
             return target.key
         }


### PR DESCRIPTION
## What
Fixed the distance calculation in `BeachBallCatchHelper` when choosing the prediction closest to the average target coordinates.

Previously, `xTarget - last.x + zTarget - last.z` was used without absolute values or squares, causing points further in the positive direction to be incorrectly selected by `.minBy`. Changed to using `LorenzVec.distanceSqIgnoreY`.

## Changelog Fixes
+ Fixed Bouncy Ball Line pointing to wrong landing spots. - 3d3n-pyc