### PR TITLE
Fix: Inverted emissary scaling discount calculation in DiscountUtils

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/DiscountUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/DiscountUtils.kt
@@ -48,11 +48,11 @@ object DiscountUtils {
 
     private fun NeuInternalName.getEmissaryDiscountedPrice(lowestNPCPrice: Double): Double {
         val rep = ProfileStorageData.profileSpecific?.crimsonIsle?.reputation?.maxBy { it.value }?.value ?: 0
-        var itemDiscount = 1.0
+        var discountFraction = 0.0
         emissaryScalingDiscounts.forEach { (reputation, discount) ->
-            if (rep > reputation) itemDiscount = (1.0 - discount)
+            if (rep > reputation) discountFraction = discount
         }
-        val priceDecrease = itemPriceCoinOnly[this]?.times(itemDiscount) ?: 0.0
+        val priceDecrease = itemPriceCoinOnly[this]?.times(discountFraction) ?: 0.0
         return lowestNPCPrice - priceDecrease
     }
 }


### PR DESCRIPTION
## What
Fixed an inverted calculation in `DiscountUtils.getEmissaryDiscountedPrice()`.

Previously, `itemDiscount` was initialized to `1.0` and set to `(1.0 - discount)` when qualifying for a reputation discount. Because `priceDecrease` was then computed as `coinPrice * itemDiscount` and subtracted from `lowestNPCPrice`, a player with 0 reputation (0% discount) would have 100% of the coin price subtracted (making items free), while a 5% discount would subtract 95% of the coin price.

Changed to tracking `discountFraction` (default `0.0`) and subtracting `coinPrice * discountFraction`.

## Changelog Fixes
+ Fixed inverted emissary reputation discount calculation in instance chest profit. - 3d3n-pyc