### PR TITLE
Improvement: Better error for missing slayer RNG meter data

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerRngMeterDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/SlayerRngMeterDisplay.kt
@@ -223,8 +223,9 @@ object SlayerRngMeterDisplay {
             val currentSlayer = getCurrentSlayer()
             storage.goalNeeded = rngScore[currentSlayer]?.get(internalName) ?: run {
                 ErrorManager.logErrorStateWithData(
-                    "Failed reading RNG Meter goal needed amount",
-                    "rngScore does not contain current slayer and current item data",
+                    "RNG Meter data for item $internalName on $currentSlayer not found in NEU repo. " +
+                        "Please report this on Discord.",
+                    "rngScore does not contain data for current slayer and item combination",
                     "internalName" to internalName,
                     "currentSlayer" to currentSlayer,
                     "rngScore" to rngScore,


### PR DESCRIPTION
## What
Improves the error messages users see when the amount of XP needed for their currently selected slayer RNG meter item is not found in the NEU repo.

## Changelog Improvements
+ Improved error message for missing Slayer RNG Meter data. - Luna