### PR TITLE
Fix: Moveable Action Bar causing GUI shifting when action bar is empty

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/gui/GuiConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/gui/GuiConfig.kt
@@ -24,6 +24,7 @@ import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorKeybind
 import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorSlider
 import io.github.notenoughupdates.moulconfig.annotations.ConfigLink
 import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+import io.github.notenoughupdates.moulconfig.annotations.SearchTag
 import io.github.notenoughupdates.moulconfig.observer.Property
 import org.lwjgl.glfw.GLFW
 
@@ -78,21 +79,25 @@ class GuiConfig {
     @Expose
     @ConfigOption(name = "Hotbar", desc = "Settings for adjusting the hotbar.")
     @Accordion
+    @SearchTag("movable moveable")
     val hotbar: HotbarConfig = HotbarConfig()
 
     @Expose
     @ConfigOption(name = "XP Bar", desc = "Settings for adjusting the XP bar.")
     @Accordion
+    @SearchTag("movable moveable")
     val xpBar: XPBarConfig = XPBarConfig()
 
     @Expose
     @ConfigOption(name = "Action Bar", desc = "Settings for adjusting the action bar.")
     @Accordion
+    @SearchTag("movable moveable")
     val actionBar: ActionBarConfig = ActionBarConfig()
 
     @Expose
     @ConfigOption(name = "Held Item Tooltip", desc = "Settings for adjusting the held item tooltip.")
     @Accordion
+    @SearchTag("movable moveable")
     val heldItemTooltip: HeldItemTooltipConfig = HeldItemTooltipConfig()
 
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinHud.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinHud.java
@@ -28,7 +28,6 @@ import net.minecraft.client.gui.Hud;
 //~ if < 26.2 'Hud' -> 'Gui'
 @Mixin(Hud.class)
 public abstract class MixinHud {
-
     @Inject(method = "displayScoreboardSidebar(Lnet/minecraft/client/gui/GuiGraphicsExtractor;Lnet/minecraft/world/scores/Objective;)V", at = @At("HEAD"), cancellable = true)
     public void renderScoreboard(GuiGraphicsExtractor drawContext, Objective objective, CallbackInfo ci) {
         if (CustomScoreboard.isHideVanillaScoreboardEnabled()) {
@@ -134,7 +133,8 @@ public abstract class MixinHud {
         }
     }
 
-    @Inject(method = "extractOverlayMessage", at = @At("TAIL"))
+    // RETURN rather than TAIL: the method returns early when there is no overlay message
+    @Inject(method = "extractOverlayMessage", at = @At("RETURN"))
     public void renderOverlayMessagePost(GuiGraphicsExtractor context, DeltaTracker deltaTracker, CallbackInfo ci) {
         RenderEvents.postActionBarLayerEventPost(context);
     }


### PR DESCRIPTION
## What
Fixes SkyHanni's "Action Bar" GUI element being moved around causing container GUIs to shift around when the action bar is empty (e.g. outside Hypixel, when the connection lags for 2+ seconds, or with Skyblocker's Fancy Bars feature enabled).

`TAIL` runs only after the last return, so an early return left the matrix unpopped. Using `RETURN` fixes this, and there are no other consumers that this change would break.

I also added the "moveable" search tag to the 4 GUI customization features as a drive-by improvement while I'm here.

## Changelog Improvements
+ Made Hotbar, XP Bar, Action Bar, and Held Item Tooltip customization options searchable by typing "moveable". - Luna

## Changelog Fixes
+ Fixed the movable Action Bar making Minecraft's GUI shift around and go off-screen while the Action Bar is empty.  - Luna
    * This could happen when outside Hypixel, when your internet or the server lagged for more than 2 seconds, or with Skyblocker's Fancy Bars feature enabled.