### PR TITLE
Backend: Fix misleading HandleEvent.priority KDoc

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/event/HandleEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/event/HandleEvent.kt
@@ -52,7 +52,8 @@ annotation class HandleEvent(
     vararg val onlyOnIslands: IslandType = [],
 
     /**
-     * The priority of when the event will be called, lower priority will be called first, see the companion object.
+     * The order the event handler will be called in relative to the other handlers of the same event.
+     * Lower number means it will be called earlier. See the companion object for predefined priorities.
      */
     val priority: Int = 0,
 


### PR DESCRIPTION
## What
The KDoc for `HandleEvent.priority` says "lower priority will be called first". This is technically true if you treat it as an integer, but is confusing with the existence of constants going from `HIGHEST` to `LOWEST`, where obviously `HIGHEST` is called first and `LOWEST` is called last (within their bounds, at least).

While I'm here, I took the opportunity to clean up the wording a bit as well.

## Changelog Technical Details
+ Fixed misleading documentation for `HandleEvent.priority`. - Luna