### PR TITLE
Fix: Sun's Grasp Detection

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/garden/GardenApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/GardenApi.kt
@@ -200,7 +200,7 @@ object GardenApi {
 
     fun hasActiveSunsGrasp(): Boolean =
         CurrentEquipmentApi.getEquipment(EquipmentSlot.GLOVES)?.getInternalName() == SUNS_GRASP &&
-            InventoryUtils.getItemInHand()?.isEmpty == true
+            InventoryUtils.getItemInHand() == null
 
     fun NeuInternalName.getCropType(): CropType? =
         if (this.startsWith("THEORETICAL_HOE_SUNFLOWER")) CropType.getTimeFlower()


### PR DESCRIPTION
## What
`GardenApi.hasActiveSunsGrasp` checks for `InventoryUtils.getItemInHand()?.isEmpty == true`. It worked fine at the time, but later, `InventoryUtils.getItemInHand` was changed to return `null` instead of `ItemStack.AIR`, and `null != true`.

## Changelog Fixes
+ Fixed Garden features behaving as if you were not farming while using Sun's Grasp with an empty hand. - Luna
+ Fixed Custom Keybinds and Mouse Sensitivity Reducer not working with Sun's Grasp despite having the option enabled. - Luna