### PR TITLE
Fix: Null safety and error handling on Mining Event API response

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/mining/eventtracker/MiningEventData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/eventtracker/MiningEventData.kt
@@ -14,8 +14,8 @@ data class MiningEventDataSend(
 
 data class MiningEventDataReceive(
     @Expose val success: Boolean,
-    @Expose val data: MiningEventData,
-    @Expose val cause: String
+    @Expose val data: MiningEventData?,
+    @Expose val cause: String?,
 )
 
 data class MiningEventData(

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/eventtracker/MiningEventTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/eventtracker/MiningEventTracker.kt
@@ -211,6 +211,8 @@ object MiningEventTracker {
         val miningEventData = ConfigManager.gson.fromJson<MiningEventDataReceive>(receivedData)
 
         if (!miningEventData.success) {
+            apiErrorCount++
+            canRequestAt = SimpleTimeMark.now() + 20.minutes
             if (receivedData.toString().trim() == "{}") ChatUtils.chat(
                 "§cFailed loading Mining Event data!\n" +
                     "§cPlease wait until the server-problem fixes itself! There is nothing else to do at the moment.",
@@ -221,11 +223,22 @@ object MiningEventTracker {
                 "cause" to miningEventData.cause,
                 "receivedData" to receivedData,
             )
+            return
         }
 
+        val data = miningEventData.data ?: run {
+            apiErrorCount++
+            canRequestAt = SimpleTimeMark.now() + 20.minutes
+            ErrorManager.logErrorStateWithData(
+                "Mining Event Tracker received incomplete data!",
+                "miningEventData.data is null despite success = true",
+                "receivedData" to receivedData,
+            )
+            return
+        }
         apiErrorCount = 0
-        canRequestAt = SimpleTimeMark.now() + miningEventData.data.updateIn.milliseconds
-        MiningEventDisplay.updateData(miningEventData.data)
+        canRequestAt = SimpleTimeMark.now() + data.updateIn.milliseconds
+        MiningEventDisplay.updateData(data)
     }
 
     @HandleEvent


### PR DESCRIPTION
## What
Fixed potential `NullPointerException` and missing error handling in `MiningEventTracker.fetchData()` when the Mining Event API returns an error payload.

- Made `data` and `cause` nullable in `MiningEventDataReceive` to accurately represent failure payloads from Gson.
- Added missing `return` when `!miningEventData.success`, incrementing `apiErrorCount` and applying the 20-minute error cooldown.
- Added `logErrorStateWithData` and error cooldown if `data` is unexpectedly null despite `success = true`.

## Changelog Fixes
+ Fixed an error message when the Mining Event Tracker could not load data. - 3d3n-pyc