### PR TITLE
Backend: Remove old chests beyond MAX_CHESTS in Croesus Chest Tracker

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/CroesusChestTracker.kt
@@ -338,7 +338,7 @@ object CroesusChestTracker {
         countUnopenedChestsAndRemoveOld()
         currentRunIndex = 0
         if ((croesusChests?.size ?: 0) > MAX_CHESTS) {
-            croesusChests?.dropLast(1)
+            croesusChests?.removeLast()
         }
         display = null
 


### PR DESCRIPTION
## What
Fixed `CroesusChestTracker` not trimming `croesusChests` when exceeding `MAX_CHESTS` (60).

`List.dropLast(1)` is a pure function that returns a new list and does not mutate the collection in place. Replaced with `removeLast()` so chests beyond `MAX_CHESTS` are properly removed from storage.

## Changelog Technical Details
+ Removed old chests beyond maximum chest limit in Croesus Chest Tracker. - 3d3n-pyc