### PR TITLE
Improvement + Fix: Disable Boost Warning Volume by default and make it only boost actual warnings

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/ConfigUpdaterMigrator.kt
@@ -12,7 +12,7 @@ import com.google.gson.JsonPrimitive
 
 object ConfigUpdaterMigrator {
     val logger = SkyHanniLogger("ConfigMigration")
-    const val CONFIG_VERSION = 145
+    const val CONFIG_VERSION = 146
     fun JsonElement.at(chain: List<String>, init: Boolean): JsonElement? {
         if (chain.isEmpty()) return this
         if (this !is JsonObject) return null
@@ -32,7 +32,6 @@ object ConfigUpdaterMigrator {
         var movesPerformed: Int,
         val dynamicPrefix: Map<String, List<String>>,
     ) : SkyHanniEvent() {
-
         init {
             dynamicPrefix.entries
                 .filter { it.value.isEmpty() }

--- a/src/main/java/at/hannibal2/skyhanni/config/features/combat/broodmother/BroodmotherSpawnAlertConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/combat/broodmother/BroodmotherSpawnAlertConfig.kt
@@ -1,7 +1,7 @@
 package at.hannibal2.skyhanni.config.features.combat.broodmother
 
+import at.hannibal2.skyhanni.features.combat.BroodmotherFeatures
 import at.hannibal2.skyhanni.utils.OSUtils
-import at.hannibal2.skyhanni.utils.SoundUtils
 import at.hannibal2.skyhanni.utils.SoundUtils.playSound
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorButton
@@ -22,7 +22,7 @@ class BroodmotherSpawnAlertConfig {
 
     @ConfigOption(name = "Test Sound", desc = "Test current sound settings.")
     @ConfigEditorButton(buttonText = "Test")
-    val testSound: () -> Unit = { SoundUtils.createSound(alertSound, pitch).playSound() }
+    val testSound: () -> Unit = { BroodmotherFeatures.alertSound.playSound() }
 
     @Expose
     @ConfigOption(name = "Repeat Sound", desc = "How many times the sound should be repeated.")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/combat/broodmother/BroodmotherSpawnAlertConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/combat/broodmother/BroodmotherSpawnAlertConfig.kt
@@ -2,7 +2,6 @@ package at.hannibal2.skyhanni.config.features.combat.broodmother
 
 import at.hannibal2.skyhanni.features.combat.BroodmotherFeatures
 import at.hannibal2.skyhanni.utils.OSUtils
-import at.hannibal2.skyhanni.utils.SoundUtils.playSound
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorButton
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider
@@ -22,7 +21,7 @@ class BroodmotherSpawnAlertConfig {
 
     @ConfigOption(name = "Test Sound", desc = "Test current sound settings.")
     @ConfigEditorButton(buttonText = "Test")
-    val testSound: () -> Unit = { BroodmotherFeatures.alertSound.playSound() }
+    val testSound: () -> Unit = { BroodmotherFeatures.playTestSound() }
 
     @Expose
     @ConfigOption(name = "Repeat Sound", desc = "How many times the sound should be repeated.")

--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.kt
@@ -401,9 +401,8 @@ class MiscConfig {
             "If the game is muted, you still won't hear the sounds.",
     )
     @ConfigEditorBoolean
-    @FeatureToggle
     @SearchTag("beep change ding during loud maintain pling quiet warnings")
-    var boostWarningVolume: Boolean = true
+    var boostWarningVolume: Boolean = false
 
     @Expose
     @ConfigOption(
@@ -503,7 +502,6 @@ class MiscConfig {
     @ConfigEditorBoolean
     @FeatureToggle
     var fixDoubleClicks: Boolean = true
-
 
     @ConfigOption(
         name = "Color Particle Warning",

--- a/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/misc/MiscConfig.kt
@@ -11,10 +11,12 @@ import at.hannibal2.skyhanni.config.features.misc.navigation.NavigationConfig
 import at.hannibal2.skyhanni.config.features.misc.tracker.UniversalTrackerConfig
 import at.hannibal2.skyhanni.config.features.pets.PetConfig
 import at.hannibal2.skyhanni.config.features.stranded.StrandedConfig
+import at.hannibal2.skyhanni.utils.SoundUtils
 import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.Accordion
 import io.github.notenoughupdates.moulconfig.annotations.Category
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorButton
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorDraggableList
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorInfoText
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorKeybind
@@ -397,12 +399,17 @@ class MiscConfig {
     @Expose
     @ConfigOption(
         name = "Boost Warning Volume",
-        desc = "Play SkyHanni warning sounds at 100% volume regardless of game volume settings.\n" +
-            "If the game is muted, you still won't hear the sounds.",
+        desc = "Always play SkyHanni warning sounds at 100% volume (unless the game is muted).\n" +
+            "§cThis may be very loud if your game is at low volume!"
     )
     @ConfigEditorBoolean
-    @SearchTag("beep change ding during loud maintain pling quiet warnings")
+    @SearchTag("beep change ding during maintain pling quiet warnings")
     var boostWarningVolume: Boolean = false
+
+    @ConfigOption(name = "Test Warning Sound", desc = "Play a test warning sound to see how loud it will be.")
+    @ConfigEditorButton(buttonText = "Test")
+    @SearchTag("beep boost change ding during loud maintain pling quiet volume warnings")
+    val testWarningSound: Runnable = Runnable(SoundUtils::playPlingSound)
 
     @Expose
     @ConfigOption(

--- a/src/main/java/at/hannibal2/skyhanni/data/garden/cropmilestones/CropMilestonesApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/garden/cropmilestones/CropMilestonesApi.kt
@@ -77,12 +77,12 @@ object CropMilestonesApi {
     )
 
     @HandleEvent(priority = HandleEvent.LOW)
-    fun onProfileJoin() {
+    private fun onProfileJoin() {
         if ((cropMilestoneCounter?.size ?: 0) == 0) inaccurateMilestone = true
     }
 
     @HandleEvent
-    fun onCollectionAdd(event: CropCollectionAddEvent) {
+    private fun onCollectionAdd(event: CropCollectionAddEvent) {
         val cropType = event.crop
         val collectionType = event.cropCollectionType
         val amount = event.amount
@@ -194,7 +194,6 @@ object CropMilestonesApi {
             return totalCrops
         }
 
-
         for (tierCrops in cropMilestone) {
             totalCrops += tierCrops
             tier++
@@ -291,7 +290,6 @@ object CropMilestonesApi {
             return tier
         }
 
-
         tier = getMaxTier()
 
         totalCrops = count - maxMilestoneAmount
@@ -352,7 +350,7 @@ object CropMilestonesApi {
             chat(message, false)
         }
 
-        SoundUtils.createSound("entity.player.levelup", 1f, 1f).playSound()
+        SoundUtils.createSound("entity.player.levelup", 1f, 1f, isWarning = false).playSound()
     }
 
     internal fun clearMilestoneCache() {
@@ -367,12 +365,12 @@ object CropMilestonesApi {
     }
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(116, "#profile.garden.cropCounter", "#profile.garden.cropMilestoneCounter")
     }
 
     @HandleEvent
-    fun onRepoReload(event: RepositoryReloadEvent) {
+    private fun onRepoReload(event: RepositoryReloadEvent) {
         cropMilestoneRepoData = event.getConstant<GardenJson>("Garden").cropMilestones
         missingMilestoneRepoData = false
         clearMilestoneCache()
@@ -383,7 +381,7 @@ object CropMilestonesApi {
     }
 
     @HandleEvent
-    fun onCommandRegistration(event: CommandRegistrationEvent) {
+    private fun onCommandRegistration(event: CommandRegistrationEvent) {
         event.registerBrigadier("shresetcropmilestones") {
             description = "Resets crop milestones."
             category = CommandCategory.DEVELOPER_DEBUG
@@ -395,7 +393,7 @@ object CropMilestonesApi {
     }
 
     @HandleEvent
-    fun onDebugDataCollect(event: DebugDataCollectEvent) {
+    private fun onDebugDataCollect(event: DebugDataCollectEvent) {
         event.title("Crop Milestones API")
         event.addIrrelevant {
             for (crop in cropMilestoneTierCache) {
@@ -410,7 +408,7 @@ object CropMilestonesApi {
     private const val CROP_MILESTONE_ACHIEVEMENT = "Expert Gardener"
 
     @HandleEvent
-    fun onAchievementRegistered(event: AchievementRegistrationEvent) {
+    private fun onAchievementRegistered(event: AchievementRegistrationEvent) {
         val achievement = Achievement(
             name = "Expert Gardener",
             description = "Get a crop milestone to level 500",

--- a/src/main/java/at/hannibal2/skyhanni/events/PlaySoundEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/PlaySoundEvent.kt
@@ -27,7 +27,6 @@ class PlaySoundEvent(
     val pitch: Float,
     val volume: Float,
 ) : CancellableWorldEvent() {
-
     val distanceToPlayer by lazy { location.distanceToPlayer() }
     override fun toString(): String {
         return "PlaySoundEvent(soundName='$soundName', pitch=$pitch, volume=$volume, location=${location.roundTo(1)}, distanceToPlayer=${
@@ -40,6 +39,6 @@ class PlaySoundEvent(
      */
     fun replaceWithOther(soundName: String) {
         this.cancel()
-        SoundUtils.createSound(soundName, pitch, volume).playSound()
+        SoundUtils.createSound(soundName, pitch, volume, isWarning = false).playSound()
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/achievements/AchievementManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/achievements/AchievementManager.kt
@@ -38,14 +38,13 @@ import net.minecraft.world.item.Items
  */
 @SkyHanniModule
 object AchievementManager {
-
     private val config get() = SkyHanniMod.achievementStorage.achievements
     val shouldShowMessages get() = SkyHanniMod.feature.misc.achievementMessages
     val group = RepoPattern.group("achievements")
-    private val achievementSound = SoundUtils.createSound("ui.toast.challenge_complete", 1f, .8f)
+    private val achievementSound = SoundUtils.createSound("ui.toast.challenge_complete", 1f, .8f, isWarning = false)
 
     @HandleEvent
-    fun onInitFinished() {
+    private fun onInitFinished() {
         val event = AchievementRegistrationEvent()
         event.post()
         for ((id, achievement) in event.getAchievements()) {
@@ -139,7 +138,7 @@ object AchievementManager {
     const val TEST_ACHIEVEMENT = "Test Achievement"
 
     @HandleEvent
-    fun onAchievementRegistration(event: AchievementRegistrationEvent) {
+    private fun onAchievementRegistration(event: AchievementRegistrationEvent) {
         val achievement = Achievement(
             name = "Test Achievement".asComponent(),
             description = componentBuilder {
@@ -153,7 +152,7 @@ object AchievementManager {
     }
 
     @HandleEvent
-    fun onCommandRegistration(event: CommandRegistrationEvent) {
+    private fun onCommandRegistration(event: CommandRegistrationEvent) {
         event.registerBrigadier("shtestachievement") {
             description = "Tests achievement granting and revoking"
             category = CommandCategory.DEVELOPER_TEST
@@ -247,7 +246,7 @@ object AchievementManager {
     }
 
     @HandleEvent
-    fun onUserLuck(event: UserLuckCalculateEvent) {
+    private fun onUserLuck(event: UserLuckCalculateEvent) {
         var luck = 0f
         var hasDoneAllAchievements = true
         for ((_, achievement) in config) {

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/ChatSoundResponse.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/ChatSoundResponse.kt
@@ -15,7 +15,6 @@ import com.google.gson.JsonPrimitive
 
 @SkyHanniModule
 object ChatSoundResponse {
-
     private val config get() = SkyHanniMod.feature.chat.soundResponse
 
     init {
@@ -23,7 +22,7 @@ object ChatSoundResponse {
     }
 
     @HandleEvent
-    fun onChat(event: SkyHanniChatEvent.Allow) {
+    private fun onChat(event: SkyHanniChatEvent.Allow) {
         if (!isEnabled()) return
 
         for (soundType in SoundResponseTypes.entries) {
@@ -36,7 +35,7 @@ object ChatSoundResponse {
     }
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.transform(95, "chat.soundResponse.soundResponses") { element ->
             if (!element.isJsonArray) return@transform element
             val array = element.asJsonArray
@@ -70,7 +69,6 @@ object ChatSoundResponse {
         }
     }
 
-
     fun isEnabled() = SkyBlockUtils.inSkyBlock && config.enabled
 }
 
@@ -94,7 +92,7 @@ enum class SoundResponseTypes(private val displayName: String, soundLocation: St
     GOAT("Goat", "entity.goat.screaming.ambient", listOf("bleat")),
     ;
 
-    val sound by lazy { SoundUtils.createSound(soundLocation, 1f) }
+    val sound by lazy { SoundUtils.createSound(soundLocation, 1f, isWarning = false) }
 
     // creates a pattern that looks for if the message contains any of the triggerOn strings but as a full word
     val pattern by RepoPattern.pattern(

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/BroodmotherFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/BroodmotherFeatures.kt
@@ -3,7 +3,6 @@ package at.hannibal2.skyhanni.features.combat
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType
-import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.data.title.TitleManager
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.SecondPassedEvent
@@ -25,13 +24,11 @@ import net.minecraft.ChatFormatting
 import kotlin.reflect.KProperty0
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
-import kotlin.time.DurationUnit
 
 // TODO clean this file up - there is a lot of state management that could utilize Resettable
 //  and other mechanisms to avoid the repetitive code.
 @SkyHanniModule
 object BroodmotherFeatures {
-
     enum class StageEntry(private val str: String, val duration: Duration) {
         SLAIN("§eSlain", 10.minutes),
         DORMANT("§eDormant", 9.minutes),
@@ -46,14 +43,16 @@ object BroodmotherFeatures {
     private val config get() = SkyHanniMod.feature.combat.broodmother
     private val spawnAlertConfig get() = config.spawnAlert
 
+    val alertSound get() = SoundUtils.createSound(spawnAlertConfig.alertSound, spawnAlertConfig.pitch, isWarning = true)
+
     private var lastStage: StageEntry? = null
     private var currentStage: StageEntry? = null
     private var broodmotherSpawnTime = SimpleTimeMark.farPast()
     private var display: Renderable? = null
 
     @HandleEvent
-    fun onWidgetUpdate(event: WidgetUpdateEvent) {
-        if (!event.isWidget(TabWidget.BROODMOTHER)) return
+    private fun onWidgetUpdate(event: WidgetUpdateEvent) {
+        if (!event.isWidget(BROODMOTHER)) return
         val newStage = event.widget.matchMatcherFirstLine { group("stage") }.orEmpty()
         if (newStage.isNotEmpty() && newStage != lastStage.toString().removeColor()) {
             lastStage = currentStage
@@ -69,9 +68,9 @@ object BroodmotherFeatures {
         if (onServerJoin()) return
 
         // ignore Hypixel bug where the stage may temporarily revert to Imminent after the Broodmother's death
-        if (currentStage == StageEntry.IMMINENT && lastStage == StageEntry.ALIVE) return
+        if (currentStage == IMMINENT && lastStage == ALIVE) return
 
-        if (currentStage == StageEntry.ALIVE) {
+        if (currentStage == ALIVE) {
             onBroodmotherSpawn()
             return
         }
@@ -80,16 +79,16 @@ object BroodmotherFeatures {
         val timeUntilSpawn = currentStage?.duration ?: return
         broodmotherSpawnTime = SimpleTimeMark.now() + timeUntilSpawn
 
-        if (currentStage == StageEntry.IMMINENT && config.imminentWarning) {
+        if (currentStage == IMMINENT && config.imminentWarning) {
             playImminentWarning()
             return
         }
 
         if (currentStage !in config.stages) return
-        if (currentStage == StageEntry.SLAIN) {
+        if (currentStage == SLAIN) {
             onBroodmotherSlain()
         } else {
-            val pluralize = StringUtils.pluralize(timeUntilSpawn.toInt(DurationUnit.MINUTES), "minute")
+            val pluralize = StringUtils.pluralize(timeUntilSpawn.toInt(MINUTES), "minute")
             ChatUtils.chat(
                 "Broodmother: $lastStage §e-> $currentStage§e. §b${timeUntilSpawn.inWholeMinutes} $pluralize §euntil it spawns!",
             )
@@ -100,7 +99,7 @@ object BroodmotherFeatures {
         if (lastStage != null || !config.stageOnJoin) return false
         // don't send if user has config enabled for either of the alive messages
         // this is so that two messages aren't immediately sent upon joining a server
-        if (!(currentStage == StageEntry.ALIVE && isAliveMessageEnabled())) {
+        if (!(currentStage == ALIVE && isAliveMessageEnabled())) {
             val duration = currentStage?.duration
             var message = "The Broodmother's current stage in this server is ${currentStage.toString().replace("!", "")}§e."
             if (duration != 0.minutes) {
@@ -120,7 +119,6 @@ object BroodmotherFeatures {
         val feature: KProperty0<*>
         if (config.alertOnSpawn) {
             feature = config::alertOnSpawn
-            val alertSound = SoundUtils.createSound(spawnAlertConfig.alertSound, spawnAlertConfig.pitch)
             SoundUtils.repeatSound(100, spawnAlertConfig.repeatSound, alertSound)
             TitleManager.sendTitle(spawnAlertConfig.text.replace("&", "§"))
         } else {
@@ -135,7 +133,7 @@ object BroodmotherFeatures {
     }
 
     private fun playImminentWarning() {
-        SoundUtils.repeatSound(100, 2, SoundUtils.createSound("block.note_block.pling", 0.5f))
+        SoundUtils.repeatSound(100, 2, SoundUtils.createSound("block.note_block.pling", 0.5f, isWarning = true))
         ChatUtils.chat(
             componentBuilder {
                 append("The Broodmother is ")
@@ -155,7 +153,7 @@ object BroodmotherFeatures {
     }
 
     @HandleEvent
-    fun onWorldChange() {
+    private fun onWorldChange() {
         broodmotherSpawnTime = SimpleTimeMark.farPast()
         lastStage = null
         currentStage = null
@@ -163,7 +161,7 @@ object BroodmotherFeatures {
     }
 
     @HandleEvent
-    fun onGuiRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
+    private fun onGuiRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
         if (!isCountdownEnabled()) return
         val display = if (broodmotherSpawnTime.isInPast() && !broodmotherSpawnTime.isFarPast()) {
             Renderable.text("§4Broodmother spawning now!")
@@ -172,11 +170,11 @@ object BroodmotherFeatures {
     }
 
     @HandleEvent
-    fun onSecondPassed(event: SecondPassedEvent) {
+    private fun onSecondPassed(event: SecondPassedEvent) {
         if (!isCountdownEnabled()) return
 
         if (broodmotherSpawnTime.isFarPast()) {
-            if (currentStage == StageEntry.ALIVE) {
+            if (currentStage == ALIVE) {
                 display = Renderable.text("§4Broodmother spawned!")
             }
         } else {
@@ -187,5 +185,5 @@ object BroodmotherFeatures {
 
     private fun inSpidersDen() = IslandType.SPIDER_DEN.isInIsland()
     private fun isCountdownEnabled() = inSpidersDen() && config.countdown
-    private fun isAliveMessageEnabled() = config.alertOnSpawn || config.stages.contains(StageEntry.ALIVE)
+    private fun isAliveMessageEnabled() = config.alertOnSpawn || config.stages.contains(ALIVE)
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/BroodmotherFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/BroodmotherFeatures.kt
@@ -13,6 +13,7 @@ import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SoundUtils
+import at.hannibal2.skyhanni.utils.SoundUtils.playSound
 import at.hannibal2.skyhanni.utils.StringUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.TimeUtils.format
@@ -43,7 +44,11 @@ object BroodmotherFeatures {
     private val config get() = SkyHanniMod.feature.combat.broodmother
     private val spawnAlertConfig get() = config.spawnAlert
 
-    val alertSound get() = SoundUtils.createSound(spawnAlertConfig.alertSound, spawnAlertConfig.pitch, isWarning = true)
+    private val alertSound get() =
+        SoundUtils.createSound(spawnAlertConfig.alertSound, spawnAlertConfig.pitch, isWarning = true)
+
+    @JvmStatic
+    fun playTestSound() = alertSound.playSound()
 
     private var lastStage: StageEntry? = null
     private var currentStage: StageEntry? = null

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonSecretChime.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonSecretChime.kt
@@ -2,7 +2,6 @@ package at.hannibal2.skyhanni.features.dungeon
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.data.ClickedBlockType
 import at.hannibal2.skyhanni.data.jsonobjects.repo.ItemsJson
 import at.hannibal2.skyhanni.events.MobEvent
 import at.hannibal2.skyhanni.events.PlaySoundEvent
@@ -22,21 +21,21 @@ object DungeonSecretChime {
     private var dungeonSecretItems = setOf<NeuInternalName>()
 
     @HandleEvent
-    fun onDungeonClickedBlock(event: DungeonBlockClickEvent) {
+    private fun onDungeonClickedBlock(event: DungeonBlockClickEvent) {
         if (!isEnabled()) return
-        if (DungeonApi.inWaterRoom && event.blockType == ClickedBlockType.LEVER) return
+        if (DungeonApi.inWaterRoom && event.blockType == LEVER) return
 
         when (event.blockType) {
-            ClickedBlockType.CHEST,
-            ClickedBlockType.TRAPPED_CHEST,
-            ClickedBlockType.LEVER,
-            ClickedBlockType.WITHER_ESSENCE,
+            CHEST,
+            TRAPPED_CHEST,
+            LEVER,
+            WITHER_ESSENCE,
             -> playSound()
         }
     }
 
     @HandleEvent
-    fun onMobDeSpawn(event: MobEvent.DeSpawn.SkyblockMob) {
+    private fun onMobDeSpawn(event: MobEvent.DeSpawn.SkyblockMob) {
         if (isEnabled() && event.mob.name == "Dungeon Secret Bat") {
             playSound()
         }
@@ -53,7 +52,7 @@ object DungeonSecretChime {
     }
 
     @HandleEvent
-    fun onPlaySound(event: PlaySoundEvent) {
+    private fun onPlaySound(event: PlaySoundEvent) {
         with(config.muteSecretSound) {
             if (!muteChestSound && !muteLeverSound) return
             if (muteChestSound && event.isChestSound()) event.cancel()
@@ -80,7 +79,7 @@ object DungeonSecretChime {
     }
 
     @HandleEvent
-    fun onRepoReload(event: RepositoryReloadEvent) {
+    private fun onRepoReload(event: RepositoryReloadEvent) {
         val data = event.getConstant<ItemsJson>("Items")
         dungeonSecretItems = data.dungeonSecretItems
     }
@@ -90,7 +89,7 @@ object DungeonSecretChime {
     @JvmStatic
     fun playSound() {
         with(config) {
-            SoundUtils.createSound(soundName, soundPitch, 100f).playSound()
+            SoundUtils.createSound(soundName, soundPitch, 100f, isWarning = true).playSound()
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/LowHealthAlert.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/LowHealthAlert.kt
@@ -19,7 +19,7 @@ object LowHealthAlert {
     private val soundConfig get() = config.lowHealthAlertSound
     private var lastAlert: TitleContext? = null
 
-    val alertSound get() = SoundUtils.createSound(soundConfig.alertSound, soundConfig.pitch, isWarning = true)
+    private val alertSound get() = SoundUtils.createSound(soundConfig.alertSound, soundConfig.pitch, isWarning = true)
 
     @HandleEvent(onlyOnIsland = IslandType.CATACOMBS)
     fun onScoreboardChange(event: ScoreboardUpdateEvent) {

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/LowHealthAlert.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/LowHealthAlert.kt
@@ -15,10 +15,11 @@ import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object LowHealthAlert {
-
     private val config get() = SkyHanniMod.feature.dungeon.lowHealthAlert
     private val soundConfig get() = config.lowHealthAlertSound
     private var lastAlert: TitleContext? = null
+
+    val alertSound get() = SoundUtils.createSound(soundConfig.alertSound, soundConfig.pitch, isWarning = true)
 
     @HandleEvent(onlyOnIsland = IslandType.CATACOMBS)
     fun onScoreboardChange(event: ScoreboardUpdateEvent) {
@@ -29,7 +30,6 @@ object LowHealthAlert {
             val health = group("health")
             if (color != "c" || health == "DEAD") return
 
-            val alertSound = SoundUtils.createSound(soundConfig.alertSound, soundConfig.pitch)
             SoundUtils.repeatSound(100, soundConfig.repeatSound, alertSound)
             lastAlert?.stop()
             TitleManager.sendTitle(
@@ -43,12 +43,8 @@ object LowHealthAlert {
     }
 
     @JvmStatic
-    fun playTestSound() {
-        with(soundConfig) {
-            SoundUtils.createSound(alertSound, pitch).playSound()
-        }
-    }
+    fun playTestSound() = alertSound.playSound()
 
     private fun isEnabled() =
-        config.enabled && DungeonApi.active && (!config.onlyWhileHealer || DungeonApi.playerClass == DungeonApi.DungeonClass.HEALER)
+        config.enabled && DungeonApi.active && (!config.onlyWhileHealer || DungeonApi.playerClass == HEALER)
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/RareMobWaypointShare.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/RareMobWaypointShare.kt
@@ -5,7 +5,6 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.config.features.event.diana.RareMobToggleConfig
-import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.title.TitleManager
 import at.hannibal2.skyhanni.events.SecondPassedEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
@@ -41,7 +40,6 @@ import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object RareMobWaypointShare {
-
     private val config get() = SkyHanniMod.feature.event.diana.rareMobsSharing
 
     private val patternGroup = RepoPattern.group("diana.waypoints.inquisitor")
@@ -113,7 +111,7 @@ object RareMobWaypointShare {
     }
 
     @HandleEvent
-    fun onSecondPassed(event: SecondPassedEvent) {
+    private fun onSecondPassed(event: SecondPassedEvent) {
         if (!isEnabled()) return
 
         if (event.repeatSeconds(3)) {
@@ -124,7 +122,7 @@ object RareMobWaypointShare {
     }
 
     @HandleEvent
-    fun onWorldChange() {
+    private fun onWorldChange() {
         _waypoints.clear()
         rareMobsNearby.clear()
     }
@@ -132,7 +130,7 @@ object RareMobWaypointShare {
     private val rareMobTime = mutableListOf<SimpleTimeMark>()
 
     @HandleEvent
-    fun onRareDianaMobFound(event: RareDianaMobFoundEvent) {
+    private fun onRareDianaMobFound(event: RareDianaMobFoundEvent) {
         val rareMob = event.entity
         rareMobsNearby[rareMob.id] = rareMob
         GriffinBurrowHelper.update()
@@ -155,8 +153,8 @@ object RareMobWaypointShare {
         }
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.HUB, receiveCancelled = true)
-    fun onChat(event: SkyHanniChatEvent.Allow) {
+    @HandleEvent(onlyOnIsland = HUB, receiveCancelled = true)
+    private fun onChat(event: SkyHanniChatEvent.Allow) {
         if (!isEnabled()) return
         val message = event.message
 
@@ -198,7 +196,7 @@ object RareMobWaypointShare {
     }
 
     @HandleEvent
-    fun onEntityHealthUpdate(event: EntityHealthUpdateEvent) {
+    private fun onEntityHealthUpdate(event: EntityHealthUpdateEvent) {
         if (!isEnabled()) return
         if (event.health > 0) return
 
@@ -210,7 +208,7 @@ object RareMobWaypointShare {
     }
 
     @HandleEvent
-    fun onKeyPress(event: KeyPressEvent) {
+    private fun onKeyPress(event: KeyPressEvent) {
         if (!isEnabled()) return
         if (MinecraftCompat.screen != null) return
         if (event.keyCode == config.keyBindShare) sendRareMob()
@@ -298,12 +296,12 @@ object RareMobWaypointShare {
     @JvmStatic
     fun playUserSound() {
         with(config.sound) {
-            SoundUtils.createSound(name, pitch).playSound()
+            SoundUtils.createSound(name, pitch, isWarning = true).playSound()
         }
     }
 
     @HandleEvent
-    fun onCommandRegistration(event: CommandRegistrationEvent) {
+    private fun onCommandRegistration(event: CommandRegistrationEvent) {
         event.registerBrigadier("shresetdianamobs") {
             description = "Resets all saved rare Diana mob locations"
             category = CommandCategory.USERS_RESET

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityCallWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityCallWarning.kt
@@ -25,14 +25,10 @@ import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object HoppityCallWarning {
-
     // <editor-fold desc="Patterns">
     /**
-     * Test messages (and the real ones from Hypixel) have a space at the end of
-     * them that the IDE kills. So it's "§r§e ✆ "
-     *
-     * REGEX-TEST: §e✆ §r§bHoppity§r§e ✆
-     * REGEX-TEST: §e✆ §r§aHoppity§r§e ✆
+     * WRAPPED-REGEX-TEST: "§e✆ §r§bHoppity§r§e ✆ "
+     * WRAPPED-REGEX-TEST: "§e✆ §r§aHoppity§r§e ✆ "
      */
     private val initHoppityCallPattern by CFApi.patternGroup.pattern(
         "hoppity.call.init",
@@ -49,7 +45,7 @@ object HoppityCallWarning {
     // </editor-fold>
 
     private val config get() = HoppityEggsManager.config.hoppityCallWarning
-    private var warningSound = SoundUtils.createSound("block.note_block.pling", 1f)
+    private var warningSound = SoundUtils.createSound("block.note_block.pling", 1f, isWarning = true)
     private var activeWarning = false
     private var nextWarningTime: Instant? = null
     private var finalWarningTime: Instant? = null
@@ -57,24 +53,24 @@ object HoppityCallWarning {
     private var commandSentTimer = SimpleTimeMark.farPast()
 
     @HandleEvent
-    fun onConfigLoad(event: ConfigLoadEvent) {
+    private fun onConfigLoad(event: ConfigLoadEvent) {
         val soundProperty = config.hoppityCallSound
         ConditionalUtils.onToggle(soundProperty) {
-            warningSound = SoundUtils.createSound(soundProperty.get(), 1f)
+            warningSound = SoundUtils.createSound(soundProperty.get(), 1f, isWarning = true)
         }
         nextWarningTime = null
         finalWarningTime = null
     }
 
     @HandleEvent(priority = HandleEvent.HIGHEST)
-    fun onChat(event: SkyHanniChatEvent.Allow) {
+    private fun onChat(event: SkyHanniChatEvent.Allow) {
         if (!isEnabled()) return
         if (initHoppityCallPattern.matches(event.message)) startWarningUser()
         if (pickupHoppityCallPattern.matches(event.message)) stopWarningUser()
     }
 
     @HandleEvent
-    fun onSecondPassed(event: SecondPassedEvent) {
+    private fun onSecondPassed(event: SecondPassedEvent) {
         if (!isEnabled()) return
         if (!activeWarning) return
         if (nextWarningTime == null || finalWarningTime == null) return
@@ -87,7 +83,7 @@ object HoppityCallWarning {
     }
 
     @HandleEvent
-    fun onGuiRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
+    private fun onGuiRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
         if (!isEnabled() || !activeWarning) return
         // Calculate a fluctuating alpha value based on the sine of time, for a smooth oscillation
         val randomizationAlphaDouble = ((2 + sin(Instant.now().toEpochMilli().toDouble() / 1000)) * 255 / 4)
@@ -106,7 +102,7 @@ object HoppityCallWarning {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onCommandSend(event: MessageSendToServerEvent) {
+    private fun onCommandSend(event: MessageSendToServerEvent) {
         if (!HoppityApi.pickupOutgoingCommandPattern.matches(event.message)) return
         if (!config.ensureCoins || commandSentTimer.passedSince() < 5.seconds) return
         if (PurseApi.getPurse() >= config.coinThreshold) return
@@ -123,7 +119,7 @@ object HoppityCallWarning {
     }
 
     @HandleEvent
-    fun onWorldChange() {
+    private fun onWorldChange() {
         stopWarningUser()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingBaitWarnings.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingBaitWarnings.kt
@@ -12,20 +12,19 @@ import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object FishingBaitWarnings {
-
     private val config get() = SkyHanniMod.feature.fishing.fishingBaitWarnings
 
     private var lastBait: FishingApi.BaitType? = null
     private var wasUsingBait = true
 
     @HandleEvent
-    fun onWorldChange() {
+    private fun onWorldChange() {
         lastBait = null
         wasUsingBait = true
     }
 
     @HandleEvent
-    fun onBaitUpdate(event: BaitUpdateEvent) {
+    private fun onBaitUpdate(event: BaitUpdateEvent) {
         if (!FishingApi.holdingRod) {
             wasUsingBait = false
             lastBait = null
@@ -46,12 +45,12 @@ object FishingBaitWarnings {
     }
 
     @HandleEvent
-    fun onBobberCast(event: FishingBobberCastEvent) {
+    private fun onBobberCast(event: FishingBobberCastEvent) {
         if (config.noBaitWarning && !wasUsingBait) showNoBaitWarning()
     }
 
     private fun showBaitChangeWarning(before: String, after: String) {
-        SoundUtils.playClickSound()
+        SoundUtils.playClickSound(isWarning = true)
         TitleManager.sendTitle("§eBait changed!", duration = 2.seconds)
         ChatUtils.chat("Fishing Bait changed: $before §e-> $after")
     }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/FarmingFortuneDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/FarmingFortuneDisplay.kt
@@ -2,15 +2,12 @@ package at.hannibal2.skyhanni.features.garden
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
-import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.garden.cropmilestones.CropMilestonesApi.getCurrentMilestoneTier
 import at.hannibal2.skyhanni.data.model.SkyblockStat
 import at.hannibal2.skyhanni.data.model.SkyblockStat.FARMING_FORTUNE
 import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.data.title.TitleManager
 import at.hannibal2.skyhanni.events.WidgetUpdateEvent
-import at.hannibal2.skyhanni.events.garden.GardenToolChangeEvent
-import at.hannibal2.skyhanni.events.garden.farming.CropClickEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.features.garden.CropType.Companion.getTurboCrop
 import at.hannibal2.skyhanni.features.garden.pests.PestApi
@@ -146,8 +143,8 @@ object FarmingFortuneDisplay {
 
     private val ZORROS_CAPE = "ZORROS_CAPE".toInternalName()
 
-    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
-    fun onWidgetUpdate(event: WidgetUpdateEvent) {
+    @HandleEvent(onlyOnIsland = GARDEN)
+    private fun onWidgetUpdate(event: WidgetUpdateEvent) {
         val widget = event.widget
         if (event.isWidget(TabWidget.STATS)) {
             checkStats(widget)
@@ -203,13 +200,13 @@ object FarmingFortuneDisplay {
         }
     }
 
-    @HandleEvent(GardenToolChangeEvent::class)
-    fun onGardenToolChange() {
+    @HandleEvent
+    private fun onGardenToolChange() {
         lastToolSwitch = SimpleTimeMark.now()
     }
 
     @HandleEvent
-    fun onGuiRenderTop() {
+    private fun onGuiRenderTop() {
         if (InventoryUtils.inAnyInventory()) {
             InventoryGuiScaleCompat.withOriginalHudScale {
                 renderDisplay()
@@ -344,8 +341,8 @@ object FarmingFortuneDisplay {
         }
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
-    fun onTick(event: SkyHanniTickEvent) {
+    @HandleEvent(onlyOnIsland = GARDEN)
+    private fun onTick(event: SkyHanniTickEvent) {
         if (event.isMod(2)) update()
         if (gardenJoinTime.passedSince() > 5.seconds && !foundTabUniversalFortune && !gardenJoinTime.isFarPast()) {
             if (lastUniversalFortuneMissingError.passedSince() < 20.seconds) return
@@ -371,13 +368,13 @@ object FarmingFortuneDisplay {
         }
     }
 
-    @HandleEvent(CropClickEvent::class)
-    fun onCropClick() {
+    @HandleEvent
+    private fun onCropClick() {
         if (firstBrokenCropTime == SimpleTimeMark.farPast()) firstBrokenCropTime = SimpleTimeMark.now()
     }
 
     @HandleEvent
-    fun onWorldChange() {
+    private fun onWorldChange() {
         display = emptyList()
         gardenJoinTime = SimpleTimeMark.now()
         firstBrokenCropTime = SimpleTimeMark.farPast()
@@ -502,7 +499,7 @@ object FarmingFortuneDisplay {
     @JvmStatic
     fun playUserSound() {
         with(config.sound) {
-            SoundUtils.createSound(name, pitch).playSound()
+            SoundUtils.createSound(name, pitch, isWarning = true).playSound()
         }
     }
 
@@ -511,7 +508,7 @@ object FarmingFortuneDisplay {
     fun CropType.getLatestTrueFarmingFortune() = latestFF?.get(this)
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(3, "garden.farmingFortuneDisplay", "garden.farmingFortunes.display")
         event.move(3, "garden.farmingFortuneDropMultiplier", "garden.farmingFortunes.dropMultiplier")
         event.move(3, "garden.farmingFortunePos", "garden.farmingFortunes.pos")

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/composter/ComposterOverlay.kt
@@ -4,17 +4,13 @@ import at.hannibal2.skyhanni.api.GetFromSackApi
 import at.hannibal2.skyhanni.api.ItemBuyApi.createBuyTipLine
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
-import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierArguments
-import at.hannibal2.skyhanni.config.features.garden.composter.ComposterConfig.RetrieveFromEntry
-import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.SackApi.getAmountInSacksOrNull
 import at.hannibal2.skyhanni.data.SackApi.isMissingSackItem
 import at.hannibal2.skyhanni.data.garden.ComposterUpgradesData
 import at.hannibal2.skyhanni.data.jsonobjects.repo.GardenJson
 import at.hannibal2.skyhanni.data.model.ComposterUpgrade
-import at.hannibal2.skyhanni.data.model.TabWidget
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.IslandJoinEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
@@ -74,7 +70,6 @@ import kotlin.time.Duration.Companion.milliseconds
  */
 @SkyHanniModule
 object ComposterOverlay {
-
     private var displayDirty = false
     private var organicMatterFactors: Map<NeuInternalName, Double> = emptyMap()
     private var fuelFactors: Map<NeuInternalName, Double> = emptyMap()
@@ -118,27 +113,27 @@ object ComposterOverlay {
     private val VOLTA = "VOLTA".toInternalName()
     private val OIL_BARREL = "OIL_BARREL".toInternalName()
 
-    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
-    fun onWidgetUpdate(event: WidgetUpdateEvent) {
-        if (!isEnabled() || !event.isWidget(TabWidget.COMPOSTER)) return
+    @HandleEvent(onlyOnIsland = GARDEN)
+    private fun onWidgetUpdate(event: WidgetUpdateEvent) {
+        if (!isEnabled() || !event.isWidget(COMPOSTER)) return
         displayDirty = true
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
-    fun onTick() {
+    @HandleEvent(onlyOnIsland = GARDEN)
+    private fun onTick() {
         if (composterUpgradesInventory.isInside() && extraComposterUpgrade != null && lastHovered.passedSince() > 200.milliseconds) {
             extraComposterUpgrade = null
             displayDirty = true
         }
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
-    fun onInventoryFullyOpened() {
+    @HandleEvent(onlyOnIsland = GARDEN)
+    private fun onInventoryFullyOpened() {
         if (inInventory) displayDirty = true
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
-    fun onToolTip(event: ToolTipTextEvent) {
+    @HandleEvent(onlyOnIsland = GARDEN)
+    private fun onToolTip(event: ToolTipTextEvent) {
         if (!composterUpgradesInventory.isInside()) return
         for (upgrade in ComposterUpgrade.entries) {
             val name = event.itemStack.cleanName
@@ -531,7 +526,7 @@ object ComposterOverlay {
 
     private fun retrieveMaterials(internalName: NeuInternalName, itemName: String, itemsNeeded: Int) {
         if (itemsNeeded == 0) return
-        if (config.retrieveFrom == RetrieveFromEntry.BAZAAR &&
+        if (config.retrieveFrom == BAZAAR &&
             !SkyBlockUtils.noTradeMode && internalName != BIOFUEL
         ) {
             BazaarApi.searchForBazaarItem(itemName, itemsNeeded)
@@ -564,7 +559,7 @@ object ComposterOverlay {
             }
         }
         if (havingInSacks == 0) {
-            SoundUtils.playErrorSound()
+            SoundUtils.playErrorSound(isWarning = false)
             if (SkyBlockUtils.noTradeMode) {
                 ChatUtils.chat("No $itemName §efound in sacks. Opening recipe.")
                 HypixelCommands.recipe(itemName)
@@ -599,19 +594,19 @@ object ComposterOverlay {
     }
 
     @HandleEvent
-    fun onNeuRepoReload() {
+    private fun onNeuRepoReload() {
         updateOrganicMatterFactors()
     }
 
     // hopefully fix the display not working properly
     @HandleEvent
-    fun onIslandJoin(event: IslandJoinEvent) {
-        if (event.island != IslandType.GARDEN) return
+    private fun onIslandJoin(event: IslandJoinEvent) {
+        if (event.island != GARDEN) return
         updateOrganicMatterFactors()
     }
 
     @HandleEvent
-    fun onRepoReload(event: RepositoryReloadEvent) {
+    private fun onRepoReload(event: RepositoryReloadEvent) {
         val data = event.getConstant<GardenJson>("Garden")
         organicMatter = data.organicMatter
         fuelFactors = data.fuel
@@ -619,7 +614,7 @@ object ComposterOverlay {
     }
 
     @HandleEvent
-    fun onConfigLoad() {
+    private fun onConfigLoad() {
         with(config) {
             ConditionalUtils.onToggle(minimumOrganicMatter) {
                 updateOrganicMatterFactors()
@@ -670,7 +665,7 @@ object ComposterOverlay {
     }
 
     @HandleEvent
-    fun onChestGuiRender() {
+    private fun onChestGuiRender() {
         if (!isEnabled() || !inInventory) return
         if (EstimatedItemValue.isCurrentlyShowing()) return
         if (displayDirty) {
@@ -696,7 +691,7 @@ object ComposterOverlay {
     }
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(3, "garden.composterOverlay", "garden.composters.overlay")
         event.move(3, "garden.composterOverlayPriceType", "garden.composters.overlayPriceType")
         event.move(3, "garden.composterOverlayRetrieveFrom", "garden.composters.retrieveFrom")
@@ -706,7 +701,7 @@ object ComposterOverlay {
     }
 
     @HandleEvent
-    fun onDebugDataCollect(event: DebugDataCollectEvent) {
+    private fun onDebugDataCollect(event: DebugDataCollectEvent) {
         event.title("Garden Composter")
 
         event.addIrrelevant {
@@ -732,10 +727,10 @@ object ComposterOverlay {
     }
 
     @HandleEvent
-    fun onCommandRegistration(event: CommandRegistrationEvent) {
+    private fun onCommandRegistration(event: CommandRegistrationEvent) {
         event.registerBrigadier("shtestcomposter") {
             description = "Test the composter overlay"
-            category = CommandCategory.DEVELOPER_DEBUG
+            category = DEVELOPER_DEBUG
             argCallback("offset", BrigadierArguments.integer()) {
                 testOffset = it
                 ChatUtils.chat("Composter test offset set to $testOffset.")

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/farming/lane/FarmingLaneFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/farming/lane/FarmingLaneFeatures.kt
@@ -1,7 +1,6 @@
 package at.hannibal2.skyhanni.features.garden.farming.lane
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.title.TitleContext
 import at.hannibal2.skyhanni.data.title.TitleManager
 import at.hannibal2.skyhanni.events.GuiRenderEvent
@@ -53,17 +52,17 @@ object FarmingLaneFeatures {
     }
 
     @HandleEvent
-    fun onFarmingLaneSwitch(event: FarmingLaneSwitchEvent) {
+    private fun onFarmingLaneSwitch(event: FarmingLaneSwitchEvent) {
         display = emptyList()
     }
 
     @HandleEvent
-    fun onGardenToolChange(event: GardenToolChangeEvent) {
+    private fun onGardenToolChange(event: GardenToolChangeEvent) {
         display = emptyList()
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
-    fun onTick() {
+    @HandleEvent(onlyOnIsland = GARDEN)
+    private fun onTick() {
         if (!config.distanceDisplay && !config.laneSwitchNotification.enabled) return
 
         if (!calculateDistance()) return
@@ -77,7 +76,7 @@ object FarmingLaneFeatures {
             display = buildList {
                 add("§7Distance until switch: §e${currentDistance.roundTo(1)}")
 
-                val normal = movementState == MovementState.NORMAL
+                val normal = movementState == NORMAL
                 val color = if (normal) "§b" else "§8"
                 val timeRemaining = timeRemaining ?: return@buildList
                 val format = timeRemaining.format(showMilliSeconds = timeRemaining < 20.seconds)
@@ -157,7 +156,7 @@ object FarmingLaneFeatures {
     private fun calculateSpeed(): Boolean {
         val speed = MovementSpeedDisplay.bpsMoveSpeed.roundTo(2)
         movementState = calculateMovementState(speed)
-        if (movementState != MovementState.NORMAL) return false
+        if (movementState != NORMAL) return false
 
         val timeRemaining = (currentDistance / speed).seconds
         FarmingLaneFeatures.timeRemaining = timeRemaining
@@ -179,23 +178,22 @@ object FarmingLaneFeatures {
         sameSpeedCounter++
 
         if (speed == 0.0 && sameSpeedCounter > 1) {
-            return MovementState.NOT_MOVING
+            return NOT_MOVING
         }
         val speedTooSlow = speed < 1
         if (speedTooSlow && sameSpeedCounter > 5) {
-            return MovementState.TOO_SLOW
+            return TOO_SLOW
         }
         // only calculate the time if the speed has not changed
         if (sameSpeedCounter < 6) {
-            return MovementState.CALCULATING
+            return CALCULATING
         }
 
-
-        return MovementState.NORMAL
+        return NORMAL
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
-    fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
+    @HandleEvent(onlyOnIsland = GARDEN)
+    private fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
         if (!config.cornerWaypoints) return
 
         val lane = FarmingLaneApi.currentLane ?: return
@@ -212,8 +210,8 @@ object FarmingLaneFeatures {
 
     private fun LorenzVec.capAtBuildHeight(): LorenzVec = if (y > 76) copy(y = 76.0) else this
 
-    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
-    fun onGuiRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
+    @HandleEvent(onlyOnIsland = GARDEN)
+    private fun onGuiRenderOverlay(event: GuiRenderEvent.GuiOverlayRenderEvent) {
         if (!config.distanceDisplay) return
 
         config.distanceDisplayPosition.renderStrings(display, posLabel = "Lane Display")
@@ -222,7 +220,7 @@ object FarmingLaneFeatures {
     @JvmStatic
     fun playUserSound() {
         with(config.laneSwitchNotification.sound) {
-            SoundUtils.createSound(name, pitch).playSound()
+            SoundUtils.createSound(name, pitch, isWarning = true).playSound()
         }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnSound.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnSound.kt
@@ -2,8 +2,6 @@ package at.hannibal2.skyhanni.features.garden.pests
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.config.features.garden.pests.PestSpawnConfig
-import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.PlaySoundEvent
 import at.hannibal2.skyhanni.features.garden.GardenApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -19,19 +17,18 @@ object PestSpawnSound {
     private val config get() = GardenApi.config.pests.pestSpawn
     private var lastPestSpawnSound = SimpleTimeMark.farPast()
 
-    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
-    fun onPlaySound(event: PlaySoundEvent) {
+    @HandleEvent(onlyOnIsland = GARDEN)
+    private fun onPlaySound(event: PlaySoundEvent) {
         if (!event.isPestSpawnSound()) return
 
         when (config.soundMode) {
-            PestSpawnConfig.PestSpawnSoundMode.DEFAULT -> return
-            PestSpawnConfig.PestSpawnSoundMode.MUTED -> event.cancel()
-            PestSpawnConfig.PestSpawnSoundMode.CUSTOM -> {
+            DEFAULT -> return
+            MUTED -> event.cancel()
+            CUSTOM -> {
                 event.cancel()
                 repeatSpawnSound()
             }
-
-            PestSpawnConfig.PestSpawnSoundMode.PLUMBER -> {
+            PLUMBER -> {
                 event.cancel()
                 plumberSpawnSound()
             }
@@ -46,7 +43,7 @@ object PestSpawnSound {
             SoundUtils.repeatSound(
                 repeatFrequency.toLong(),
                 repeatAmount,
-                createSound(name, pitch)
+                createSound(name, pitch, isWarning = true)
             )
         }
     }
@@ -58,10 +55,10 @@ object PestSpawnSound {
 
     private fun playPlumberTheme(soundName: String) {
         SkyHanniMod.launchCoroutine("pest spawn sound") {
-            val noteE = createSound(soundName, 0.890899f)
-            val noteC = createSound(soundName, 0.707107f)
-            val noteG = createSound(soundName, 1.059463f)
-            val noteLowG = createSound(soundName, 0.529732f)
+            val noteE = createSound(soundName, 0.890899f, isWarning = true)
+            val noteC = createSound(soundName, 0.707107f, isWarning = true)
+            val noteG = createSound(soundName, 1.059463f, isWarning = true)
+            val noteLowG = createSound(soundName, 0.529732f, isWarning = true)
 
             noteE.playSound()
             delay((166).toLong())

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestSpawnTimer.kt
@@ -44,7 +44,6 @@ import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object PestSpawnTimer {
-
     private val config get() = PestApi.config.pestTimer
     private val patternGroup = RepoPattern.group("garden.pests")
     private val cooldownOverMessageId = ChatUtils.getUniqueMessageId()
@@ -325,7 +324,7 @@ object PestSpawnTimer {
     @JvmStatic
     fun playUserSound() {
         with(config.sound) {
-            SoundUtils.createSound(name, pitch).playSound()
+            SoundUtils.createSound(name, pitch, isWarning = true).playSound()
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestTrapFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/pests/PestTrapFeatures.kt
@@ -3,9 +3,7 @@ package at.hannibal2.skyhanni.features.garden.pests
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.features.garden.pests.PestTrapConfig
-import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.title.TitleManager
-import at.hannibal2.skyhanni.events.ConfigLoadEvent
 import at.hannibal2.skyhanni.events.GuiKeyPressEvent
 import at.hannibal2.skyhanni.events.garden.pests.PestTrapDataEvent
 import at.hannibal2.skyhanni.features.garden.pests.PestTrapApi.MAX_TRAPS
@@ -31,7 +29,6 @@ private typealias WarningDisplayType = PestTrapConfig.WarningConfig.WarningDispl
 
 @SkyHanniModule
 object PestTrapFeatures {
-
     private val config get() = SkyHanniMod.feature.garden.pests.pestTrap
     private val enabledTypes: WarningDisplayType get() = config.warningConfig.warningDisplayType.get()
     private val userEnabledWarnings: List<WarningReason> get() = config.warningConfig.enabledWarnings.get()
@@ -54,17 +51,18 @@ object PestTrapFeatures {
     private var warningSound: SoundInstance? = refreshSound()
 
     private fun getNextWarningMark() = SimpleTimeMark.now() + virtualReminderInterval
-    private fun refreshSound() = soundString.takeIf(String::isNotEmpty)?.let { SoundUtils.createSound(it, 1f) }
+    private fun refreshSound() =
+        soundString.takeIf(String::isNotEmpty)?.let { SoundUtils.createSound(it, 1f, isWarning = true) }
 
     @HandleEvent
-    fun onKeybind(event: GuiKeyPressEvent) {
+    private fun onKeybind(event: GuiKeyPressEvent) {
         if (!PestTrapApi.inInventory) return
         if (!config.releaseHotkey.isKeyHeld()) return
         InventoryUtils.clickSlot(16)
     }
 
-    @HandleEvent(ConfigLoadEvent::class)
-    fun onConfigLoad() {
+    @HandleEvent
+    private fun onConfigLoad() {
         ConditionalUtils.onToggle(config.warningConfig.warningSound) {
             warningSound = refreshSound()
         }
@@ -98,15 +96,15 @@ object PestTrapFeatures {
     }
 
     @HandleEvent
-    fun onPestTrapDataUpdate(event: PestTrapDataEvent) {
+    private fun onPestTrapDataUpdate(event: PestTrapDataEvent) {
         allActiveWarnings.clear()
         if (event.trapsPlaced < MAX_TRAPS) allActiveWarnings.add(WarningReason.UNPLACED_TRAPS)
         if (event.fullTraps.isNotEmpty()) allActiveWarnings.add(WarningReason.TRAP_FULL)
         if (event.noBaitTraps.isNotEmpty()) allActiveWarnings.add(WarningReason.NO_BAIT)
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.GARDEN)
-    fun onSecondPassed() {
+    @HandleEvent(onlyOnIsland = GARDEN)
+    private fun onSecondPassed() {
         val applicableWarnings = allActiveWarnings.filter { it in userEnabledWarnings }
         if (applicableWarnings.isEmpty() || nextWarningMark.isInFuture()) return
         val activeWarnings = applicableWarnings.map { it.getDescriptiveWarning() }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/OldSkyblockMenu.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/OldSkyblockMenu.kt
@@ -71,7 +71,7 @@ object OldSkyblockMenu {
             sbButton.command.call()
         } else {
             TitleManager.sendTitle("Requires cookie buff!", location = TitleManager.TitleLocation.INVENTORY)
-            SoundUtils.playErrorSound()
+            SoundUtils.playErrorSound(isWarning = false)
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/CFApi.kt
@@ -46,7 +46,6 @@ import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object CFApi {
-
     private val chromaEnabled get() = ChromaManager.config.enabled.get()
     val config: CFConfig get() = SkyHanniMod.feature.inventory.chocolateFactory
     val profileStorage: CFStorage? get() = ProfileStorageData.profileSpecific?.chocolateFactory
@@ -128,7 +127,7 @@ object CFApi {
     var bestPossibleSlot = -1
 
     var specialRabbitTextures = listOf<String>()
-    var warningSound = SoundUtils.createSound("block.note_block.pling", 1f)
+    var warningSound = SoundUtils.createSound("block.note_block.pling", 1f, isWarning = true)
     val mainInventory = InventoryDetector { HoppityApi.chocolateFactoryInvPattern }
 
     private val partyModeRegex = Regex("§[a-fA-F0-9]")

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/data/CFDataLoader.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/chocolatefactory/data/CFDataLoader.kt
@@ -36,7 +36,6 @@ import at.hannibal2.skyhanni.utils.compat.formattedTextCompatLeadingWhiteLessRes
 
 @SkyHanniModule
 object CFDataLoader {
-
     private val config get() = CFApi.config
     private val profileStorage get() = CFApi.profileStorage
 
@@ -237,7 +236,7 @@ object CFDataLoader {
     // </editor-fold>
 
     @HandleEvent
-    fun onInventoryUpdated(event: InventoryUpdatedEvent) {
+    private fun onInventoryUpdated(event: InventoryUpdatedEvent) {
         if (!CFApi.inChocolateFactory) return
         DelayedRun.runOrNextTick {
             updateInventoryItems(event.inventoryItems)
@@ -245,17 +244,17 @@ object CFDataLoader {
     }
 
     @HandleEvent
-    fun onWorldChange() {
+    private fun onWorldChange() {
         clearData()
     }
 
     @HandleEvent
-    fun onInventoryClose(event: InventoryCloseEvent) {
+    private fun onInventoryClose(event: InventoryCloseEvent) {
         clearData()
     }
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(
             47,
             "inventory.chocolateFactory.rabbitWarning",
@@ -264,10 +263,10 @@ object CFDataLoader {
     }
 
     @HandleEvent
-    fun onConfigLoad(event: ConfigLoadEvent) {
+    private fun onConfigLoad(event: ConfigLoadEvent) {
         val soundProperty = config.rabbitWarning.specialRabbitSound
         ConditionalUtils.onToggle(soundProperty) {
-            CFApi.warningSound = SoundUtils.createSound(soundProperty.get(), 1f)
+            CFApi.warningSound = SoundUtils.createSound(soundProperty.get(), 1f, isWarning = true)
         }
 
         config.chocolateUpgradeWarnings.upgradeWarningTimeTower.whenChanged { _, _ ->

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/superpairs/UltraRareBookAlert.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/experimentationtable/superpairs/UltraRareBookAlert.kt
@@ -4,7 +4,6 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.ExperimentationTableApi
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
-import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.title.TitleManager
 import at.hannibal2.skyhanni.events.GuiRenderEvent
 import at.hannibal2.skyhanni.events.InventoryCloseEvent
@@ -22,9 +21,8 @@ import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object UltraRareBookAlert {
-
     private val config get() = SkyHanniMod.feature.inventory.experimentationTable
-    private val dragonSound by lazy { createSound("entity.ender_dragon.growl", 1f) }
+    private val dragonSound by lazy { createSound("entity.ender_dragon.growl", 1f, isWarning = true) }
 
     private var enchantsFound = false
 
@@ -53,8 +51,8 @@ object UltraRareBookAlert {
         )
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND)
-    fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
+    @HandleEvent(onlyOnIsland = PRIVATE_ISLAND)
+    private fun onChestGuiRender(event: GuiRenderEvent.ChestGuiOverlayRenderEvent) {
         if (!isEnabled()) return
         if (lastNotificationTime.passedSince() > 5.seconds) return
 
@@ -65,21 +63,21 @@ object UltraRareBookAlert {
         )
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND)
-    fun onTableRareUncover(event: TableRareUncoverEvent) {
+    @HandleEvent(onlyOnIsland = PRIVATE_ISLAND)
+    private fun onTableRareUncover(event: TableRareUncoverEvent) {
         if (enchantsFound || !isEnabled()) return
         lastUncoveredWasBook = event.isBook
         notification(event.dropName, event.isBook)
         enchantsFound = true
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.PRIVATE_ISLAND)
-    fun onInventoryClose(event: InventoryCloseEvent) {
+    @HandleEvent(onlyOnIsland = PRIVATE_ISLAND)
+    private fun onInventoryClose(event: InventoryCloseEvent) {
         enchantsFound = false
     }
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(59, "inventory.helper.enchanting.ultraRareBookAlert", "inventory.experimentationTable.ultraRareBookAlert")
 
         val pathBase = "inventory.experimentationTable"

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ScrapGFS.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/fossilexcavator/ScrapGFS.kt
@@ -4,7 +4,6 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.GetFromSackApi
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.HypixelData
-import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.SackApi
 import at.hannibal2.skyhanni.events.OwnInventoryItemUpdateEvent
 import at.hannibal2.skyhanni.events.SackChangeEvent
@@ -17,7 +16,6 @@ import at.hannibal2.skyhanni.utils.KeyboardManager.LEFT_MOUSE
 import at.hannibal2.skyhanni.utils.KeyboardManager.RIGHT_MOUSE
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.NeuItemStackProvider
-import at.hannibal2.skyhanni.utils.RenderUtils
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SoundUtils
@@ -39,7 +37,6 @@ import kotlin.time.Duration.Companion.milliseconds
 
 @SkyHanniModule
 object ScrapGFS {
-
     private val config get() = SkyHanniMod.feature.mining.fossilExcavator.scrapGFS
     private val enabled get() = config.enabled && FossilExcavatorApi.inExcavatorMenu
     private val currentFetchAmount get() = config.fetchAmount.get()
@@ -73,7 +70,7 @@ object ScrapGFS {
     }.sumOf { it.count }
 
     @HandleEvent
-    fun onConfigLoad() {
+    private fun onConfigLoad() {
         config.fetchAmount.afterChange {
             uiDirty = true
             if (currentFetchAmount !in validRange) {
@@ -82,21 +79,21 @@ object ScrapGFS {
         }
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.DWARVEN_MINES)
-    fun onOwnInventoryItemUpdate(event: OwnInventoryItemUpdateEvent) {
+    @HandleEvent(onlyOnIsland = DWARVEN_MINES)
+    private fun onOwnInventoryItemUpdate(event: OwnInventoryItemUpdateEvent) {
         if (!enabled) return
         susScrapInInventory = getSusScrapCurrentlyInInventory()
         uiDirty = true
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.DWARVEN_MINES)
-    fun onSackChange(event: SackChangeEvent) {
+    @HandleEvent(onlyOnIsland = DWARVEN_MINES)
+    private fun onSackChange(event: SackChangeEvent) {
         if (!enabled || event.sackChanges.none { it.internalName == FossilExcavatorApi.scrapItem }) return
         uiDirty = true
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.DWARVEN_MINES)
-    fun onChestGuiRender() {
+    @HandleEvent(onlyOnIsland = DWARVEN_MINES)
+    private fun onChestGuiRender() {
         if (!enabled) return
         if (config.onlyIfNoScrap && susScrapInInventory > 0) return
         if (uiDirty) {
@@ -109,8 +106,8 @@ object ScrapGFS {
 
     private fun buildFinalRenderable() = Renderable.drawInsideRoundedRectWithOutline(
         Renderable.vertical(
-            horizontalAlign = RenderUtils.HorizontalAlignment.CENTER,
-            verticalAlign = RenderUtils.VerticalAlignment.CENTER,
+            horizontalAlign = CENTER,
+            verticalAlign = CENTER,
             spacing = 5,
         ) {
             addFetchButton()
@@ -121,20 +118,19 @@ object ScrapGFS {
         topOutlineColor = lighterGray.rgb,
         bottomOutlineColor = lighterGray.rgb,
         borderOutlineThickness = 3,
-        horizontalAlign = RenderUtils.HorizontalAlignment.CENTER,
-        verticalAlign = RenderUtils.VerticalAlignment.CENTER,
+        horizontalAlign = CENTER,
+        verticalAlign = CENTER,
         padding = 5,
     )
 
     private fun MutableList<Renderable>.addCenterDisplay() = Renderable.horizontal(
         spacing = 10,
-        horizontalAlign = RenderUtils.HorizontalAlignment.CENTER
+        horizontalAlign = CENTER
     ) {
-        addStaticSetButton("Minimum", LorenzColor.RED, validRange.first)
+        addStaticSetButton("Minimum", RED, validRange.first)
         addCurrentFetchContainer()
-        addStaticSetButton("Maximum", LorenzColor.GREEN, validRange.last)
+        addStaticSetButton("Maximum", GREEN, validRange.last)
     }.let { add(it) }
-
 
     private fun MutableList<Renderable>.addSackInfoFooter() = with(SackApi) {
         FossilExcavatorApi.scrapItem.getAmountInSacksOrNull()?.takeIf { it > 0 }?.let { scrapInSacks ->
@@ -144,7 +140,7 @@ object ScrapGFS {
                         "Scrap In Sacks: §f$scrapInSacks",
                         scale = 0.9,
                         color = lighterGray,
-                        horizontalAlign = RenderUtils.HorizontalAlignment.CENTER
+                        horizontalAlign = CENTER
                     ),
                     tips = listOf("§7Click to set fetch amount to §f$scrapInSacks§7!")
                 ),
@@ -159,7 +155,7 @@ object ScrapGFS {
                 "No Scrap in Sacks!",
                 scale = 0.9,
                 color = lighterGray,
-                horizontalAlign = RenderUtils.HorizontalAlignment.CENTER
+                horizontalAlign = CENTER
             )
             when (config.bzIfSacksEmpty && !HypixelData.noTrade) {
                 true -> Renderable.vertical {
@@ -168,7 +164,7 @@ object ScrapGFS {
                         Renderable.text(
                             "§eClick to buy from Bazaar",
                             scale = 0.9,
-                            horizontalAlign = RenderUtils.HorizontalAlignment.CENTER
+                            horizontalAlign = CENTER
                         ),
                         onLeftClick = { HypixelCommands.bazaar("Suspicious Scrap") },
                         underlineColor = lightestGray,
@@ -180,7 +176,7 @@ object ScrapGFS {
     }
 
     private fun MutableList<Renderable>.addFetchButton() = Renderable.darkRectButton(
-        Renderable.text("Get Scrap from Sacks", horizontalAlign = RenderUtils.HorizontalAlignment.CENTER, scale = 1.2),
+        Renderable.text("Get Scrap from Sacks", horizontalAlign = CENTER, scale = 1.2),
         onClick = {
             SoundUtils.playClickSound()
             GetFromSackApi.getFromSack(FossilExcavatorApi.scrapItem, currentFetchAmount)
@@ -197,12 +193,12 @@ object ScrapGFS {
                         frameStorage = scrapFrameStorage
                         rotationStorage = scrapRotationStorage
                         scale = 1.2
-                        horizontalAlign = RenderUtils.HorizontalAlignment.CENTER
+                        horizontalAlign = CENTER
                     },
-                    Renderable.text(currentFetchAmount.toString(), scale = 0.9, horizontalAlign = RenderUtils.HorizontalAlignment.CENTER),
+                    Renderable.text(currentFetchAmount.toString(), scale = 0.9, horizontalAlign = CENTER),
                 ),
-                horizontalAlign = RenderUtils.HorizontalAlignment.CENTER,
-                verticalAlign = RenderUtils.VerticalAlignment.CENTER,
+                horizontalAlign = CENTER,
+                verticalAlign = CENTER,
                 spacing = 3,
             ),
             padding = 4,
@@ -219,7 +215,7 @@ object ScrapGFS {
 
     private fun scrollWithStaggerSound(offset: Int) {
         if (!offset.incrementValid()) {
-            SoundUtils.playErrorSound()
+            SoundUtils.playErrorSound(isWarning = false)
             return
         }
         config.fetchAmount.set(currentFetchAmount + offset)
@@ -237,7 +233,7 @@ object ScrapGFS {
             increment > 0 -> "§a"
             else -> "§c"
         } + increment.getIncrementText(),
-        horizontalAlign = RenderUtils.HorizontalAlignment.CENTER,
+        horizontalAlign = CENTER,
     )
 
     private fun buildIncrementButton(increment: Int): Renderable = Renderable.darkRectButton(
@@ -245,7 +241,7 @@ object ScrapGFS {
         onClick = {
             if (!increment.incrementValid()) {
                 if (lastScrollErrorSound.passedSince() > 100.milliseconds) {
-                    SoundUtils.playErrorSound()
+                    SoundUtils.playErrorSound(isWarning = false)
                     lastScrollErrorSound = SimpleTimeMark.now()
                 }
                 return@darkRectButton
@@ -263,18 +259,18 @@ object ScrapGFS {
         value: Int
     ) = Renderable.darkRectButton(
         Renderable.vertical(
-            horizontalAlign = RenderUtils.HorizontalAlignment.CENTER,
-            verticalAlign = RenderUtils.VerticalAlignment.CENTER,
+            horizontalAlign = CENTER,
+            verticalAlign = CENTER,
         ) {
             val pre = color.getChatColor()
             Renderable.text(
                 "$pre$label",
-                horizontalAlign = RenderUtils.HorizontalAlignment.CENTER,
+                horizontalAlign = CENTER,
                 scale = 0.9
             ).let { add(it) }
             Renderable.text(
                 "$pre($value)",
-                horizontalAlign = RenderUtils.HorizontalAlignment.CENTER,
+                horizontalAlign = CENTER,
                 scale = 0.8
             ).let { add(it) }
         },
@@ -284,6 +280,6 @@ object ScrapGFS {
         },
         padding = 4,
     ).let {
-        add(Renderable.vertical(verticalAlign = RenderUtils.VerticalAlignment.CENTER) { add(it) })
+        add(Renderable.vertical(verticalAlign = CENTER) { add(it) })
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/NoBitsWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/NoBitsWarning.kt
@@ -17,13 +17,11 @@ import net.minecraft.ChatFormatting
 
 @SkyHanniModule
 object NoBitsWarning {
-
     private val config get() = SkyHanniMod.feature.misc.bits
 
     @HandleEvent
-    fun onBitsGain(event: BitsUpdateEvent.BitsGain) {
+    private fun onBitsGain(event: BitsUpdateEvent.BitsGain) {
         if (config.enableWarning && event.bitsAvailable == 0) {
-
             ChatUtils.clickableChat(
                 "§bNo Bits Available! §eClick to buy booster cookies on the bazaar.",
                 onClick = { HypixelCommands.bazaar("booster cookie") },
@@ -31,7 +29,8 @@ object NoBitsWarning {
             )
             // TODO use reminder utils
             TitleManager.sendTitle("§bNo Bits Available")
-            if (config.notificationSound) SoundUtils.repeatSound(100, 10, createSound("block.note_block.pling", 0.6f))
+            val sound = createSound("block.note_block.pling", 0.6f, isWarning = true)
+            if (config.notificationSound) SoundUtils.repeatSound(100, 10, sound)
         }
 
         if (config.bitsGainChatMessage) {
@@ -47,7 +46,7 @@ object NoBitsWarning {
     }
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(35, "misc.noBitsWarning", "misc.noBitsWarning.enabled")
         event.move(40, "misc.noBitsWarning.enabled", "misc.bits.enableWarning")
         event.move(40, "misc.noBitsWarning.notificationSound", "misc.bits.notificationSound")

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/reminders/ReminderManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/reminders/ReminderManager.kt
@@ -27,7 +27,6 @@ import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object ReminderManager {
-
     private const val REMINDERS_PER_PAGE = 10
 
     // Random numbers chosen, this will be used to delete the old list and action messages
@@ -154,7 +153,7 @@ object ReminderManager {
     }
 
     @HandleEvent
-    fun onSecondPassed(event: SecondPassedEvent) {
+    private fun onSecondPassed(event: SecondPassedEvent) {
         val remindersToSend = mutableListOf<Component>()
         val firedReasons = mutableListOf<String>()
 
@@ -194,7 +193,7 @@ object ReminderManager {
         }
 
         if (remindersToSend.isNotEmpty()) {
-            SoundUtils.repeatSound(150, 3, SoundUtils.createSound("block.note_block.pling", 1.5f))
+            SoundUtils.repeatSound(150, 3, SoundUtils.createSound("block.note_block.pling", 1.5f, isWarning = true))
             if (config.showTitle) {
                 val subtitle = if (firedReasons.size == 1) "§e${firedReasons.first()}" else null
                 val titleText = if (firedReasons.size == 1) "§cReminder!" else "§c${firedReasons.size} Reminders!"
@@ -206,7 +205,7 @@ object ReminderManager {
     }
 
     @HandleEvent
-    fun onCommandRegistration(event: CommandRegistrationEvent) {
+    private fun onCommandRegistration(event: CommandRegistrationEvent) {
         event.registerBrigadier("shremind") {
             description = "Set a reminder for yourself"
             literal("list") {

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/colosseum/KillZoneWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/colosseum/KillZoneWarning.kt
@@ -21,7 +21,6 @@ import kotlin.time.Duration.Companion.milliseconds
 
 @SkyHanniModule
 object KillZoneWarning {
-
     private val config get() = SkyHanniMod.feature.rift.area.colosseum
 
     private val patternGroup = RepoPattern.group("rift.colosseum.bacte")
@@ -37,7 +36,7 @@ object KillZoneWarning {
         "§a⚠ §r§cGet back in the arena or you will DIE(?<exclamation>!+) §r§a⚠"
     )
 
-    private val sound by lazy { SoundUtils.createSound("entity.experience_orb.pickup", 0.0f) }
+    private val sound by lazy { SoundUtils.createSound("entity.experience_orb.pickup", 0.0f, isWarning = true) }
 
     private var lastMessageTime = SimpleTimeMark.farPast()
     private var killDeadline = SimpleTimeMark.farPast()

--- a/src/main/java/at/hannibal2/skyhanni/features/skillprogress/SkillProgress.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/skillprogress/SkillProgress.kt
@@ -42,7 +42,6 @@ import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object SkillProgress {
-
     val config get() = SkyHanniMod.feature.skillProgress
     private val barConfig get() = config.skillProgressBarConfig
     private val allSkillConfig get() = config.allSkillDisplayConfig
@@ -58,7 +57,7 @@ object SkillProgress {
     var hideInActionBar = listOf<String>()
 
     @HandleEvent
-    fun onGuiRenderOverlay() {
+    private fun onGuiRenderOverlay() {
         if (!isDisplayEnabled()) return
         if (display.isEmpty()) return
 
@@ -76,7 +75,7 @@ object SkillProgress {
     }
 
     @HandleEvent
-    fun onChestGuiRender() {
+    private fun onChestGuiRender() {
         if (!isDisplayEnabled()) return
         if (display.isEmpty()) return
 
@@ -86,7 +85,7 @@ object SkillProgress {
     }
 
     @HandleEvent
-    fun onGuiRenderTop() {
+    private fun onGuiRenderTop() {
         if (!isDisplayEnabled()) return
         if (display.isEmpty()) return
 
@@ -154,7 +153,7 @@ object SkillProgress {
     }
 
     @HandleEvent
-    fun onProfileJoin() {
+    private fun onProfileJoin() {
         display = emptyList()
         allDisplay = emptyList()
         etaDisplay = emptyList()
@@ -162,7 +161,7 @@ object SkillProgress {
     }
 
     @HandleEvent
-    fun onSecondPassed(event: SecondPassedEvent) {
+    private fun onSecondPassed(event: SecondPassedEvent) {
         if (!isDisplayEnabled()) return
         if (lastUpdate.passedSince() > 3.seconds) showDisplay = config.alwaysShow.get()
 
@@ -176,7 +175,7 @@ object SkillProgress {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onLevelUp(event: SkillOverflowLevelUpEvent) {
+    private fun onLevelUp(event: SkillOverflowLevelUpEvent) {
         if (!config.overflowConfig.enableInChat) return
         val skillName = event.skill.displayName
         val oldLevel = event.oldLevel
@@ -209,11 +208,11 @@ object SkillProgress {
         if (goalReached)
             chat("§lYou have reached your goal level of §b§l${skill.customGoalLevel} §e§lin the §b§l$skillName §e§lskill!")
 
-        SoundUtils.createSound("entity.player.levelup", 1f, 1f).playSound()
+        SoundUtils.createSound("entity.player.levelup", 1f, 1f, isWarning = false).playSound()
     }
 
     @HandleEvent
-    fun onConfigLoad() {
+    private fun onConfigLoad() {
         onToggle(
             config.enabled,
             config.alwaysShow,
@@ -236,7 +235,7 @@ object SkillProgress {
     }
 
     @HandleEvent(priority = HandleEvent.LOW)
-    fun onActionBar(event: ActionBarUpdateEvent) {
+    private fun onActionBar(event: ActionBarUpdateEvent) {
         if (!config.hideInActionBar || !isDisplayEnabled()) return
         var msg = event.actionBar
         for (line in hideInActionBar) {
@@ -494,7 +493,6 @@ object SkillProgress {
         if (xpInfo.lastTotalXP > 0) {
             val delta = totalXP - xpInfo.lastTotalXP
             if (delta > 0) {
-
                 xpInfo.timer = when (SkillApi.activeSkill) {
                     SkillType.FARMING -> etaConfig.farmingPauseTime
                     SkillType.MINING -> etaConfig.miningPauseTime

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/GummyWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/GummyWarning.kt
@@ -30,7 +30,6 @@ import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object GummyWarning {
-
     private val config get() = SkyHanniMod.feature.slayer
     private var lastWarned = SimpleTimeMark.farPast()
     private var lastWarningShown = SimpleTimeMark.farPast()
@@ -98,7 +97,7 @@ object GummyWarning {
 
         DelayedRun.runDelayed(0.5.seconds) {
             lastWarningShown = SimpleTimeMark.now()
-            SoundUtils.createSound("block.anvil.land", 0.5f).playSound()
+            SoundUtils.createSound("block.anvil.land", 0.5f, isWarning = true).playSound()
             ChatUtils.clickToActionOrDisable(
                 message = "You do not have an active Re-Heated Gummy Polar Bear!",
                 option = config::gummyWarning,
@@ -117,4 +116,3 @@ object GummyWarning {
 
     private fun isEnabled() = config.gummyWarning && SlayerApi.activeType != null
 }
-

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/blaze/BlazeSlayerFirePitsWarning.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/blaze/BlazeSlayerFirePitsWarning.kt
@@ -17,7 +17,6 @@ import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
 object BlazeSlayerFirePitsWarning {
-
     private val config get() = SlayerApi.config.blazes
 
     private var lastFirePitsWarning = SimpleTimeMark.farPast()
@@ -28,17 +27,17 @@ object BlazeSlayerFirePitsWarning {
     }
 
     @HandleEvent
-    fun onTick(event: SkyHanniTickEvent) {
+    private fun onTick(event: SkyHanniTickEvent) {
         if (!isEnabled()) return
         if (!event.isMod(10)) return
 
         if (lastFirePitsWarning.passedSince() < 2.seconds) {
-            SoundUtils.createSound("entity.experience_orb.pickup", 0.8f).playSound()
+            SoundUtils.createSound("entity.experience_orb.pickup", 0.8f, isWarning = true).playSound()
         }
     }
 
     @HandleEvent
-    fun onBossHealthChange(event: BossHealthChangeEvent) {
+    private fun onBossHealthChange(event: BossHealthChangeEvent) {
         if (!isEnabled()) return
         val entityData = event.entityData
 
@@ -72,7 +71,7 @@ object BlazeSlayerFirePitsWarning {
             )
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(3, "slayer.firePitsWarning", "slayer.blazes.firePitsWarning")
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/hooks/SoundEngineHook.kt
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/hooks/SoundEngineHook.kt
@@ -6,13 +6,14 @@ import net.minecraft.client.resources.sounds.SoundInstance
 
 object SoundEngineHook {
     /**
-     * Makes SkyHanni's own sounds bypass the user's volume settings, without touching
+     * Makes SkyHanni's own warning sounds bypass the user's volume settings, without touching
      * the volume of any other sound or the sound engine's global volume state.
      * A complete mute is still respected and not bypassed.
      */
     @JvmStatic
     fun modifyVolume(soundInstance: SoundInstance, original: Float): Float {
         if (soundInstance !is SkyHanniSoundInstance) return original
+        if (!soundInstance.isWarning) return original
         if (original == 0f) return original
         if (!SkyHanniMod.feature.misc.boostWarningVolume) return original
         return soundInstance.volume.coerceIn(0f, 1f)

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyHanniSoundInstance.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyHanniSoundInstance.kt
@@ -6,15 +6,16 @@ import net.minecraft.resources.Identifier
 import net.minecraft.sounds.SoundSource
 
 /**
- * A UI sound created by SkyHanni. Unless the user turned off the Boost Warning Volume option,
- * these sounds bypass the volume settings and play at their instance volume, without affecting
- * any other sounds. A complete mute is still respected and not bypassed.
+ * A UI sound created by SkyHanni. If [isWarning] is true and the user enabled the Boost Warning
+ * Volume option, these sounds bypass the volume settings and play at their instance volume,
+ * without affecting any other sounds. A complete mute is still respected and not bypassed.
  * See `MixinSoundEngine` and [at.hannibal2.skyhanni.mixins.hooks.SoundEngineHook].
  */
 class SkyHanniSoundInstance(
     identifier: Identifier,
     pitch: Float,
     volume: Float,
+    val isWarning: Boolean,
 ) : SimpleSoundInstance(
     identifier,
     SoundSource.UI,

--- a/src/main/java/at/hannibal2/skyhanni/utils/SoundUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SoundUtils.kt
@@ -109,5 +109,8 @@ object SoundUtils {
         event.move(145, "misc.maintainGameVolume", "misc.boostWarningVolume") { element ->
             JsonPrimitive(!element.asBoolean)
         }
+        event.transform(146, "misc.boostWarningVolume") { _ ->
+            JsonPrimitive(false)
+        }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/utils/SoundUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SoundUtils.kt
@@ -3,7 +3,6 @@ package at.hannibal2.skyhanni.utils
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
-import at.hannibal2.skyhanni.config.commands.CommandCategory
 import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
 import at.hannibal2.skyhanni.config.commands.brigadier.BrigadierArguments
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -18,11 +17,13 @@ import kotlinx.coroutines.delay
 @SkyHanniModule
 object SoundUtils {
     private val beepSoundCache = mutableMapOf<Float, SoundInstance>()
-    private val clickSound by lazy { createSound("ui.button.click", 1f) }
-    private val errorSound by lazy { createSound("entity.enderman.teleport", 0f) }
-    val plingSound by lazy { createSound("block.note_block.pling", 1f) }
+    private val clickSound by lazy { createSound("ui.button.click", 1f, isWarning = false) }
+    private val clickWarningSound by lazy { createSound("ui.button.click", 1f, isWarning = true) }
+    private val errorSound by lazy { createSound("entity.enderman.teleport", 0f, isWarning = true) }
+    private val errorUiSound by lazy { createSound("entity.enderman.teleport", 0f, isWarning = false) }
+    val plingSound by lazy { createSound("block.note_block.pling", 1f, isWarning = true) }
 
-    // Sounds created via createSound bypass the user's volume settings
+    // Warning sounds created via createSound bypass the user's volume settings
     // if the boostWarningVolume option is enabled, see SoundEngineHook.
     fun SoundInstance.playSound() {
         DelayedRun.runOrNextTick {
@@ -45,27 +46,31 @@ object SoundUtils {
         }
     }
 
-    fun createSound(name: String, pitch: Float, volume: Float = 50f): SoundInstance {
+    // isWarning controls whether the sound is affected by the boostWarningVolume option.
+    // Set it to false for GUI interaction feedback and other non-warning sound effects.
+    fun createSound(name: String, pitch: Float, volume: Float = 50f, isWarning: Boolean): SoundInstance {
         val newSound = SoundCompat.getModernSoundName(name)
         val identifier = Identifier.parse(newSound.replace(Regex("[^a-z0-9:/._-]"), ""))
-        return SkyHanniSoundInstance(identifier, pitch, volume)
+        return SkyHanniSoundInstance(identifier, pitch, volume, isWarning)
     }
 
     fun playBeepSound(pitch: Float = 1f) {
-        val beepSound = beepSoundCache.getOrPut(pitch) { createSound("entity.experience_orb.pickup", pitch) }
+        val beepSound = beepSoundCache.getOrPut(pitch) {
+            createSound("entity.experience_orb.pickup", pitch, isWarning = true)
+        }
         beepSound.playSound()
     }
 
-    fun playClickSound() {
-        clickSound.playSound()
+    fun playClickSound(isWarning: Boolean = false) {
+        (if (isWarning) clickWarningSound else clickSound).playSound()
     }
 
     fun playPlingSound() {
         plingSound.playSound()
     }
 
-    fun playErrorSound() {
-        errorSound.playSound()
+    fun playErrorSound(isWarning: Boolean = true) {
+        (if (isWarning) errorSound else errorUiSound).playSound()
     }
 
     // TODO use duration for delay
@@ -82,20 +87,27 @@ object SoundUtils {
     private fun onCommandRegistration(event: CommandRegistrationEvent) {
         event.registerBrigadier("shplaysound") {
             description = "Play the specified sound effect at the given pitch and volume."
-            category = CommandCategory.DEVELOPER_TEST
+            category = DEVELOPER_TEST
             arg("name", BrigadierArguments.string()) { soundName ->
                 arg("pitch", BrigadierArguments.float()) { pitch ->
                     arg("volume", BrigadierArguments.float()) { volume ->
+                        arg("warning", BrigadierArguments.bool()) { isWarning ->
+                            callback {
+                                createSound(
+                                    getArg(soundName), getArg(pitch), getArg(volume), getArg(isWarning),
+                                ).playSound()
+                            }
+                        }
                         callback {
-                            createSound(getArg(soundName), getArg(pitch), getArg(volume)).playSound()
+                            createSound(getArg(soundName), getArg(pitch), getArg(volume), isWarning = false).playSound()
                         }
                     }
                     callback {
-                        createSound(getArg(soundName), getArg(pitch), 50f).playSound()
+                        createSound(getArg(soundName), getArg(pitch), 50f, isWarning = false).playSound()
                     }
                 }
                 callback {
-                    createSound(getArg(soundName), 1f, 50f).playSound()
+                    createSound(getArg(soundName), 1f, 50f, isWarning = false).playSound()
                 }
             }
             simpleCallback {


### PR DESCRIPTION
## What
I made a bad judgement call in #6418. The state of the toggle was migrated based on its intent, which logically makes sense, but ignores nuance. The volume boost has been broken since probably all the way back in the 1.21.5 port, so people are used to not having their ears blown out by SkyHanni warning sounds.

This PR sets "Boost Warning Volume" to default disabled, removes the FeatureToggle, and performs a one-time migration turning it off for all existing users.

Another issue that was discovered was that this was boosting literally *all* SkyHanni sounds. So now sounds can opt out with `isWarning = false`, which has been added to a bunch of existing sounds. This has been applied to mostly non-warning UI clicks, unimportant notifications (achievements), as well as anything that's replacing/emulating a Hypixel sound that wouldn't be boosted normally (overflow level up).

## Changelog Improvements
+ Disabled the "Boost Warning Volume" option by default based on user feedback. - Luna
    * The volume boost was always on by default, just under a different name, but it has been broken for a long time.
    * If you want it enabled, you'll have to turn it back on manually after this update.

## Changelog Fixes
+ Fixed "Boost Warning Volume" also boosting non-warning sounds from SkyHanni. - Luna