### PR TITLE
Improvement: Added DisableGiftMessages option to TreeGiftTracker

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/foraging/ForagingTrackerConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/foraging/ForagingTrackerConfig.kt
@@ -60,6 +60,12 @@ class ForagingTrackerConfig {
     }
 
     @Expose
+    @ConfigOption(name = "Disable Gifts", desc = "Disable the chat messages when you receive a tree gift.")
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var disableGiftChats: Boolean = false
+
+    @Expose
     @ConfigOption(name = "Only Holding Axe", desc = "Only show the tracker while holding an axe.")
     @ConfigEditorBoolean
     var onlyHoldingAxe: Boolean = true

--- a/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingTracker.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/foraging/ForagingTracker.kt
@@ -235,7 +235,7 @@ object ForagingTracker : SkyHanniBucketedItemTracker<ForagingTrackerLegacy.TreeT
                 }
                 loot.clear()
             }
-            if (config.compactGiftChats) blockedReason = "TREE_GIFT"
+            if (config.compactGiftChats || config.disableGiftChats) blockedReason = "TREE_GIFT"
         }
         if (!openLootLoop) return
 
@@ -300,7 +300,7 @@ object ForagingTracker : SkyHanniBucketedItemTracker<ForagingTrackerLegacy.TreeT
     }
 
     private fun SkyHanniChatEvent.Allow.tryBlock() {
-        if (!config.compactGiftChats || !openLootLoop) return
+        if (!config.compactGiftChats || !config.disableGiftChats || !openLootLoop) return
         blockedReason = "TREE_GIFT"
     }
 


### PR DESCRIPTION
## What

<details>
Adds a new option to TreeGiftTracker called Disable Gifts which disables the default tree gift messages from going through. This option does not stop Compact Gifts from working. The option was implemented by adding onto the pre-existing if statements for Compact Gifts to remove the Tree Gift message and skipping over writing the new message. Could be implemented as a dropdown but I didn't want to mess with pre-existing configs.
</details>

## Changelog Improvements
+ Added Disable Gift Messages option to the Foraging Tracker. - Ironfort9
    * This option does not override Compact Gift Messages.
