### PR TITLE
Backend: Fix some RepositoryReloadEvent handlers not being disableable

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/event/SkyHanniEvents.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/event/SkyHanniEvents.kt
@@ -18,7 +18,6 @@ import java.util.concurrent.atomic.AtomicInteger
 
 @SkyHanniModule
 object SkyHanniEvents {
-
     private val listeners: MutableMap<Class<out SkyHanniEvent>, EventListeners> = mutableMapOf()
     private val handlers: MutableMap<Class<out SkyHanniEvent>, EventHandler<out SkyHanniEvent>> = mutableMapOf()
     private var disabledHandlers = emptySet<String>()
@@ -139,16 +138,16 @@ object SkyHanniEvents {
 
     fun markEventCacheDirty(type: DirtyReason) {
         when (type) {
-            DirtyReason.REPO_RELOAD,
-            DirtyReason.OUTSIDE_SB_FEATURE_CHANGED,
+            REPO_RELOAD,
+            OUTSIDE_SB_FEATURE_CHANGED,
             -> listenerCacheGeneration.incrementAndGet()
 
-            DirtyReason.LOCATION_CHANGED -> {
+            LOCATION_CHANGED -> {
                 listenerCacheGeneration.incrementAndGet()
                 currentStateIndex.set(ListenerCollection.getCurrentStateIndex())
             }
 
-            DirtyReason.SERVER_DISCONNECTED -> {
+            SERVER_DISCONNECTED -> {
                 listenerCacheGeneration.incrementAndGet()
                 currentStateIndex.set(ListenerCollection.OUTSIDE)
             }
@@ -165,8 +164,8 @@ object SkyHanniEvents {
         REPO_RELOAD,
     }
 
-    // This is marked highest priority to let it
-    // disable other RepositoryReloadEvent listeners before they happen
+    // This is marked highest priority to let it disable other RepositoryReloadEvent listeners
+    // before they happen. All other listeners of this event must use HIGH or lower priority.
     @HandleEvent(priority = HandleEvent.HIGHEST)
     private fun onRepoReload(event: RepositoryReloadEvent) {
         val data = event.getConstant<DisabledEventsJson>("DisabledEvents")
@@ -175,9 +174,8 @@ object SkyHanniEvents {
         val mcVersion = PlatformUtils.MC_VERSION
         disabledHandlers = data.disabledHandlers + data.disabledHandlersVersioned.activeNames(version, mcVersion)
         disabledHandlerInvokers = data.disabledInvokers + data.disabledInvokersVersioned.activeNames(version, mcVersion)
-        markEventCacheDirty(DirtyReason.REPO_RELOAD)
+        markEventCacheDirty(REPO_RELOAD)
     }
-
 
     private fun Set<DisabledEventVersionedJson>.activeNames(
         version: ModVersion,
@@ -198,7 +196,6 @@ object SkyHanniEvents {
 
             for (second in seconds) {
                 if (event.repeatSeconds(second)) {
-
                     for (handler in list) {
                         val log = handler.invokeLog
                         val current = log.invokeCount
@@ -221,7 +218,6 @@ object SkyHanniEvents {
     class EventInvokeData(var oldValue: Long, var diff: Long)
 
     class EventInvokeLog {
-
         var invokeCount: Long = 0L
 
         var overTimeLog = mutableMapOf<Int, EventInvokeData>()
@@ -252,7 +248,6 @@ object SkyHanniEvents {
 
                             append(" ")
                             append("${(log.invokeCount / (ClientEvents.totalTicks / 20)).addSeparators()}/s")
-
                         },
                     )
                 }

--- a/src/main/java/at/hannibal2/skyhanni/data/IslandType.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/IslandType.kt
@@ -2,7 +2,6 @@ package at.hannibal2.skyhanni.data
 
 import at.hannibal2.skyhanni.SkyHanniMod.launch
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.api.event.HandleEvent.Companion.HIGHEST
 import at.hannibal2.skyhanni.data.jsonobjects.repo.IslandTypeJson
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -93,7 +92,6 @@ enum class IslandType(private val nameFallback: String, private val apiNameFallb
 
     @SkyHanniModule
     companion object {
-
         fun Collection<IslandType>.isInAnyIsland(): Boolean = any { it.isInIsland() }
         private val repoReloadCoroutine = CoroutineSettings("island type repo reload")
 
@@ -116,8 +114,8 @@ enum class IslandType(private val nameFallback: String, private val apiNameFallb
         fun getByIdOrNull(id: String): IslandType? = entries.find { it.apiName == id }
         fun getByIdOrUnknown(id: String): IslandType = getByIdOrNull(id) ?: UNKNOWN
 
-        @HandleEvent(priority = HIGHEST)
-        fun onRepoReload(event: RepositoryReloadEvent) = repoReloadCoroutine.launch {
+        @HandleEvent(priority = HandleEvent.HIGH)
+        private fun onRepoReload(event: RepositoryReloadEvent) = repoReloadCoroutine.launch {
             val data = event.getConstantAsync<IslandTypeJson>("misc/IslandType")
 
             entries.forEach { islandType ->

--- a/src/main/java/at/hannibal2/skyhanni/features/chat/PowderMiningChatFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/chat/PowderMiningChatFilter.kt
@@ -13,7 +13,6 @@ import at.hannibal2.skyhanni.config.features.chat.PowderMiningConfig.SimplePowde
 import at.hannibal2.skyhanni.config.features.chat.PowderMiningConfig.SimplePowderMiningRewardTypes.TREASURITE
 import at.hannibal2.skyhanni.config.features.chat.PowderMiningConfig.SimplePowderMiningRewardTypes.WISHING_COMPASS
 import at.hannibal2.skyhanni.config.features.chat.PowderMiningConfig.SimplePowderMiningRewardTypes.YOGGIE
-import at.hannibal2.skyhanni.config.features.chat.PowderMiningGemstoneConfig.GemstoneFilterEntry
 import at.hannibal2.skyhanni.events.RepositoryReloadEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
@@ -27,7 +26,6 @@ import java.util.regex.Pattern
 
 @SkyHanniModule
 object PowderMiningChatFilter {
-
     private val config get() = SkyHanniMod.feature.chat.filterType.powderMining
     private val gemstoneConfig get() = config.gemstone
 
@@ -316,8 +314,8 @@ object PowderMiningChatFilter {
     private var rewardPatterns: Map<Pair<Pattern, PowderMiningConfig.SimplePowderMiningRewardTypes>, String> =
         emptyMap()
 
-    @HandleEvent(priority = HandleEvent.HIGHEST)
-    fun onRepoReload(event: RepositoryReloadEvent) {
+    @HandleEvent(priority = HandleEvent.HIGH)
+    private fun onRepoReload(event: RepositoryReloadEvent) {
         rewardPatterns = mapOf(
             ascensionRopeRewardPattern to ASCENSION_ROPE to "powder_mining_ascension_rope",
             wishingCompassRewardPattern to WISHING_COMPASS to "powder_mining_wishing_compass",
@@ -344,21 +342,21 @@ object PowderMiningChatFilter {
 
     private fun blockGoblinEggs(ssMessage: String): String? {
         goblinEggPattern.matchMatcher(ssMessage) {
-            if (config.goblinEggs == PowderMiningConfig.GoblinEggEntry.SHOW_ALL) return "no_filter"
-            if (config.goblinEggs == PowderMiningConfig.GoblinEggEntry.HIDE_ALL) return "powder_mining_goblin_eggs"
+            if (config.goblinEggs == SHOW_ALL) return "no_filter"
+            if (config.goblinEggs == HIDE_ALL) return "powder_mining_goblin_eggs"
 
             return when (val colorStr = groupOrNull("color")?.lowercase()) {
                 // 'Colorless', base goblin eggs will never be shown in this code path
                 null -> "powder_mining_goblin_eggs"
-                "green" -> if (config.goblinEggs > PowderMiningConfig.GoblinEggEntry.GREEN_UP) {
+                "green" -> if (config.goblinEggs > GREEN_UP) {
                     "powder_mining_goblin_eggs"
                 } else "no_filter"
 
-                "yellow" -> if (config.goblinEggs > PowderMiningConfig.GoblinEggEntry.YELLOW_UP) {
+                "yellow" -> if (config.goblinEggs > YELLOW_UP) {
                     "powder_mining_goblin_eggs"
                 } else "no_filter"
 
-                "red" -> if (config.goblinEggs > PowderMiningConfig.GoblinEggEntry.RED_UP) {
+                "red" -> if (config.goblinEggs > RED_UP) {
                     "powder_mining_goblin_eggs"
                 } else "no_filter"
                 // BLUE_ONLY enum not explicitly used in comparison, as the only
@@ -394,17 +392,17 @@ object PowderMiningChatFilter {
                 else -> return "no_filter"
             }
 
-            if (gemSpecificFilterEntry == GemstoneFilterEntry.HIDE_ALL) return "powder_mining_gemstones"
+            if (gemSpecificFilterEntry == HIDE_ALL) return "powder_mining_gemstones"
 
             return when (tierStr) {
                 // Never allowed through, except for in SHOW_ALL,
                 // which is handled above
                 "rough" -> "powder_mining_gemstones"
-                "flawed" -> if (gemSpecificFilterEntry > GemstoneFilterEntry.FLAWED_UP) {
+                "flawed" -> if (gemSpecificFilterEntry > FLAWED_UP) {
                     "powder_mining_gemstones"
                 } else "no_filter"
 
-                "fine" -> if (gemSpecificFilterEntry > GemstoneFilterEntry.FINE_UP) {
+                "fine" -> if (gemSpecificFilterEntry > FINE_UP) {
                     "powder_mining_gemstones"
                 } else "no_filter"
                 // FLAWLESS_ONLY enum not explicitly used in comparison, as the only

--- a/src/main/java/at/hannibal2/skyhanni/features/slayer/RemainingSlayerKills.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/slayer/RemainingSlayerKills.kt
@@ -2,11 +2,9 @@ package at.hannibal2.skyhanni.features.slayer
 
 import at.hannibal2.skyhanni.SkyHanniMod
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.api.event.HandleEvent.Companion.HIGHEST
 import at.hannibal2.skyhanni.api.pet.CurrentPetApi
 import at.hannibal2.skyhanni.data.ElectionApi
 import at.hannibal2.skyhanni.data.SlayerApi
-import at.hannibal2.skyhanni.data.effect.NonGodPotEffect
 import at.hannibal2.skyhanni.data.hypixel.chat.event.SystemMessageEvent
 import at.hannibal2.skyhanni.data.model.SkyblockStat
 import at.hannibal2.skyhanni.events.ProfileJoinEvent
@@ -43,7 +41,6 @@ import kotlin.time.Duration.Companion.minutes
 
 @SkyHanniModule
 object RemainingSlayerKills {
-
     private val config get() = SlayerApi.config.slayerRemainingKills
     private val debugToggle get() = SkyHanniMod.feature.dev.debug.remainingKillsDebug
 
@@ -119,7 +116,7 @@ object RemainingSlayerKills {
     private var lastReminder = SimpleTimeMark.farPast()
     private var killComboWisdom = 0
 
-    @HandleEvent(priority = HIGHEST)
+    @HandleEvent(priority = HandleEvent.HIGH)
     private fun onRepoReload(event: RepositoryReloadEvent) {
         data = event.getConstant<SlayerData>("Slayer")
     }
@@ -243,7 +240,7 @@ object RemainingSlayerKills {
             }
         }
 
-        if (NonGodPotEffectDisplay.isActive(NonGodPotEffect.SMOLDERING) && SlayerApi.activeType == SlayerType.INFERNO) {
+        if (NonGodPotEffectDisplay.isActive(SMOLDERING) && SlayerApi.activeType == INFERNO) {
             combatWisdom += 10
         }
 
@@ -275,7 +272,6 @@ object RemainingSlayerKills {
      * https://hypixelskyblock.minecraft.wiki/w/Combat_Wisdom#Notes
      */
     private fun getAdditivelyMultiplicativeValues(): Double {
-
         var additiveWithMultMultipliers = 1.0
 
         val championLevel = (InventoryUtils.getItemInHand()?.getHypixelEnchantments().orEmpty()["champion"] ?: 0) - 1
@@ -372,4 +368,3 @@ object RemainingSlayerKills {
 
     private fun isEnabled() = SkyBlockUtils.inSkyBlock && config.display
 }
-


### PR DESCRIPTION
## What
Changes `RepositoryReloadEvent` handlers outside `SkyHanniEvents` that were using `HIGHEST` priority to `HIGH` to ensure they can be disabled. There was no reason for them to use `HIGHEST`, as there were no `HIGH` priority listeners for them to take precedence over.

## Changelog Technical Details
+ Lowered the priority of IslandType.onRepoReload, PowderMiningChatFilter.onRepoReload, and RemainingSlayerKills.onRepoReload from HIGHEST to HIGH to ensure SkyHanniEvents can disable them. - Luna