### PR TITLE
Backend: Misc Cleanup around nullable prices being pointlessly called

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/SlayerApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/SlayerApi.kt
@@ -18,7 +18,7 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ConditionalUtils
-import at.hannibal2.skyhanni.utils.ItemPriceUtils.getNpcPriceOrNull
+import at.hannibal2.skyhanni.utils.ItemPriceUtils.getNpcPrice
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPrice
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPriceName
 import at.hannibal2.skyhanni.utils.NeuInternalName
@@ -158,7 +158,7 @@ object SlayerApi {
     fun getItemNameAndPrice(internalName: NeuInternalName, amount: Int): Pair<String, Double> =
         nameCache.getOrPut(internalName to amount) {
             val price = internalName.getPrice()
-            val npcPrice = internalName.getNpcPriceOrNull() ?: 0.0
+            val npcPrice = internalName.getNpcPrice()
             val maxPrice = npcPrice.coerceAtLeast(price)
             val totalPrice = maxPrice * amount
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/HideNotClickableItems.kt
@@ -22,7 +22,7 @@ import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils.getLowerItems
 import at.hannibal2.skyhanni.utils.ItemCategory
-import at.hannibal2.skyhanni.utils.ItemPriceUtils.getNpcPriceOrNull
+import at.hannibal2.skyhanni.utils.ItemPriceUtils.getNpcPrice
 import at.hannibal2.skyhanni.utils.ItemUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.cleanName
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
@@ -505,7 +505,7 @@ object HideNotClickableItems {
         }
 
         val sellable = clickToSellPattern.anyMatches(stack.getLore()) ||
-            (stack.getItemId() != "PET" && (stack.getInternalNameOrNull()?.getNpcPriceOrNull() ?: 0.0) > 0)
+            (stack.getItemId() != "PET" && (stack.getInternalNameOrNull()?.getNpcPrice() ?: 0.0) > 0)
         if (!sellable) {
             hideReason = "This item cannot be sold at the NPC!"
             return true

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemPickupLog.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/ItemPickupLog.kt
@@ -14,7 +14,7 @@ import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemCategory
 import at.hannibal2.skyhanni.utils.ItemNameResolver
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.formatCoin
-import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPriceOrNull
+import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPrice
 import at.hannibal2.skyhanni.utils.ItemUtils.cleanName
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
@@ -110,13 +110,13 @@ object ItemPickupLog {
     )
 
     @HandleEvent(GuiRenderEvent.GuiOverlayRenderEvent::class)
-    fun onGuiRenderOverlay() {
+    private fun onGuiRenderOverlay() {
         if (!isEnabled()) return
         display?.let { config.position.renderRenderable(it, posLabel = "Item Pickup Log Display") }
     }
 
     @HandleEvent
-    fun onWorldChange() {
+    private fun onWorldChange() {
         if (!isEnabled()) return
         itemList.clear()
         itemsAddedToInventory.clear()
@@ -124,7 +124,7 @@ object ItemPickupLog {
     }
 
     @HandleEvent
-    fun onSackChange(event: SackChangeEvent) {
+    private fun onSackChange(event: SackChangeEvent) {
         if (!isEnabled() || !config.sack) return
 
         event.sackChanges.forEach {
@@ -136,7 +136,7 @@ object ItemPickupLog {
     }
 
     @HandleEvent
-    fun onShardGain(event: ShardEvent) {
+    private fun onShardGain(event: ShardEvent) {
         if (!isEnabled() || !config.shards) return
 
         val itemStack = event.shardInternalName.getItemStack()
@@ -146,14 +146,14 @@ object ItemPickupLog {
     }
 
     @HandleEvent
-    fun onPurseChange(event: PurseChangeEvent) {
+    private fun onPurseChange(event: PurseChangeEvent) {
         if (!isEnabled() || !config.coins || !worldChangeCooldown()) return
 
         updateItem(0, PickupEntry("§6Coins", event.coins.absoluteValue.toLong(), coinIcon), event.coins < 0)
     }
 
     @HandleEvent(SkyHanniTickEvent::class)
-    fun onTick() {
+    private fun onTick() {
         if (!isEnabled()) return
         val oldItemList = mutableMapOf<Int, Pair<SafeItemStack, Int>>()
 
@@ -310,7 +310,7 @@ object ItemPickupLog {
         // Handle purse coins as a special case
         amount.toDouble()
     } else {
-        val pricePer = neuInternalName?.getPriceOrNull(coinConfig.priceSource) ?: 0.0
+        val pricePer = neuInternalName?.getPrice(coinConfig.priceSource) ?: 0.0
         pricePer * amount
     }
 
@@ -371,7 +371,7 @@ object ItemPickupLog {
     private fun isEnabled() = SkyBlockUtils.inSkyBlock && config.enabled
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(97, "inventory.itemPickupLogConfig", "inventory.itemPickupLog")
         event.move(97, "inventory.itemPickupLog.pos", "inventory.itemPickupLog.position")
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsProfitTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/ExperimentsProfitTracker.kt
@@ -19,7 +19,7 @@ import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.InventoryDetector
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemPriceSource
-import at.hannibal2.skyhanni.utils.ItemPriceUtils.getNpcPriceOrNull
+import at.hannibal2.skyhanni.utils.ItemPriceUtils.getNpcPrice
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.NeuItems.getItemStackOrNull
@@ -80,13 +80,13 @@ object ExperimentsProfitTracker {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND)
-    fun onItemAdd(event: ItemAddEvent) {
+    private fun onItemAdd(event: ItemAddEvent) {
         if (!isEnabled() || !config.enabled || event.source != ItemAddManager.Source.COMMAND) return
         tracker.addItem(event.internalName, event.amount, command = true)
     }
 
     @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND)
-    fun onChat(event: SkyHanniChatEvent.Allow) {
+    private fun onChat(event: SkyHanniChatEvent.Allow) {
         if (!isEnabled()) return
         experimentRenewPattern.matchMatcher(event.cleanMessage) {
             val increments = mapOf(1 to 150, 2 to 300, 3 to 500)
@@ -97,7 +97,7 @@ object ExperimentsProfitTracker {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND)
-    fun onTableTaskCompleted(event: TableTaskCompletedEvent) {
+    private fun onTableTaskCompleted(event: TableTaskCompletedEvent) {
         tracker.modify {
             if (event.type == ExperimentationTableApi.ExperimentationTaskType.SUPERPAIRS) {
                 it.experimentsDone++
@@ -113,7 +113,7 @@ object ExperimentsProfitTracker {
     private val bottlesInventory = InventoryDetector { ExperimentationTableApi.bottlesOfEnchantingInventoryPattern }
 
     @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND)
-    fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
+    private fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
         if (!isEnabled() || !bottlesInventory.isInside() || !allowedSlots.contains(event.slotId)) return
         val internalName = event.slot?.item?.getInternalNameOrNull()?.takeIf {
             experienceBottlePattern.matches(it.asString())
@@ -132,7 +132,7 @@ object ExperimentsProfitTracker {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND)
-    fun onTableXpBottleUsed(event: TableXPBottleUsedEvent) {
+    private fun onTableXpBottleUsed(event: TableXPBottleUsedEvent) {
         if (!isEnabled() || !config.trackUsedBottles) return
         val bottlePrice = calculateBottlePrice(event.internalName)
         tracker.modify {
@@ -158,7 +158,7 @@ object ExperimentsProfitTracker {
     private var lastAddedTimeWasted: SimpleTimeMark = SimpleTimeMark.farPast()
 
     @HandleEvent
-    fun onSecondPassed() {
+    private fun onSecondPassed() {
         if (ExperimentationTableApi.expOverInventoryPattern.matches(InventoryUtils.openInventoryName())) return
         if (!ExperimentationTableApi.inTable || !config.trackTimeSpent) {
             lastAddedTimeWasted = SimpleTimeMark.farPast()
@@ -183,7 +183,7 @@ object ExperimentsProfitTracker {
 
     private fun calculateBottlePrice(internalName: NeuInternalName): Int {
         val price = tracker.getPricePer(internalName)
-        val npcPrice = internalName.getNpcPriceOrNull() ?: 0.0
+        val npcPrice = internalName.getNpcPrice()
         return npcPrice.coerceAtLeast(price).toInt()
     }
 
@@ -239,12 +239,12 @@ object ExperimentsProfitTracker {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND)
-    fun onIslandChange() {
+    private fun onIslandChange() {
         tracker.firstUpdate()
     }
 
     @HandleEvent
-    fun onCommandRegistration(event: CommandRegistrationEvent) {
+    private fun onCommandRegistration(event: CommandRegistrationEvent) {
         event.registerBrigadier("shresetexperimentsprofittracker") {
             description = "Resets the Experiments Profit Tracker"
             category = CommandCategory.USERS_RESET

--- a/src/main/java/at/hannibal2/skyhanni/features/minion/MinionUpgradeHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/minion/MinionUpgradeHelper.kt
@@ -5,14 +5,12 @@ import at.hannibal2.skyhanni.api.GetFromSackApi
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.SackApi.getAmountInSacksOrNull
 import at.hannibal2.skyhanni.events.GuiContainerEvent
-import at.hannibal2.skyhanni.events.InventoryCloseEvent
-import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.MinionCloseEvent
 import at.hannibal2.skyhanni.events.MinionOpenEvent
 import at.hannibal2.skyhanni.events.render.gui.ReplaceItemEvent
 import at.hannibal2.skyhanni.features.inventory.bazaar.BazaarApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPriceOrNull
+import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPrice
 import at.hannibal2.skyhanni.utils.ItemUtils.getCleanLore
 import at.hannibal2.skyhanni.utils.ItemUtils.repoItemName
 import at.hannibal2.skyhanni.utils.ItemUtils.setLoreString
@@ -50,7 +48,7 @@ object MinionUpgradeHelper {
     private var lastMinionOpen = SimpleTimeMark.farPast()
 
     @HandleEvent
-    fun onMinionOpen(event: MinionOpenEvent) {
+    private fun onMinionOpen(event: MinionOpenEvent) {
         if (!config.minionConfigHelper) return
         lastMinionOpen = SimpleTimeMark.now()
         val lore = event.inventoryItems[50]?.getCleanLore() ?: return
@@ -67,25 +65,25 @@ object MinionUpgradeHelper {
     }
 
     @HandleEvent
-    fun onMinionClose(event: MinionCloseEvent) {
+    private fun onMinionClose(event: MinionCloseEvent) {
         resetItems()
     }
 
     // TODO make this event not necessary here.
     @HandleEvent
-    fun onInventoryClose(event: InventoryCloseEvent) {
+    private fun onInventoryClose() {
         resetItems()
     }
 
     // TODO make this event not necessary here.
     @HandleEvent
-    fun onWorldChange() {
+    private fun onWorldChange() {
         resetItems()
     }
 
     // TODO make this event not necessary here.
     @HandleEvent
-    fun onInventoryFullyOpened(event: InventoryFullyOpenedEvent) {
+    private fun onInventoryFullyOpened() {
         if (lastMinionOpen.passedSince() > 2.seconds) {
             resetItems()
         }
@@ -104,7 +102,7 @@ object MinionUpgradeHelper {
     }
 
     private fun createLore(internalName: NeuInternalName): List<String> {
-        val itemPrice = internalName.getPriceOrNull() ?: 0.0
+        val itemPrice = internalName.getPrice()
         val lore = buildList {
             val itemsRemaining = itemsNeeded - itemsInSacks
             val totalCost = itemsNeeded * itemPrice
@@ -135,7 +133,7 @@ object MinionUpgradeHelper {
     }
 
     @HandleEvent
-    fun replaceItem(event: ReplaceItemEvent) {
+    private fun replaceItem(event: ReplaceItemEvent) {
         if (!config.minionConfigHelper) return
         if (event.inventory !is Inventory && event.slot == 51) {
             displayItem?.let { event.replace(it) }
@@ -143,7 +141,7 @@ object MinionUpgradeHelper {
     }
 
     @HandleEvent(priority = HandleEvent.HIGH)
-    fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
+    private fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
         if (!config.minionConfigHelper || displayItem == null || event.slotId != 51) return
         event.cancel()
         val internalName = internalName ?: return

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/items/EstimatedItemValueCalculator.kt
@@ -15,6 +15,7 @@ import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.formatCoin
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.formatCoinWithBrackets
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getNpcPriceOrNull
+import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPrice
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPriceName
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getPriceOrNull
 import at.hannibal2.skyhanni.utils.ItemPriceUtils.getRawCraftCostOrNull
@@ -941,6 +942,6 @@ object EstimatedItemValueCalculator {
         return boosters
     }
 
-    private fun NeuInternalName.getPrice(): Double = getPriceOrNull() ?: 0.0
+    private fun NeuInternalName.getPrice(): Double = getPrice(config.priceSource.get())
     private fun NeuInternalName.getPriceOrNull(): Double? = getPriceOrNull(config.priceSource.get())
 }


### PR DESCRIPTION
## What
Looking at the nullable price calls made me realise there was some very pointless null calls where we elvis'd back to what the non-nullable already did.
This is so barely code changes that I don't really think it needs a changelog anyway

exclude_from_changelog
