### PR TITLE
Fix: Bazaar Re-order not working with Attributes

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/BazaarConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/BazaarConfig.kt
@@ -70,7 +70,7 @@ class BazaarConfig {
 
     @Expose
     @ConfigOption(
-        name = "Cancelled Buy Order Clipboard",
+        name = "Re-order Missing Items",
         desc = "Send missing items from cancelled buy orders in chat.\n" +
             "Click on the message to quickly order the same item and amount again.",
     )

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/BazaarConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/BazaarConfig.kt
@@ -6,6 +6,7 @@ import com.google.gson.annotations.Expose
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
 import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+import io.github.notenoughupdates.moulconfig.annotations.SearchTag
 
 class BazaarConfig {
     @Expose
@@ -69,6 +70,7 @@ class BazaarConfig {
     val dailyLimitTrackerPosition: Position = Position(550, 150)
 
     @Expose
+    @SearchTag("clipboard")
     @ConfigOption(
         name = "Re-order Missing Items",
         desc = "Send missing items from cancelled buy orders in chat.\n" +

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarApi.kt
@@ -21,6 +21,7 @@ import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils.getUpperItems
 import at.hannibal2.skyhanni.utils.ItemNameResolver
 import at.hannibal2.skyhanni.utils.ItemUtils.cleanName
+import at.hannibal2.skyhanni.utils.ItemUtils.getCleanLore
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.itemNameWithoutColor
@@ -212,7 +213,7 @@ object BazaarApi {
             OwnInventoryData.ignoreItem(1.seconds) { it == orderOptionProduct }
         }
 
-        if (inBazaarInventory && item.getLore().lastOrNull()?.removeColor() == "Click to buy now!") {
+        if (inBazaarInventory && item.getCleanLore().lastOrNull() == "Click to buy now!") {
             // instant buy
             OwnInventoryData.ignoreItem(1.seconds) { it == lastOpenedProduct }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarApi.kt
@@ -19,9 +19,9 @@ import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils.getUpperItems
+import at.hannibal2.skyhanni.utils.ItemNameResolver
 import at.hannibal2.skyhanni.utils.ItemUtils.cleanName
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
-import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.itemNameWithoutColor
 import at.hannibal2.skyhanni.utils.ItemUtils.repoItemName
@@ -193,8 +193,7 @@ object BazaarApi {
 
         if (isBazaarOrderInventory(openInvName)) {
             val nameStr = item.cleanName.removePrefix("BUY ").removePrefix("SELL ")
-            val internalName = item.getInternalNameOrNull() ?: NeuInternalName.fromItemNameOrNull(nameStr)
-
+            val internalName = ItemNameResolver.getInternalNameOrNull(nameStr)
 
             if (internalName != null) {
                 if (itemName.contains("SELL", ignoreCase = true)) {
@@ -213,11 +212,9 @@ object BazaarApi {
             OwnInventoryData.ignoreItem(1.seconds) { it == orderOptionProduct }
         }
 
-        if (inBazaarInventory) {
-            if (item.getLore().lastOrNull()?.removeColor() == "Click to buy now!") {
-                // instant buy
-                OwnInventoryData.ignoreItem(1.seconds) { it == lastOpenedProduct }
-            }
+        if (inBazaarInventory && item.getLore().lastOrNull()?.removeColor() == "Click to buy now!") {
+            // instant buy
+            OwnInventoryData.ignoreItem(1.seconds) { it == lastOpenedProduct }
         }
     }
 
@@ -225,7 +222,7 @@ object BazaarApi {
         val buyInstantly = inventoryItems[10] ?: return null
         if (buyInstantly.hoverName.formattedTextCompatLeadingWhiteLessResets() != "§aBuy Instantly") return null
         val bazaarItem = inventoryItems[13] ?: return null
-        return NeuInternalName.fromItemName(bazaarItem.hoverName.formattedTextCompatLeadingWhiteLessResets())
+        return ItemNameResolver.getInternalNameOrNull(bazaarItem.cleanName)
     }
 
     private fun updateTaxRate(inventoryItems: Map<Int, SafeItemStack>) {
@@ -298,8 +295,7 @@ object BazaarApi {
             }
         }
 
-        if (isBazaarOrderInventory(inventoryName)) return true
-        return inventoryNamePattern.matches(inventoryName)
+        return isBazaarOrderInventory(inventoryName) || inventoryNamePattern.matches(inventoryName)
     }
 
     @HandleEvent
@@ -329,9 +325,9 @@ object BazaarApi {
         val offers = if (priceSource == SimpleTransactionType.SELL_OFFER) bazaarData.buySummary else bazaarData.sellSummary
         var remaining = count
         var totalPrice = 0.0
-        for (offer in offers) {
-            val takeAmount = offer.amount.coerceAtMost(remaining)
-            totalPrice += takeAmount * offer.pricePerUnit
+        for ((amount, pricePerUnit) in offers) {
+            val takeAmount = amount.coerceAtMost(remaining)
+            totalPrice += takeAmount * pricePerUnit
             remaining -= takeAmount
             if (remaining <= 0) break
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarApi.kt
@@ -19,10 +19,10 @@ import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.HypixelCommands
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.InventoryUtils.getUpperItems
-import at.hannibal2.skyhanni.utils.ItemNameResolver
 import at.hannibal2.skyhanni.utils.ItemUtils.cleanName
 import at.hannibal2.skyhanni.utils.ItemUtils.getCleanLore
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
+import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.getLore
 import at.hannibal2.skyhanni.utils.ItemUtils.itemNameWithoutColor
 import at.hannibal2.skyhanni.utils.ItemUtils.repoItemName
@@ -194,7 +194,7 @@ object BazaarApi {
 
         if (isBazaarOrderInventory(openInvName)) {
             val nameStr = item.cleanName.removePrefix("BUY ").removePrefix("SELL ")
-            val internalName = NeuInternalName.fromItemNameOrNull(nameStr)
+            val internalName = item.getInternalNameOrNull() ?: NeuInternalName.fromItemNameOrNull(nameStr)
 
             if (internalName != null) {
                 if (itemName.contains("SELL", ignoreCase = true)) {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarApi.kt
@@ -194,7 +194,7 @@ object BazaarApi {
 
         if (isBazaarOrderInventory(openInvName)) {
             val nameStr = item.cleanName.removePrefix("BUY ").removePrefix("SELL ")
-            val internalName = ItemNameResolver.getInternalNameOrNull(nameStr)
+            val internalName = NeuInternalName.fromItemNameOrNull(nameStr)
 
             if (internalName != null) {
                 if (itemName.contains("SELL", ignoreCase = true)) {
@@ -223,7 +223,7 @@ object BazaarApi {
         val buyInstantly = inventoryItems[10] ?: return null
         if (buyInstantly.hoverName.formattedTextCompatLeadingWhiteLessResets() != "§aBuy Instantly") return null
         val bazaarItem = inventoryItems[13] ?: return null
-        return ItemNameResolver.getInternalNameOrNull(bazaarItem.cleanName)
+        return NeuInternalName.fromItemNameOrNull(bazaarItem.hoverName.formattedTextCompatLeadingWhiteLessResets())
     }
 
     private fun updateTaxRate(inventoryItems: Map<Int, SafeItemStack>) {

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/bazaar/BazaarApi.kt
@@ -223,7 +223,7 @@ object BazaarApi {
         val buyInstantly = inventoryItems[10] ?: return null
         if (buyInstantly.hoverName.formattedTextCompatLeadingWhiteLessResets() != "§aBuy Instantly") return null
         val bazaarItem = inventoryItems[13] ?: return null
-        return NeuInternalName.fromItemNameOrNull(bazaarItem.hoverName.formattedTextCompatLeadingWhiteLessResets())
+        return NeuInternalName.fromItemName(bazaarItem.hoverName.formattedTextCompatLeadingWhiteLessResets())
     }
 
     private fun updateTaxRate(inventoryItems: Map<Int, SafeItemStack>) {

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemNameResolver.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemNameResolver.kt
@@ -34,7 +34,7 @@ object ItemNameResolver {
             return itemNameCache.getOrPut(lowercase) { NeuInternalName.MISSING_ITEM }
         }
 
-        ItemResolutionQuery.attributeNameToInternalName(itemName)?.let {
+        ItemResolutionQuery.attributeNameToInternalName(itemName.removeColor())?.let {
             return itemNameCache.getOrPut(lowercase) { it.toInternalName() }
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemNameResolver.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemNameResolver.kt
@@ -34,6 +34,10 @@ object ItemNameResolver {
             return itemNameCache.getOrPut(lowercase) { NeuInternalName.MISSING_ITEM }
         }
 
+        ItemResolutionQuery.attributeNameToInternalName(itemName)?.let {
+            return itemNameCache.getOrPut(lowercase) { it.toInternalName() }
+        }
+
         ItemResolutionQuery.resolveEnchantmentByName(itemName)?.let {
             return itemNameCache.getOrPut(lowercase) { fixEnchantmentName(it.asString()) }
         }


### PR DESCRIPTION
## What
Fixes attributes not working with the Bazaar Re-order (previously Cancelled Buy Order Clipboard) feature.

## Changelog Fixes
+ Fixed attributes not working with the Bazaar Re-order feature. - ksndq