### PR TITLE
Fix: Detect Heavy Pearls via skull texture instead of mob nametags

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/mob/IslandExceptions.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/IslandExceptions.kt
@@ -1,7 +1,6 @@
 package at.hannibal2.skyhanni.data.mob
 
 import at.hannibal2.skyhanni.data.ElectionApi.derpy
-import at.hannibal2.skyhanni.data.IslandType
 import at.hannibal2.skyhanni.data.mob.MobFilter.makeMobResult
 import at.hannibal2.skyhanni.utils.EntityUtils.baseMaxHealth
 import at.hannibal2.skyhanni.utils.EntityUtils.cleanName
@@ -34,26 +33,25 @@ import net.minecraft.world.entity.monster.zombie.Zombie
 import net.minecraft.world.entity.monster.zombie.ZombifiedPiglin
 
 object IslandExceptions {
-
     internal fun islandSpecificExceptions(
         baseEntity: LivingEntity,
         armorStand: ArmorStand?,
         nextEntity: LivingEntity?,
     ): MobData.MobResult? =
         when (SkyBlockUtils.currentIsland) {
-            IslandType.CATACOMBS -> dungeon(baseEntity, armorStand, nextEntity)
-            IslandType.PRIVATE_ISLAND -> privateIsland(armorStand, baseEntity)
-            IslandType.THE_RIFT -> theRift(baseEntity, nextEntity, armorStand)
-            IslandType.CRIMSON_ISLE -> crimsonIsle(baseEntity, armorStand, nextEntity)
-            IslandType.DEEP_CAVERNS -> deepCaverns(baseEntity)
-            IslandType.DWARVEN_MINES -> dwarvenMines(baseEntity)
-            IslandType.CRYSTAL_HOLLOWS -> crystalHollows(baseEntity, armorStand)
-            IslandType.HUB -> hub(baseEntity, armorStand, nextEntity)
-            IslandType.GARDEN -> garden(baseEntity)
-            IslandType.KUUDRA_ARENA -> kuudraArena(baseEntity, nextEntity)
-            IslandType.WINTER -> winterIsland(baseEntity)
-            IslandType.GALATEA -> ModernIslandExceptions.moongladeMarsh(baseEntity, armorStand, nextEntity)
-            IslandType.TORRHUS_CANYON -> ModernIslandExceptions.torrhus(baseEntity, armorStand, nextEntity)
+            CATACOMBS -> dungeon(baseEntity, armorStand, nextEntity)
+            PRIVATE_ISLAND -> privateIsland(armorStand, baseEntity)
+            THE_RIFT -> theRift(baseEntity, nextEntity, armorStand)
+            CRIMSON_ISLE -> crimsonIsle(baseEntity, armorStand, nextEntity)
+            DEEP_CAVERNS -> deepCaverns(baseEntity)
+            DWARVEN_MINES -> dwarvenMines(baseEntity)
+            CRYSTAL_HOLLOWS -> crystalHollows(baseEntity, armorStand)
+            HUB -> hub(baseEntity, armorStand, nextEntity)
+            GARDEN -> garden(baseEntity)
+            KUUDRA_ARENA -> kuudraArena(baseEntity, nextEntity)
+            WINTER -> winterIsland(baseEntity)
+            GALATEA -> ModernIslandExceptions.moongladeMarsh(baseEntity, armorStand, nextEntity)
+            TORRHUS_CANYON -> ModernIslandExceptions.torrhus(baseEntity, armorStand, nextEntity)
 
             else -> null
         }
@@ -129,9 +127,6 @@ object IslandExceptions {
         armorStand: ArmorStand?,
         nextEntity: LivingEntity?,
     ) = when {
-        baseEntity is Slime && MobFilter.heavyPearlPattern.matches(armorStand?.name.formattedTextCompatLessResets()) ->
-            MobData.MobResult.found(MobFactories.special(baseEntity, "Heavy Pearl"))
-
         baseEntity is Pig && nextEntity is Pig -> MobData.MobResult.illegal // Matriarch Tongue
         baseEntity is RemotePlayer && baseEntity.isNpc() && baseEntity.name.string == "BarbarianGuard " ->
             MobData.MobResult.found(Mob(baseEntity, MobCategory.DISPLAY_NPC, name = "Barbarian Guard"))
@@ -270,7 +265,7 @@ object IslandExceptions {
                     it.distanceTo(baseEntity) < 4.0 &&
                     it.wearingSkullTexture(MobFilter.RAT_SKULL_TEXTURE)
             }?.let {
-                MobData.MobResult.found(Mob(baseEntity, category = MobCategory.BASIC, armorStand = it, name = "Rat"))
+                MobData.MobResult.found(Mob(baseEntity, category = BASIC, armorStand = it, name = "Rat"))
             } ?: if (nextEntity is Zombie) MobData.MobResult.notYetFound else null
 
     private fun petCareHandler(baseEntity: LivingEntity): MobData.MobResult {

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/MobFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/MobFilter.kt
@@ -49,10 +49,9 @@ import net.minecraft.world.entity.npc.villager.Villager
 import net.minecraft.world.entity.player.Player
 import org.intellij.lang.annotations.Language
 
-@Suppress("RegExpRedundantEscape", "MaxLineLength")
 @SkyHanniModule
+@Suppress("MaxLineLength", "RegExpRedundantEscape")
 object MobFilter {
-
     private val patternGroup = RepoPattern.group("mob.detection")
 
     @Language("RegExp")
@@ -139,11 +138,6 @@ object MobFilter {
         "pattern.summon.owner",
         ".*Spawned by: (?<name>.*).*",
     )
-    val heavyPearlPattern by patternGroup.pattern(
-        "pattern.heavypearl.collect",
-        "§.§lCOLLECT!",
-    )
-
     /**
      * REGEX-TEST: SHINY PIG
      */
@@ -294,7 +288,7 @@ object MobFilter {
 
         baseEntity.isFarmMob() -> createFarmMobs(baseEntity)?.let { MobResult.found(it) }
         baseEntity is EnderDragon -> when (SkyBlockUtils.currentIsland) {
-            IslandType.CATACOMBS -> (8..16).map { MobUtils.getArmorStand(baseEntity, it) }
+            CATACOMBS -> (8..16).map { MobUtils.getArmorStand(baseEntity, it) }
                 .makeMobResult {
                     MobFactories.boss(baseEntity, it.first(), it.drop(1))
                 }
@@ -372,7 +366,7 @@ object MobFilter {
                 else -> null
             }
         } else when (SkyBlockUtils.currentIsland) {
-            IslandType.CRIMSON_ISLE -> when {
+            CRIMSON_ISLE -> when {
                 else -> null
             }
 
@@ -397,7 +391,7 @@ object MobFilter {
 
     fun LivingEntity.isFarmMob() =
         this is Animal && this.baseMaxHealth.derpy()
-            .let { it == 50 || it == 20 || it == 130 } && SkyBlockUtils.currentIsland != IslandType.PRIVATE_ISLAND
+            .let { it == 50 || it == 20 || it == 130 } && SkyBlockUtils.currentIsland != PRIVATE_ISLAND
 
     private fun createFarmMobs(baseEntity: LivingEntity): Mob? = when (baseEntity) {
         is MushroomCow -> MobFactories.basic(baseEntity, "Farm Mooshroom")

--- a/src/main/java/at/hannibal2/skyhanni/events/entity/EntityEquipmentChangeEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/entity/EntityEquipmentChangeEvent.kt
@@ -1,9 +1,11 @@
 package at.hannibal2.skyhanni.events.entity
 
 import at.hannibal2.skyhanni.api.event.GenericSkyHanniEvent
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import net.minecraft.world.entity.Entity
 
+@PrimaryFunction("onEntityEquipmentChange")
 data class EntityEquipmentChangeEvent<T : Entity>(
     val entity: T,
     val equipmentSlot: Int,
@@ -17,7 +19,6 @@ data class EntityEquipmentChangeEvent<T : Entity>(
     val isHand get() = equipmentSlot == EQUIPMENT_SLOT_HAND
 
     companion object {
-
         const val EQUIPMENT_SLOT_HEAD = 4
         const val EQUIPMENT_SLOT_CHEST = 3
         const val EQUIPMENT_SLOT_LEGGINGS = 2

--- a/src/main/java/at/hannibal2/skyhanni/features/nether/MatriarchHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/nether/MatriarchHelper.kt
@@ -3,20 +3,19 @@ package at.hannibal2.skyhanni.features.nether
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.IslandGraphs
-import at.hannibal2.skyhanni.data.IslandType
-import at.hannibal2.skyhanni.data.mob.Mob
 import at.hannibal2.skyhanni.data.model.graph.GraphNode
-import at.hannibal2.skyhanni.events.IslandGraphReloadEvent
-import at.hannibal2.skyhanni.events.MobEvent
+import at.hannibal2.skyhanni.events.entity.EntityEquipmentChangeEvent
+import at.hannibal2.skyhanni.events.entity.EntityLeaveWorldEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
-import at.hannibal2.skyhanni.events.skyblock.GraphAreaChangeEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.test.command.CopyNearbyEntitiesCommand.getMobInfo
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.ColorUtils.toColor
+import at.hannibal2.skyhanni.utils.EntityUtils.getEntitiesInBoundingBox
+import at.hannibal2.skyhanni.utils.EntityUtils.wearingSkullTexture
 import at.hannibal2.skyhanni.utils.GraphUtils
 import at.hannibal2.skyhanni.utils.LocationUtils
 import at.hannibal2.skyhanni.utils.LorenzVec
+import at.hannibal2.skyhanni.utils.SkullTextureHolder
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.getLorenzVec
 import at.hannibal2.skyhanni.utils.navigation.NavigationUtils
@@ -25,118 +24,157 @@ import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.draw3DLine
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawFilledBoundingBox
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.exactPlayerEyeLocation
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.expandBlock
-import java.util.TreeSet
+import net.minecraft.world.entity.LivingEntity
+import net.minecraft.world.entity.decoration.ArmorStand
+import net.minecraft.world.entity.monster.cubemob.Slime
 
 @SkyHanniModule
 object MatriarchHelper {
-
     private val config get() = SkyHanniMod.feature.crimsonIsle.matriarchHelper
 
-    private val pearlList = TreeSet<Pair<Mob, GraphNode>> { first, second ->
-        first.first.baseEntity.getLorenzVec().y.compareTo(second.first.baseEntity.getLorenzVec().y)
-    }
+    private val HEAVY_PEARL_TEXTURE by SkullTextureHolder.texture("HEAVY_PEARL")
 
     private const val EXIT_LABEL = "Heavy Pearls"
     private const val AREA_NAME = "Belly of the Beast"
 
-    private val exitNodeLazy = { IslandGraphs.currentIslandGraph?.getNodesWithName(EXIT_LABEL)?.firstOrNull()?.also { exitNode == it } }
-    private var exitNode: GraphNode? = null
-
-    @HandleEvent(onlyOnIsland = IslandType.CRIMSON_ISLE)
-    private fun onMobSpawn(event: MobEvent.Spawn.Special) {
-        if (!event.isHeavyPearl()) return
-        val node = IslandGraphs.findClosestNode(event.mob.baseEntity.getLorenzVec().up(1.2), { true })
-        if (node == null) {
-            ErrorManager.logErrorStateWithData(
-                "Something went wrong with the Heavy Pearl detection",
-                "No graphNode found for pearl",
-                "pearList" to pearlList.map { getMobInfo(it.first) to it.second },
-                "mob" to getMobInfo(event.mob),
-            )
-            return
-        }
-        pearlList.add(event.mob to node)
-        if (pearlList.size > 3) {
-            ErrorManager.logErrorStateWithData(
-                "Something went wrong with the Heavy Pearl detection",
-                "More than 3 pearls",
-                "pearList" to pearlList.map { getMobInfo(it.first) to it.second },
-                "mob" to getMobInfo(event.mob),
-            )
-            pearlList.clear()
-        }
+    private class Pearl(val armorStand: ArmorStand, val slime: Slime, val node: GraphNode) {
+        val location get() = slime.getLorenzVec().up(1.2)
     }
 
-    private fun MobEvent.isHeavyPearl() = isEnabled() && mob.name == "Heavy Pearl"
-
-    @HandleEvent(onlyOnIsland = IslandType.CRIMSON_ISLE)
-    private fun onMobDespawn(event: MobEvent.DeSpawn.Special) {
-        if (!event.isHeavyPearl()) return
-        pearlList.removeIf { it.first == event.mob }
-    }
+    // Armor stands wearing the pearl skull that have no associated slime (yet).
+    // Decorative midair pearls have no slime and stay in here.
+    private val candidates = mutableSetOf<ArmorStand>()
+    private val pearls = mutableListOf<Pearl>()
 
     private val path = mutableListOf<LorenzVec>()
+    private val pearlWaypoints = mutableListOf<LorenzVec>()
 
-    private var tspCache: List<LorenzVec>? = null
-    private var lastTspPearls = 0
+    private var tspCache = emptyList<LorenzVec>()
+    private var lastTspPearls = -1
 
-    private fun accessPearls(): List<LorenzVec> {
-        if (config.useShortestDistance) {
-            val path = tspCache ?: NavigationUtils.getRouteLocations(
-                pearlList.map { it.second },
-                maxIterations = 5
-            ).also {
-                val pearls = path.size
-                if (pearls != lastTspPearls) {
-                    tspCache = path
-                    lastTspPearls = pearls
-                }
-            }
-            return path
-        } else {
-            return pearlList.map { it.first.baseEntity.getLorenzVec().up(1.2) }
+    private var exitNode: GraphNode? = null
+
+    @HandleEvent(onlyOnIsland = CRIMSON_ISLE)
+    private fun onEntityEquipmentChange(event: EntityEquipmentChangeEvent<ArmorStand>) {
+        if (!event.isHead) return
+        val entity = event.entity
+        if (!entity.wearingSkullTexture(HEAVY_PEARL_TEXTURE)) return
+        if (pearls.none { it.armorStand == entity }) candidates.add(entity)
+    }
+
+    @HandleEvent(onlyOnIsland = CRIMSON_ISLE)
+    private fun onEntityLeaveWorld(event: EntityLeaveWorldEvent<LivingEntity>) {
+        when (val entity = event.entity) {
+            is ArmorStand -> candidates.remove(entity)
+            // The slime despawning means the pearl got collected
+            is Slime -> pearls.removeIf { it.slime == entity }
+            else -> return
         }
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.CRIMSON_ISLE)
+    @HandleEvent(onlyOnIsland = CRIMSON_ISLE)
     private fun onTick() {
-        if (SkyBlockUtils.graphArea != AREA_NAME) return
+        if (!isEnabled() || SkyBlockUtils.graphArea != AREA_NAME) return
+        checkCandidates()
+        if (!config.line) return
+        pearlWaypoints.clear()
+        pearlWaypoints.addAll(accessPearls())
+        if (config.simpleLine) return
         path.clear()
-        path.addAll(accessPearls())
-        val exitNode = exitNode ?: exitNodeLazy() ?: return
+        path.addAll(pearlWaypoints)
+        val exitNode = getExitNode() ?: return
         val end = path.lastOrNull() ?: LocationUtils.playerLocation()
         val endNode = IslandGraphs.findClosestNode(end, { true }) ?: return
         path.addAll(GraphUtils.findShortestPath(endNode, exitNode).drop(1).map { it.blockCenter() })
     }
 
-    @HandleEvent(GraphAreaChangeEvent::class, onlyOnIsland = IslandType.CRIMSON_ISLE)
-    private fun onAreaChange() {
-        if (SkyBlockUtils.graphArea != AREA_NAME) {
-            tspCache = null
-            lastTspPearls = 0
-            path.clear()
-            pearlList.clear()
+    private fun checkCandidates() {
+        if (candidates.isEmpty()) return
+        val iterator = candidates.iterator()
+        while (iterator.hasNext()) {
+            val armorStand = iterator.next()
+            val slime = getEntitiesInBoundingBox<Slime>(armorStand.boundingBox).firstOrNull() ?: continue
+            // Each pearl consists of multiple stacked armor stands sharing one slime
+            if (pearls.any { it.slime == slime }) {
+                iterator.remove()
+                continue
+            }
+            val location = slime.getLorenzVec().up(1.2)
+            val node = IslandGraphs.findClosestNode(location, { true })
+            if (node == null) {
+                ErrorManager.logErrorStateWithData(
+                    "Something went wrong with the Heavy Pearl detection",
+                    "No graphNode found for pearl",
+                    "location" to location,
+                )
+                iterator.remove()
+                continue
+            }
+            iterator.remove()
+            pearls.add(Pearl(armorStand, slime, node))
+        }
+        if (pearls.size > 3) {
+            ErrorManager.logErrorStateWithData(
+                "Something went wrong with the Heavy Pearl detection",
+                "More than 3 pearls",
+                "pearls" to pearls.map { it.location },
+            )
+            reset()
         }
     }
 
-    @HandleEvent(onlyOnIsland = IslandType.CRIMSON_ISLE)
+    private fun accessPearls(): List<LorenzVec> = if (config.useShortestDistance) {
+        if (pearls.size != lastTspPearls) {
+            lastTspPearls = pearls.size
+            tspCache = NavigationUtils.getRouteLocations(pearls.map { it.node }, maxIterations = 5)
+        }
+        tspCache
+    } else {
+        pearls.sortedBy { it.location.y }.map { it.location }
+    }
+
+    private fun getExitNode(): GraphNode? = exitNode
+        ?: IslandGraphs.currentIslandGraph?.getNodesWithName(EXIT_LABEL)?.firstOrNull()?.also { exitNode = it }
+
+    @HandleEvent(onlyOnIsland = CRIMSON_ISLE)
+    private fun onAreaChange() {
+        if (SkyBlockUtils.graphArea != AREA_NAME) reset()
+    }
+
+    @HandleEvent
+    private fun onWorldChange() {
+        reset()
+        candidates.clear()
+    }
+
+    // Known pearls become candidates again and get revalidated by the next tick in the area
+    private fun reset() {
+        tspCache = emptyList()
+        lastTspPearls = -1
+        path.clear()
+        pearlWaypoints.clear()
+        pearls.forEach { candidates.add(it.armorStand) }
+        pearls.clear()
+    }
+
+    @HandleEvent(onlyOnIsland = CRIMSON_ISLE)
     private fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
         if (!isEnabled()) return
         if (config.highlight) {
             val color = config.highlightColor
-            pearlList.forEach {
-                event.drawFilledBoundingBox(it.first.boundingBox.expandBlock(), color, 1f)
+            pearls.forEach {
+                event.drawFilledBoundingBox(it.slime.boundingBox.expandBlock(), color, 1f)
             }
         }
         if (config.line) {
             val color = config.lineColor.toColor()
             var prePoint = event.exactPlayerEyeLocation()
             if (config.simpleLine) {
-                accessPearls().forEach { point ->
+                pearlWaypoints.forEach { point ->
                     event.draw3DLine(prePoint, point, color, 10, true)
                     prePoint = point
                 }
-            } else {
+            } else if (path.isNotEmpty()) {
                 LineDrawer.draw3D(event, lineWidth = 10, depth = true) {
                     drawPath(
                         listOf(prePoint) + path, color, bezierPoint = -1.0,
@@ -146,9 +184,10 @@ object MatriarchHelper {
         }
     }
 
-    @HandleEvent(IslandGraphReloadEvent::class)
+    @HandleEvent
     private fun onIslandGraphReload() {
         exitNode = null
+        reset()
     }
 
     private fun isEnabled() = config.enabled


### PR DESCRIPTION
## Dependencies
- https://github.com/hannibal002/SkyHanni-REPO/pull/844

## What
Our Heavy Pearl detection has been bugged forever. This PR ports over a tried and true detection method I implemented in a private mod a while back. Tested a total of 10 "runs" (5 main + 5 alpha, most of them in different lobbies for good measure), all of them detected 3/3 pearls consistently.

## Changelog Fixes
+ Fixed Matriarch Helper sometimes not detecting all Heavy Pearls. - Luna