### PR TITLE
Backend: EntityLeaveWorldEvent cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -260,6 +260,10 @@ Make sure such pull requests have a good explanation in the **What** section.
 - Avoid using deprecated functions.
     - These functions are marked for removal in future versions.
     - If you're unsure why a function is deprecated or how to replace it, please ask for guidance.
+- When renaming or replacing a symbol other code already uses, keep a deprecated alias under the old
+  name instead of deleting it right away. Open pull requests that still use the old name then keep
+  compiling and their authors get time to react. Remove the alias in a separate pull request one or
+  two months later, and note that date in a TODO comment above it.
 - Future JSON data objects should be made in kotlin.
 - Config files should be made in **Kotlin**.
     - There may be legacy config files left as Java files, however they will all be ported eventually.

--- a/src/main/java/at/hannibal2/skyhanni/events/RenderEntityOutlineEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/RenderEntityOutlineEvent.kt
@@ -9,32 +9,46 @@ import net.minecraft.world.entity.Entity
 import net.minecraft.world.entity.decoration.ItemFrame
 import java.awt.Color
 
+
+/**
+ * Fired once per frame, right before the visible entities are collected for rendering.
+ *
+ * Fired on the render thread via a Mixin into `LevelExtractor.extractVisibleEntities`
+ * (`LevelRenderer` below 26.2).
+ *
+ * Listeners do not render anything themselves. They call [queueEntitiesToOutline] with a function
+ * returning the outline color for an entity, or null to leave it unoutlined.
+ * `RenderLivingEntityHelper` reads the queued entities back while the entity is rendered.
+ *
+ * Since this runs every frame, guard the color function with checks that do not depend on the
+ * individual entity, such as the island or whether the feature is enabled.
+ */
 @PrimaryFunction("onRenderEntityOutline")
 class RenderEntityOutlineEvent : SkyHanniEvent() {
     /**
-     * The entities to outline. This is progressively cumulated from [.entitiesToChooseFrom]
+     * The entities to outline. This is progressively cumulated from [entitiesToChooseFrom]
      */
     var entitiesToOutline: HashMap<Entity, Int> = hashMapOf()
 
     /**
-     * The entities we can outline. Note that this set and [.entitiesToOutline] are disjoint at all times.
+     * The entities we can outline. Note that this set and [entitiesToOutline] are disjoint at all times.
      */
     var entitiesToChooseFrom: HashSet<Entity> = hashSetOf()
 
     /**
-     * Whether [.entitiesToChooseFrom] has been computed already.
+     * Whether [entitiesToChooseFrom] has been computed already.
      */
     private var computed: Boolean = false
 
     /**
      * Conditionally queue entities around which to render outlines.
-     * Selects from the pool of [.entitiesToChooseFrom] to speed up the predicate testing on subsequent calls.
-     * Is more efficient (theoretically) than calling [.queueEntityToOutline] for each entity because lists are handled internally.
+     * Selects from the pool of [entitiesToChooseFrom] to speed up the predicate testing on subsequent calls.
      *
      * This function loops through all entities and so is not very efficient.
-     * It's advisable to encapsulate calls to this function with global checks (those not dependent on an individual entity) for efficiency purposes.
+     * It's advisable to encapsulate calls to this function with global checks
+     * (those not dependent on an individual entity) for efficiency purposes.
      *
-     * @param outlineColor a function to test
+     * @param outlineColor returns the outline color for an entity, or null to leave it unoutlined
      */
     fun queueEntitiesToOutline(outlineColor: ((entity: Entity) -> Color?)? = null) {
         if (outlineColor == null) {

--- a/src/main/java/at/hannibal2/skyhanni/events/entity/EntityLeaveWorldEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/entity/EntityLeaveWorldEvent.kt
@@ -7,5 +7,17 @@ import net.minecraft.world.entity.Entity
 @Deprecated("Use EntityLeaveWorldEvent instead", ReplaceWith("EntityLeaveWorldEvent"))
 typealias EntityRemovedEvent<T> = EntityLeaveWorldEvent<T>
 
+/**
+ * Fired when an entity is removed from the client world.
+ *
+ * Fired on the main client thread via a Mixin into `TransientEntitySectionManager.Callback.onRemove`.
+ *
+ * Covers every removal reason: despawning, dying, leaving the tracking range and chunk unloading.
+ * The reason is not part of the event, so this is not a death detection. The type parameter [T]
+ * allows filtering for a specific entity type.
+ *
+ * @param T the type of entity
+ * @param entity the entity that was removed from the world
+ */
 @PrimaryFunction("onEntityLeaveWorld")
 class EntityLeaveWorldEvent<T : Entity>(val entity: T) : GenericSkyHanniEvent<T>(entity.javaClass)

--- a/src/main/java/at/hannibal2/skyhanni/events/entity/EntityLeaveWorldEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/entity/EntityLeaveWorldEvent.kt
@@ -4,6 +4,7 @@ import at.hannibal2.skyhanni.api.event.GenericSkyHanniEvent
 import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 import net.minecraft.world.entity.Entity
 
+// TODO remove after 2026-11, kept so open PRs using the old name keep compiling
 @Deprecated("Use EntityLeaveWorldEvent instead", ReplaceWith("EntityLeaveWorldEvent"))
 typealias EntityRemovedEvent<T> = EntityLeaveWorldEvent<T>
 

--- a/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonSecretChime.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/dungeon/DungeonSecretChime.kt
@@ -8,7 +8,7 @@ import at.hannibal2.skyhanni.events.MobEvent
 import at.hannibal2.skyhanni.events.PlaySoundEvent
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.events.dungeon.DungeonBlockClickEvent
-import at.hannibal2.skyhanni.events.entity.EntityRemovedEvent
+import at.hannibal2.skyhanni.events.entity.EntityLeaveWorldEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.NeuInternalName
 import at.hannibal2.skyhanni.utils.SoundUtils
@@ -42,8 +42,9 @@ object DungeonSecretChime {
         }
     }
 
+    // An item entity leaving the world means the player picked it up
     @HandleEvent
-    fun onItemPickup(event: EntityRemovedEvent<ItemEntity>) {
+    private fun onEntityLeaveWorld(event: EntityLeaveWorldEvent<ItemEntity>) {
         if (!isEnabled()) return
         val itemName = event.entity.item.hoverName.formattedTextCompatLeadingWhiteLessResets()
         if (NeuInternalName.fromItemName(itemName) in dungeonSecretItems) {

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHookDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/FishingHookDisplay.kt
@@ -6,7 +6,7 @@ import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.config.core.config.Position
 import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
 import at.hannibal2.skyhanni.events.entity.EntityCustomNameUpdateEvent
-import at.hannibal2.skyhanni.events.entity.EntityRemovedEvent
+import at.hannibal2.skyhanni.events.entity.EntityLeaveWorldEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.LorenzVec
 import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
@@ -87,7 +87,7 @@ object FishingHookDisplay {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    private fun onEntityRemoved(event: EntityRemovedEvent<ArmorStand>) {
+    private fun onEntityLeaveWorld(event: EntityLeaveWorldEvent<ArmorStand>) {
         if (event.entity.id == timerDisplay?.id) {
             reset()
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/ThunderSparksHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/ThunderSparksHighlight.kt
@@ -5,7 +5,7 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.entity.EntityEquipmentChangeEvent
-import at.hannibal2.skyhanni.events.entity.EntityRemovedEvent
+import at.hannibal2.skyhanni.events.entity.EntityLeaveWorldEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.BlockUtils.getBlockAt
@@ -35,7 +35,7 @@ object ThunderSparksHighlight {
     }
 
     @HandleEvent
-    fun onEntityRemoved(event: EntityRemovedEvent<ArmorStand>) {
+    private fun onEntityLeaveWorld(event: EntityLeaveWorldEvent<ArmorStand>) {
         sparks.remove(event.entity)
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/TreeProgressDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/TreeProgressDisplay.kt
@@ -4,7 +4,7 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandTypeTag
 import at.hannibal2.skyhanni.events.entity.EntityCustomNameUpdateEvent
-import at.hannibal2.skyhanni.events.entity.EntityRemovedEvent
+import at.hannibal2.skyhanni.events.entity.EntityLeaveWorldEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ComponentMatcher
 import at.hannibal2.skyhanni.utils.ComponentMatcherUtils.matchStyledMatcher
@@ -60,7 +60,7 @@ object TreeProgressDisplay {
     }
 
     @HandleEvent(onlyOnIslandTypeTag = [IslandTypeTag.FORAGING_CUSTOM_TREES])
-    private fun onEntityRemoved(event: EntityRemovedEvent<ArmorStand>) {
+    private fun onEntityLeaveWorld(event: EntityLeaveWorldEvent<ArmorStand>) {
         if (event.entity.id == progressDisplay?.id) {
             progressDisplay = null
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/hunting/InvisibugHighlighter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/hunting/InvisibugHighlighter.kt
@@ -5,7 +5,7 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.config.ConfigUpdaterMigrator
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.events.ParticleEvent
-import at.hannibal2.skyhanni.events.entity.EntityRemovedEvent
+import at.hannibal2.skyhanni.events.entity.EntityLeaveWorldEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -75,7 +75,7 @@ object InvisibugHighlighter {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.GALATEA)
-    fun onEntityRemoved(event: EntityRemovedEvent<ArmorStand>) {
+    private fun onEntityLeaveWorld(event: EntityLeaveWorldEvent<ArmorStand>) {
         invisibugEntities.remove(event.entity)
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/blaze/FirePillarDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/blaze/FirePillarDisplay.kt
@@ -4,7 +4,7 @@ import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.SlayerApi
 import at.hannibal2.skyhanni.events.entity.EntityCustomNameUpdateEvent
-import at.hannibal2.skyhanni.events.entity.EntityRemovedEvent
+import at.hannibal2.skyhanni.events.entity.EntityLeaveWorldEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.RegexUtils.matchGroup
 import at.hannibal2.skyhanni.utils.RenderUtils.renderRenderable
@@ -38,7 +38,7 @@ object FirePillarDisplay {
     }
 
     @HandleEvent
-    fun onEntityRemoved(event: EntityRemovedEvent<ArmorStand>) {
+    private fun onEntityLeaveWorld(event: EntityLeaveWorldEvent<ArmorStand>) {
         if (event.entity.id == entityId) display = null
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/spider/SpiderEggSacHighlighter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/spider/SpiderEggSacHighlighter.kt
@@ -2,7 +2,7 @@ package at.hannibal2.skyhanni.features.slayer.spider
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.SlayerApi
-import at.hannibal2.skyhanni.events.entity.EntityRemovedEvent
+import at.hannibal2.skyhanni.events.entity.EntityLeaveWorldEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniTickEvent
 import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
 import at.hannibal2.skyhanni.features.slayer.SlayerType
@@ -81,7 +81,7 @@ object SpiderEggSacHighlighter {
     }
 
     @HandleEvent
-    fun onEntityRemoved(event: EntityRemovedEvent<ArmorStand>) {
+    private fun onEntityLeaveWorld(event: EntityLeaveWorldEvent<ArmorStand>) {
         if (highlightedEggSacs.remove(event.entity)) {
             RenderLivingEntityHelper.removeEntityColor(event.entity)
         }


### PR DESCRIPTION
## What
Cleanup after #6411, which renamed `EntityRemovedEvent` to `EntityLeaveWorldEvent` and left a
deprecated typealias behind. The remaining usages and their handler functions now use the new name.

The typealias stays so open PRs using the old name keep compiling, and gets removed in about two
months. CONTRIBUTING.md now documents that grace period.

## Changelog Technical Details
+ Replaced the remaining `EntityRemovedEvent` usages with `EntityLeaveWorldEvent`. - hannibal2
+ Added class KDoc to `RenderEntityOutlineEvent` and `EntityLeaveWorldEvent`. - hannibal2