### PR TITLE
Feature: Compactor GfS Keybind

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/CompactorCraftApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/CompactorCraftApi.kt
@@ -49,12 +49,13 @@ object CompactorCraftApi {
         data class Missing(val upgrade: Upgrade, val amount: Int) : CraftState
     }
 
-    fun getCraftState(base: NeuInternalName): CraftState {
+    /** [inInventory] is passed in when the caller already counted, to save one inventory scan per item. */
+    fun getCraftState(base: NeuInternalName, inInventory: Int = base.getAmountInInventory()): CraftState {
         val lookup = lookup ?: return CraftState.NotLoaded
         lookup.ambiguous[base]?.let { return CraftState.Ambiguous(it) }
         val upgrade = lookup.upgrades[base] ?: return CraftState.NoCraft
 
-        val missing = upgrade.baseAmount - base.getAmountInInventory()
+        val missing = upgrade.baseAmount - inInventory
         return if (missing > 0) CraftState.Missing(upgrade, missing) else CraftState.Enough(upgrade)
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/api/CompactorCraftApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/CompactorCraftApi.kt
@@ -33,8 +33,12 @@ object CompactorCraftApi {
 
     /** What the craft data says about one base item. */
     sealed interface CraftState {
+        /** Whether a craft exists at all, no matter if it can be started right now. */
+        val hasCraft: Boolean get() = this is Missing || this is Enough
+
         /** The first build has not finished yet, so nothing is known about any item. */
         data object NotLoaded : CraftState
+
 
         /** The item has no single step craft. */
         data object NoCraft : CraftState

--- a/src/main/java/at/hannibal2/skyhanni/api/CompactorCraftApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/CompactorCraftApi.kt
@@ -1,0 +1,140 @@
+package at.hannibal2.skyhanni.api
+
+import at.hannibal2.skyhanni.SkyHanniMod.launch
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.commands.CommandCategory
+import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
+import at.hannibal2.skyhanni.data.SackApi
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.DelayedRun
+import at.hannibal2.skyhanni.utils.InventoryUtils.getAmountInInventory
+import at.hannibal2.skyhanni.utils.ItemUtils
+import at.hannibal2.skyhanni.utils.NeuInternalName
+import at.hannibal2.skyhanni.utils.NeuItems
+import at.hannibal2.skyhanni.utils.coroutines.CoroutineSettings
+import kotlin.time.Duration
+
+/**
+ * Single step crafts as the compactor does them: a fixed amount of one item crafts into another item.
+ * Built once per repo reload from the NEU recipes.
+ */
+@SkyHanniModule
+object CompactorCraftApi {
+
+    /** Null until the first repo reload build finished. Replaced as a whole, never field by field. */
+    @Volatile
+    private var lookup: CraftLookup? = null
+
+    private val repoReloadCoroutine = CoroutineSettings("compactor gfs single step crafts", Duration.INFINITE)
+
+    /** A single step craft: [baseAmount] of [base] crafts into [result]. */
+    data class Upgrade(val base: NeuInternalName, val baseAmount: Int, val result: NeuInternalName)
+
+    /** What the craft data says about one base item. */
+    sealed interface CraftState {
+        /** The first build has not finished yet, so nothing is known about any item. */
+        data object NotLoaded : CraftState
+
+        /** The item has no single step craft. */
+        data object NoCraft : CraftState
+
+        /** Two or more crafts tie at the highest amount, so no single one can be picked. */
+        data class Ambiguous(val options: List<Upgrade>) : CraftState
+
+        /** The inventory already holds enough for one craft. */
+        data class Enough(val upgrade: Upgrade) : CraftState
+
+        /** [amount] more of the base item are needed for one craft. */
+        data class Missing(val upgrade: Upgrade, val amount: Int) : CraftState
+    }
+
+    fun getCraftState(base: NeuInternalName): CraftState {
+        val lookup = lookup ?: return CraftState.NotLoaded
+        lookup.ambiguous[base]?.let { return CraftState.Ambiguous(it) }
+        val upgrade = lookup.upgrades[base] ?: return CraftState.NoCraft
+
+        val missing = upgrade.baseAmount - base.getAmountInInventory()
+        return if (missing > 0) CraftState.Missing(upgrade, missing) else CraftState.Enough(upgrade)
+    }
+
+    @HandleEvent
+    private fun onNeuRepoReload() {
+        // The sack item list is only rebuilt after this event, so the build has to wait for it.
+        DelayedRun.runNextTickEnd("compactor gfs single step crafts") {
+            repoReloadCoroutine.launch {
+                buildUpgrades()
+            }
+        }
+    }
+
+    private fun buildUpgrades() {
+        val picked = mutableMapOf<NeuInternalName, Upgrade>()
+        val unclear = mutableMapOf<NeuInternalName, List<Upgrade>>()
+        for ((base, results) in createCandidates()) {
+            // Assumed, not verified: the compactor takes the largest craft. Ice makes Packed Ice at 9
+            // and Enchanted Ice at 160, and 160 is what the compactor produces.
+            val highest = results.maxOf { it.baseAmount }
+            val tied = results.filter { it.baseAmount == highest }
+            tied.singleOrNull()?.let { picked[base] = it } ?: run { unclear[base] = tied }
+        }
+        lookup = CraftLookup(picked, unclear)
+    }
+
+    private fun createCandidates(): Map<NeuInternalName, List<Upgrade>> = NeuItems.allNeuRepoInternalNames()
+        // The compactor puts its result into a sack, so anything that has no sack cannot be one.
+        .filter { it.asString() in SackApi.sackListInternalNames }
+        .flatMap { result -> upgradesFor(result) }
+        .groupBy { it.base }
+
+    private fun upgradesFor(result: NeuInternalName): List<Upgrade> = NeuItems.getRecipes(result)
+        .filter { it.isCraftingRecipe() }
+        .mapNotNull { recipe ->
+            val (base, amount) =
+                ItemUtils.neededItems(recipe).entries.singleOrNull() ?: return@mapNotNull null
+            if (amount <= 1) return@mapNotNull null
+            // The base item is what gets pulled with /gfs later, so it needs a sack of its own.
+            if (base.asString() !in SackApi.sackListInternalNames) return@mapNotNull null
+
+            Upgrade(base, amount, result)
+        }
+
+    @HandleEvent
+    private fun onCommandRegistration(event: CommandRegistrationEvent) {
+        event.registerBrigadier("shtestcompactorcrafts") {
+            description = "List all items with more than one single step craft at the same highest amount"
+            category = CommandCategory.DEVELOPER_DEBUG
+            simpleCallback {
+                printAmbiguous()
+            }
+        }
+    }
+
+    private fun printAmbiguous() {
+        val ambiguous = lookup?.ambiguous ?: run {
+            ChatUtils.userError("Recipe data is not loaded yet.")
+            return
+        }
+        if (ambiguous.isEmpty()) {
+            ChatUtils.chat("No ambiguous single step crafts found.")
+            return
+        }
+        val lines = ambiguous.map { (base, results) ->
+            "${base.asString()} -> ${results.joinToString(", ") { "x${it.baseAmount} into ${it.result.asString()}" }}"
+        }.sorted()
+
+        for (line in lines) {
+            ChatUtils.consoleLog("ambiguous single step craft: $line")
+        }
+        ChatUtils.clickToClipboard("Found ${lines.size} ambiguous single step crafts.", lines)
+    }
+
+    /**
+     * One finished build. [ambiguous] holds base items where two or more crafts tie at the highest
+     * amount, so no single upgrade can be picked.
+     */
+    private data class CraftLookup(
+        val upgrades: Map<NeuInternalName, Upgrade>,
+        val ambiguous: Map<NeuInternalName, List<Upgrade>>,
+    )
+}

--- a/src/main/java/at/hannibal2/skyhanni/api/GetFromSackApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/GetFromSackApi.kt
@@ -24,6 +24,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.SkyBlockUtils
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
+import at.hannibal2.skyhanni.utils.collection.TimeLimitedSet
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 import net.minecraft.world.inventory.Slot
 import java.util.Deque
@@ -86,23 +87,35 @@ object GetFromSackApi {
 
     private fun addToInventory(items: List<PrimitiveItemStack>, slotId: Int) = inventoryMap.put(slotId, items)
 
+    private val sentCooldown = 5.seconds
+
+    /** Items a command was sent for, kept until the server has had time to answer. */
+    private val recentlySent = TimeLimitedSet<NeuInternalName>(sentCooldown)
+
+    /** Whether a command for this item is still waiting to be sent. */
+    fun isQueued(internalName: NeuInternalName): Boolean = queue.any { it.internalName == internalName }
+
+    /** Whether a command for this item went out recently, so the inventory does not reflect it yet. */
+    fun wasRecentlySent(internalName: NeuInternalName): Boolean = internalName in recentlySent
+
     @HandleEvent(onlyOnSkyblock = true)
-    fun onTick() {
+    private fun onTick() {
         if (queue.isNotEmpty() && lastTimeOfCommand.passedSince() >= minimumDelay) {
             val item = queue.poll()
             // TODO find a better workaround
             ChatUtils.sendMessageToServer("/gfs ${item.internalName.asString().replace('-', ':')} ${item.amount}")
+            recentlySent.add(item.internalName)
             lastTimeOfCommand = ChatUtils.getTimeWhenNewlyQueuedMessageGetsExecuted()
         }
     }
 
     @HandleEvent
-    fun onInventoryClose() {
+    private fun onInventoryClose() {
         inventoryMap.clear()
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
+    private fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
         if (!event.mouseType.isRightClick()) return // filter none right clicks
         addToQueue(inventoryMap[event.slotId] ?: return)
         inventoryMap.remove(event.slotId)
@@ -110,7 +123,7 @@ object GetFromSackApi {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onToolTip(event: ToolTipTextEvent) {
+    private fun onToolTip(event: ToolTipTextEvent) {
         event.slot ?: return
         val list = inventoryMap[event.slot.containerSlot] ?: return
         event.toolTip.let { tip ->
@@ -189,7 +202,7 @@ object GetFromSackApi {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onChat(event: SkyHanniChatEvent.Allow) {
+    private fun onChat(event: SkyHanniChatEvent.Allow) {
         if (!config.bazaarGFS || SkyBlockUtils.noTradeMode) return
         val stack = lastItemStack ?: return
         val message = event.message

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/GetFromSackConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/GetFromSackConfig.kt
@@ -55,7 +55,8 @@ class GetFromSackConfig {
     @Expose
     @ConfigOption(
         name = "Compactor GfS Keybind",
-        desc = "Grabs the amount of the hovered item from your sacks that is missing to reach the next craft step."
+        desc = "While held, marks every item in your inventory that can reach its next craft step. " +
+            "Click one to grab the missing amount from your sacks."
     )
     @ConfigEditorKeybind(defaultKey = GLFW.GLFW_KEY_UNKNOWN)
     var compactorKeybind: Int = GLFW.GLFW_KEY_UNKNOWN

--- a/src/main/java/at/hannibal2/skyhanni/config/features/inventory/GetFromSackConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/inventory/GetFromSackConfig.kt
@@ -51,4 +51,12 @@ class GetFromSackConfig {
     )
     @ConfigEditorKeybind(defaultKey = GLFW.GLFW_KEY_UNKNOWN)
     var keybind: Int = GLFW.GLFW_KEY_UNKNOWN
+
+    @Expose
+    @ConfigOption(
+        name = "Compactor GfS Keybind",
+        desc = "Grabs the amount of the hovered item from your sacks that is missing to reach the next craft step."
+    )
+    @ConfigEditorKeybind(defaultKey = GLFW.GLFW_KEY_UNKNOWN)
+    var compactorKeybind: Int = GLFW.GLFW_KEY_UNKNOWN
 }

--- a/src/main/java/at/hannibal2/skyhanni/events/GuiKeyPressEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/GuiKeyPressEvent.kt
@@ -1,8 +1,21 @@
 package at.hannibal2.skyhanni.events
 
 import at.hannibal2.skyhanni.api.event.CancellableSkyHanniEvent
+import at.hannibal2.skyhanni.events.render.gui.GuiMouseInputEvent
 import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 import at.hannibal2.skyhanni.utils.compat.SkyHanniGuiContainer
 
+/**
+ * Fired when a key is pressed or a mouse button is clicked while a container screen is open.
+ * Despite the name, this covers mouse input as well.
+ *
+ * The event carries no information about which input triggered it, so listeners have to check the
+ * key or mouse button themselves, for example through `KeyboardManager.isKeyClicked()`.
+ * Cancelling it stops the screen from handling the input.
+ *
+ * For mouse input specifically, prefer [GuiMouseInputEvent], which is fired alongside this one.
+ *
+ * @param guiContainer The container screen that received the input.
+ */
 @PrimaryFunction("onGuiKeyPress")
 class GuiKeyPressEvent(val guiContainer: SkyHanniGuiContainer) : CancellableSkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/MessageSendToServerEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/MessageSendToServerEvent.kt
@@ -1,12 +1,21 @@
 package at.hannibal2.skyhanni.events
 
 import at.hannibal2.skyhanni.api.event.CancellableSkyHanniEvent
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 import at.hannibal2.skyhanni.utils.system.ModInstance
 
 /**
  * Fired when a message or command is about to be sent from the client to the server.
  * Cancelling this event prevents the message from being sent.
+ *
+ * @param message The message with trailing whitespace removed, including the leading slash for
+ * commands.
+ * @param splitMessage The message split on spaces, so for a command the first entry is the command
+ * with its slash.
+ * @param originatingModContainer The mod that caused the message to be sent, or null when it could
+ * not be resolved. Use [senderIsSkyhanni] to skip messages this mod sent itself.
  */
+@PrimaryFunction("onMessageSendToServer")
 class MessageSendToServerEvent(
     val message: String,
     val splitMessage: List<String>,

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/CompactorGfSKeybind.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/CompactorGfSKeybind.kt
@@ -4,25 +4,77 @@ import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.CompactorCraftApi
 import at.hannibal2.skyhanni.api.GetFromSackApi
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.events.minecraft.KeyDownEvent
+import at.hannibal2.skyhanni.events.GuiContainerEvent
+import at.hannibal2.skyhanni.events.minecraft.ToolTipTextEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.repoItemName
+import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyHeld
+import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.NeuInternalName
-import at.hannibal2.skyhanni.utils.compat.slotUnderCursor
+import at.hannibal2.skyhanni.utils.RenderUtils.drawBorder
+import at.hannibal2.skyhanni.utils.RenderUtils.highlight
+import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
+import at.hannibal2.skyhanni.utils.collection.CollectionUtils.addOrPut
 import net.minecraft.world.entity.player.Inventory
+import net.minecraft.world.inventory.Slot
 
 @SkyHanniModule
 object CompactorGfSKeybind {
 
     private val config get() = SkyHanniMod.feature.inventory.gfs
 
+    private const val OVERLAY_OPACITY = 130
+    private const val BORDER_OPACITY = 200
+
+    // HideNotClickableItems clears the whole tooltip at LOWEST, so this has to run after it.
+    private const val TOOLTIP_PRIORITY = HandleEvent.LOWEST + 1
+
+    private fun isActive(): Boolean = config.compactorKeybind.isKeyHeld()
+
+    private val Slot.isOwnInventory: Boolean get() = container is Inventory
+
+    private fun isPending(internalName: NeuInternalName): Boolean =
+        GetFromSackApi.isQueued(internalName) || GetFromSackApi.wasRecentlySent(internalName)
+
     @HandleEvent(onlyOnSkyblock = true)
-    private fun onKeyDown(event: KeyDownEvent) {
-        if (event.keyCode != config.compactorKeybind) return
-        val slot = slotUnderCursor() ?: return
-        if (slot.container !is Inventory) return
+    private fun onForegroundDrawn(event: GuiContainerEvent.ForegroundDrawnEvent) {
+        if (!isActive()) return
+        val amounts = countOwnInventory()
+
+        for (slot in event.container.slots) {
+            if (!slot.isOwnInventory) continue
+            val internalName = slot.item.getInternalNameOrNull() ?: continue
+
+            when {
+                isPending(internalName) -> slot.highlight(LorenzColor.YELLOW.addOpacity(OVERLAY_OPACITY))
+                hasMissingAmount(internalName, amounts) -> slot.drawBorder(LorenzColor.GREEN.addOpacity(BORDER_OPACITY))
+                else -> slot.highlight(LorenzColor.DARK_GRAY.addOpacity(OVERLAY_OPACITY))
+            }
+        }
+    }
+
+    private fun hasMissingAmount(internalName: NeuInternalName, amounts: Map<NeuInternalName, Int>): Boolean =
+        CompactorCraftApi.getCraftState(internalName, amounts[internalName] ?: 0) is Missing
+
+    /** Counted once per frame, so that the state of every slot does not scan the inventory again. */
+    private fun countOwnInventory(): Map<NeuInternalName, Int> = buildMap {
+        for (stack in InventoryUtils.getItemsInOwnInventory()) {
+            val internalName = stack.getInternalNameOrNull() ?: continue
+            addOrPut(internalName, stack.count)
+        }
+    }
+
+    @HandleEvent(onlyOnSkyblock = true)
+    private fun onSlotClick(event: GuiContainerEvent.SlotClickEvent) {
+        if (!isActive()) return
+        val slot = event.slot ?: return
+        if (!slot.isOwnInventory) return
+        // Swallow every click while the key is held, so nothing gets picked up by accident.
+        event.cancel()
+        if (!event.mouseType.isLeftClick()) return
 
         val internalName = slot.item.getInternalNameOrNull() ?: return
         grabMissing(internalName)
@@ -30,15 +82,46 @@ object CompactorGfSKeybind {
 
     private fun grabMissing(internalName: NeuInternalName) {
         // Ignore silently, the previous request for this item is still on its way.
-        if (GetFromSackApi.isQueued(internalName) || GetFromSackApi.wasRecentlySent(internalName)) return
-        val itemName = internalName.repoItemName
+        if (isPending(internalName)) return
 
-        when (val state = CompactorCraftApi.getCraftState(internalName)) {
-            NotLoaded -> ChatUtils.userError("Recipe data is not loaded yet.")
-            NoCraft -> ChatUtils.userError("$itemName §ccannot be crafted into another item.")
-            is Ambiguous -> ChatUtils.userError("$itemName §chas more than one craft at the same amount.")
-            is Enough -> ChatUtils.userError("You already have enough $itemName §cfor ${state.upgrade.result.repoItemName}§c.")
-            is Missing -> GetFromSackApi.getFromSack(internalName, state.amount)
+        val state = CompactorCraftApi.getCraftState(internalName)
+        if (state == NotLoaded) {
+            ChatUtils.userError("Recipe data is not loaded yet.")
+            return
         }
+        val missing = state as? Missing ?: return
+        GetFromSackApi.getFromSack(internalName, missing.amount)
+    }
+
+    @HandleEvent(onlyOnSkyblock = true, priority = TOOLTIP_PRIORITY)
+    private fun onToolTip(event: ToolTipTextEvent) {
+        if (!isActive()) return
+        val slot = event.slot ?: return
+        if (!slot.isOwnInventory) return
+        val internalName = event.itemStack.getInternalNameOrNull() ?: return
+
+        val pending = isPending(internalName)
+        val state = CompactorCraftApi.getCraftState(internalName)
+        val itemName = event.toolTip.firstOrNull() ?: return
+
+        event.toolTip.clear()
+        // Only a clickable item keeps its rarity color.
+        if (!pending && state is Missing) {
+            event.toolTip.add(itemName)
+        } else {
+            event.toolTip.add("§7${itemName.string}".asComponent())
+        }
+
+        val status = statusLine(pending, state) ?: return
+        event.toolTip.add("".asComponent())
+        event.toolTip.add(status.asComponent())
+    }
+
+    private fun statusLine(pending: Boolean, state: CompactorCraftApi.CraftState): String? = when {
+        pending -> "§7Already requested"
+        state is Missing -> "§eClick to grab §ax${state.amount} §emore for ${state.upgrade.result.repoItemName}"
+        state is Enough -> "§7Already enough for ${state.upgrade.result.repoItemName}"
+        state is Ambiguous -> "§7More than one craft at the same amount"
+        else -> null
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/CompactorGfSKeybind.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/CompactorGfSKeybind.kt
@@ -48,12 +48,13 @@ object CompactorGfSKeybind {
             if (!slot.isOwnInventory) continue
             val internalName = slot.item.getInternalNameOrNull() ?: continue
 
-            if (isPending(internalName)) {
+            val state = CompactorCraftApi.getCraftState(internalName, amounts[internalName] ?: 0)
+            // A pending request only matters for items that have a craft at all.
+            if (state.hasCraft && isPending(internalName)) {
                 slot.highlight(LorenzColor.YELLOW.addOpacity(OVERLAY_OPACITY))
                 continue
             }
 
-            val state = CompactorCraftApi.getCraftState(internalName, amounts[internalName] ?: 0)
             if (state is Missing) {
                 slot.drawBorder(LorenzColor.GREEN.addOpacity(BORDER_OPACITY))
             } else {
@@ -103,8 +104,8 @@ object CompactorGfSKeybind {
         if (!slot.isOwnInventory) return
         val internalName = event.itemStack.getInternalNameOrNull() ?: return
 
-        val pending = isPending(internalName)
         val state = CompactorCraftApi.getCraftState(internalName)
+        val pending = state.hasCraft && isPending(internalName)
         val itemName = event.toolTip.firstOrNull() ?: return
 
         event.toolTip.clear()

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/CompactorGfSKeybind.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/CompactorGfSKeybind.kt
@@ -1,0 +1,155 @@
+package at.hannibal2.skyhanni.features.inventory
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.SkyHanniMod.launch
+import at.hannibal2.skyhanni.api.GetFromSackApi
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.commands.CommandCategory
+import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
+import at.hannibal2.skyhanni.data.SackApi
+import at.hannibal2.skyhanni.events.minecraft.KeyDownEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.DelayedRun
+import at.hannibal2.skyhanni.utils.InventoryUtils.getAmountInInventory
+import at.hannibal2.skyhanni.utils.ItemUtils
+import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
+import at.hannibal2.skyhanni.utils.ItemUtils.repoItemName
+import at.hannibal2.skyhanni.utils.NeuInternalName
+import at.hannibal2.skyhanni.utils.NeuItems
+import at.hannibal2.skyhanni.utils.compat.slotUnderCursor
+import at.hannibal2.skyhanni.utils.coroutines.CoroutineSettings
+import net.minecraft.world.entity.player.Inventory
+import kotlin.time.Duration
+
+@SkyHanniModule
+object CompactorGfSKeybind {
+
+    private val config get() = SkyHanniMod.feature.inventory.gfs
+
+    /** Null until the first repo reload build finished. Replaced as a whole, never field by field. */
+    @Volatile
+    private var lookup: CraftLookup? = null
+
+    private val repoReloadCoroutine = CoroutineSettings("compactor gfs single step crafts", Duration.INFINITE)
+
+    @HandleEvent
+    private fun onNeuRepoReload() {
+        // The sack item list is only rebuilt after this event, so the build has to wait for it.
+        DelayedRun.runNextTickEnd("compactor gfs single step crafts") {
+            repoReloadCoroutine.launch {
+                buildUpgrades()
+            }
+        }
+    }
+
+    private fun buildUpgrades() {
+        val picked = mutableMapOf<NeuInternalName, Upgrade>()
+        val unclear = mutableMapOf<NeuInternalName, List<Upgrade>>()
+        for ((base, results) in createCandidates()) {
+            // Assumed, not verified: the compactor takes the largest craft. Ice makes Packed Ice at 9
+            // and Enchanted Ice at 160, and 160 is what the compactor produces.
+            val highest = results.maxOf { it.baseAmount }
+            val tied = results.filter { it.baseAmount == highest }
+            tied.singleOrNull()?.let { picked[base] = it } ?: run { unclear[base] = tied }
+        }
+        lookup = CraftLookup(picked, unclear)
+    }
+
+    private fun createCandidates(): Map<NeuInternalName, List<Upgrade>> = NeuItems.allNeuRepoInternalNames()
+        // The compactor puts its result into a sack, so anything that has no sack cannot be one.
+        .filter { it.asString() in SackApi.sackListInternalNames }
+        .flatMap { result -> upgradesFor(result) }
+        .groupBy { it.base }
+
+    private fun upgradesFor(result: NeuInternalName): List<Upgrade> = NeuItems.getRecipes(result)
+        .filter { it.isCraftingRecipe() }
+        .mapNotNull { recipe ->
+            val (base, amount) =
+                ItemUtils.neededItems(recipe).entries.singleOrNull() ?: return@mapNotNull null
+            if (amount <= 1) return@mapNotNull null
+            // The base item is what gets pulled with /gfs later, so it needs a sack of its own.
+            if (base.asString() !in SackApi.sackListInternalNames) return@mapNotNull null
+
+            Upgrade(base, amount, result)
+        }
+
+    @HandleEvent(onlyOnSkyblock = true)
+    private fun onKeyDown(event: KeyDownEvent) {
+        if (event.keyCode != config.compactorKeybind) return
+        val slot = slotUnderCursor() ?: return
+        if (slot.container !is Inventory) return
+
+        val internalName = slot.item.getInternalNameOrNull() ?: return
+        grabMissing(internalName)
+    }
+
+    private fun grabMissing(internalName: NeuInternalName) {
+        // Ignore silently, the previous request for this item is still on its way.
+        if (GetFromSackApi.isQueued(internalName) || GetFromSackApi.wasRecentlySent(internalName)) return
+        val lookup = lookup ?: run {
+            ChatUtils.userError("Recipe data is not loaded yet.")
+            return
+        }
+        val itemName = internalName.repoItemName
+
+        if (internalName in lookup.ambiguous) {
+            ChatUtils.userError("$itemName §chas more than one craft at the same amount.")
+            return
+        }
+        val upgrade = lookup.upgrades[internalName] ?: run {
+            ChatUtils.userError("$itemName §ccannot be crafted into another item.")
+            return
+        }
+
+        val missing = upgrade.baseAmount - internalName.getAmountInInventory()
+        if (missing <= 0) {
+            ChatUtils.userError("You already have enough $itemName §cfor ${upgrade.result.repoItemName}§c.")
+            return
+        }
+
+        GetFromSackApi.getFromSack(internalName, missing)
+    }
+
+    @HandleEvent
+    private fun onCommandRegistration(event: CommandRegistrationEvent) {
+        event.registerBrigadier("shtestcompactorcrafts") {
+            description = "List all items with more than one single step craft at the same highest amount"
+            category = CommandCategory.DEVELOPER_DEBUG
+            simpleCallback {
+                printAmbiguous()
+            }
+        }
+    }
+
+    private fun printAmbiguous() {
+        val ambiguous = lookup?.ambiguous ?: run {
+            ChatUtils.userError("Recipe data is not loaded yet.")
+            return
+        }
+        if (ambiguous.isEmpty()) {
+            ChatUtils.chat("No ambiguous single step crafts found.")
+            return
+        }
+        val lines = ambiguous.map { (base, results) ->
+            "${base.asString()} -> ${results.joinToString(", ") { "x${it.baseAmount} into ${it.result.asString()}" }}"
+        }.sorted()
+
+        for (line in lines) {
+            ChatUtils.consoleLog("ambiguous single step craft: $line")
+        }
+        ChatUtils.clickToClipboard("Found ${lines.size} ambiguous single step crafts.", lines)
+    }
+
+    /** A single step craft: [baseAmount] of [base] makes one [result]. */
+    private data class Upgrade(val base: NeuInternalName, val baseAmount: Int, val result: NeuInternalName)
+
+    /**
+     * One finished build. [ambiguous] holds base items where two or more crafts tie at the highest
+     * amount, so no single upgrade can be picked.
+     */
+    private data class CraftLookup(
+        val upgrades: Map<NeuInternalName, Upgrade>,
+        val ambiguous: Map<NeuInternalName, List<Upgrade>>,
+    )
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/CompactorGfSKeybind.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/CompactorGfSKeybind.kt
@@ -48,16 +48,19 @@ object CompactorGfSKeybind {
             if (!slot.isOwnInventory) continue
             val internalName = slot.item.getInternalNameOrNull() ?: continue
 
-            when {
-                isPending(internalName) -> slot.highlight(LorenzColor.YELLOW.addOpacity(OVERLAY_OPACITY))
-                hasMissingAmount(internalName, amounts) -> slot.drawBorder(LorenzColor.GREEN.addOpacity(BORDER_OPACITY))
-                else -> slot.highlight(LorenzColor.DARK_GRAY.addOpacity(OVERLAY_OPACITY))
+            if (isPending(internalName)) {
+                slot.highlight(LorenzColor.YELLOW.addOpacity(OVERLAY_OPACITY))
+                continue
+            }
+
+            val state = CompactorCraftApi.getCraftState(internalName, amounts[internalName] ?: 0)
+            if (state is Missing) {
+                slot.drawBorder(LorenzColor.GREEN.addOpacity(BORDER_OPACITY))
+            } else {
+                slot.highlight(LorenzColor.DARK_GRAY.addOpacity(OVERLAY_OPACITY))
             }
         }
     }
-
-    private fun hasMissingAmount(internalName: NeuInternalName, amounts: Map<NeuInternalName, Int>): Boolean =
-        CompactorCraftApi.getCraftState(internalName, amounts[internalName] ?: 0) is Missing
 
     /** Counted once per frame, so that the state of every slot does not scan the inventory again. */
     private fun countOwnInventory(): Map<NeuInternalName, Int> = buildMap {
@@ -112,16 +115,18 @@ object CompactorGfSKeybind {
             event.toolTip.add("§7${itemName.string}".asComponent())
         }
 
-        val status = statusLine(pending, state) ?: return
         event.toolTip.add("".asComponent())
-        event.toolTip.add(status.asComponent())
+        event.toolTip.add(statusLine(pending, state).asComponent())
     }
 
-    private fun statusLine(pending: Boolean, state: CompactorCraftApi.CraftState): String? = when {
-        pending -> "§7Already requested"
-        state is Missing -> "§eClick to grab §ax${state.amount} §emore for ${state.upgrade.result.repoItemName}"
-        state is Enough -> "§7Already enough for ${state.upgrade.result.repoItemName}"
-        state is Ambiguous -> "§7More than one craft at the same amount"
-        else -> null
+    private fun statusLine(pending: Boolean, state: CompactorCraftApi.CraftState): String {
+        if (pending) return "§7Already requested"
+        return when (state) {
+            is Missing -> "§eClick to grab §ax${state.amount} §emore for ${state.upgrade.result.repoItemName}"
+            is Enough -> "§7Already enough for ${state.upgrade.result.repoItemName}"
+            is Ambiguous -> "§7More than one craft at the same amount"
+            NoCraft -> "§7Cannot be crafted into another item"
+            NotLoaded -> "§7Recipe data is still loading"
+        }
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/CompactorGfSKeybind.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/CompactorGfSKeybind.kt
@@ -1,78 +1,22 @@
 package at.hannibal2.skyhanni.features.inventory
 
 import at.hannibal2.skyhanni.SkyHanniMod
-import at.hannibal2.skyhanni.SkyHanniMod.launch
+import at.hannibal2.skyhanni.api.CompactorCraftApi
 import at.hannibal2.skyhanni.api.GetFromSackApi
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.config.commands.CommandCategory
-import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
-import at.hannibal2.skyhanni.data.SackApi
 import at.hannibal2.skyhanni.events.minecraft.KeyDownEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
-import at.hannibal2.skyhanni.utils.DelayedRun
-import at.hannibal2.skyhanni.utils.InventoryUtils.getAmountInInventory
-import at.hannibal2.skyhanni.utils.ItemUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.ItemUtils.repoItemName
 import at.hannibal2.skyhanni.utils.NeuInternalName
-import at.hannibal2.skyhanni.utils.NeuItems
 import at.hannibal2.skyhanni.utils.compat.slotUnderCursor
-import at.hannibal2.skyhanni.utils.coroutines.CoroutineSettings
 import net.minecraft.world.entity.player.Inventory
-import kotlin.time.Duration
 
 @SkyHanniModule
 object CompactorGfSKeybind {
 
     private val config get() = SkyHanniMod.feature.inventory.gfs
-
-    /** Null until the first repo reload build finished. Replaced as a whole, never field by field. */
-    @Volatile
-    private var lookup: CraftLookup? = null
-
-    private val repoReloadCoroutine = CoroutineSettings("compactor gfs single step crafts", Duration.INFINITE)
-
-    @HandleEvent
-    private fun onNeuRepoReload() {
-        // The sack item list is only rebuilt after this event, so the build has to wait for it.
-        DelayedRun.runNextTickEnd("compactor gfs single step crafts") {
-            repoReloadCoroutine.launch {
-                buildUpgrades()
-            }
-        }
-    }
-
-    private fun buildUpgrades() {
-        val picked = mutableMapOf<NeuInternalName, Upgrade>()
-        val unclear = mutableMapOf<NeuInternalName, List<Upgrade>>()
-        for ((base, results) in createCandidates()) {
-            // Assumed, not verified: the compactor takes the largest craft. Ice makes Packed Ice at 9
-            // and Enchanted Ice at 160, and 160 is what the compactor produces.
-            val highest = results.maxOf { it.baseAmount }
-            val tied = results.filter { it.baseAmount == highest }
-            tied.singleOrNull()?.let { picked[base] = it } ?: run { unclear[base] = tied }
-        }
-        lookup = CraftLookup(picked, unclear)
-    }
-
-    private fun createCandidates(): Map<NeuInternalName, List<Upgrade>> = NeuItems.allNeuRepoInternalNames()
-        // The compactor puts its result into a sack, so anything that has no sack cannot be one.
-        .filter { it.asString() in SackApi.sackListInternalNames }
-        .flatMap { result -> upgradesFor(result) }
-        .groupBy { it.base }
-
-    private fun upgradesFor(result: NeuInternalName): List<Upgrade> = NeuItems.getRecipes(result)
-        .filter { it.isCraftingRecipe() }
-        .mapNotNull { recipe ->
-            val (base, amount) =
-                ItemUtils.neededItems(recipe).entries.singleOrNull() ?: return@mapNotNull null
-            if (amount <= 1) return@mapNotNull null
-            // The base item is what gets pulled with /gfs later, so it needs a sack of its own.
-            if (base.asString() !in SackApi.sackListInternalNames) return@mapNotNull null
-
-            Upgrade(base, amount, result)
-        }
 
     @HandleEvent(onlyOnSkyblock = true)
     private fun onKeyDown(event: KeyDownEvent) {
@@ -87,69 +31,14 @@ object CompactorGfSKeybind {
     private fun grabMissing(internalName: NeuInternalName) {
         // Ignore silently, the previous request for this item is still on its way.
         if (GetFromSackApi.isQueued(internalName) || GetFromSackApi.wasRecentlySent(internalName)) return
-        val lookup = lookup ?: run {
-            ChatUtils.userError("Recipe data is not loaded yet.")
-            return
-        }
         val itemName = internalName.repoItemName
 
-        if (internalName in lookup.ambiguous) {
-            ChatUtils.userError("$itemName §chas more than one craft at the same amount.")
-            return
-        }
-        val upgrade = lookup.upgrades[internalName] ?: run {
-            ChatUtils.userError("$itemName §ccannot be crafted into another item.")
-            return
-        }
-
-        val missing = upgrade.baseAmount - internalName.getAmountInInventory()
-        if (missing <= 0) {
-            ChatUtils.userError("You already have enough $itemName §cfor ${upgrade.result.repoItemName}§c.")
-            return
-        }
-
-        GetFromSackApi.getFromSack(internalName, missing)
-    }
-
-    @HandleEvent
-    private fun onCommandRegistration(event: CommandRegistrationEvent) {
-        event.registerBrigadier("shtestcompactorcrafts") {
-            description = "List all items with more than one single step craft at the same highest amount"
-            category = CommandCategory.DEVELOPER_DEBUG
-            simpleCallback {
-                printAmbiguous()
-            }
+        when (val state = CompactorCraftApi.getCraftState(internalName)) {
+            NotLoaded -> ChatUtils.userError("Recipe data is not loaded yet.")
+            NoCraft -> ChatUtils.userError("$itemName §ccannot be crafted into another item.")
+            is Ambiguous -> ChatUtils.userError("$itemName §chas more than one craft at the same amount.")
+            is Enough -> ChatUtils.userError("You already have enough $itemName §cfor ${state.upgrade.result.repoItemName}§c.")
+            is Missing -> GetFromSackApi.getFromSack(internalName, state.amount)
         }
     }
-
-    private fun printAmbiguous() {
-        val ambiguous = lookup?.ambiguous ?: run {
-            ChatUtils.userError("Recipe data is not loaded yet.")
-            return
-        }
-        if (ambiguous.isEmpty()) {
-            ChatUtils.chat("No ambiguous single step crafts found.")
-            return
-        }
-        val lines = ambiguous.map { (base, results) ->
-            "${base.asString()} -> ${results.joinToString(", ") { "x${it.baseAmount} into ${it.result.asString()}" }}"
-        }.sorted()
-
-        for (line in lines) {
-            ChatUtils.consoleLog("ambiguous single step craft: $line")
-        }
-        ChatUtils.clickToClipboard("Found ${lines.size} ambiguous single step crafts.", lines)
-    }
-
-    /** A single step craft: [baseAmount] of [base] makes one [result]. */
-    private data class Upgrade(val base: NeuInternalName, val baseAmount: Int, val result: NeuInternalName)
-
-    /**
-     * One finished build. [ambiguous] holds base items where two or more crafts tie at the highest
-     * amount, so no single upgrade can be picked.
-     */
-    private data class CraftLookup(
-        val upgrades: Map<NeuInternalName, Upgrade>,
-        val ambiguous: Map<NeuInternalName, List<Upgrade>>,
-    )
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/GfSKeybind.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/GfSKeybind.kt
@@ -14,7 +14,7 @@ object GfSKeybind {
     private val config get() = SkyHanniMod.feature.inventory.gfs
 
     @HandleEvent
-    fun onKey(event: GuiKeyPressEvent) {
+    private fun onGuiKeyPress() {
         if (!config.keybind.isKeyClicked()) return
         stackUnderCursor()?.getInternalNameOrNull()?.let {
             GetFromSackApi.getFromSack(it, 9999)

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/GfSKeybind.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/GfSKeybind.kt
@@ -3,7 +3,6 @@ package at.hannibal2.skyhanni.features.inventory
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.GetFromSackApi
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.events.GuiKeyPressEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalNameOrNull
 import at.hannibal2.skyhanni.utils.KeyboardManager.isKeyClicked


### PR DESCRIPTION
## Changelog New Features
+ Added Compactor GFS Keybind. - hannibal2
    * Hold the keybind to mark every item in your inventory that can be crafted into another item.
    * Click a marked item to grab the number of items missing for that craft from your sacks.
    * Items that cannot be used show the reason in their tooltip.