### PR TITLE
Fix: Wrong guesses from particle path tracking

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
@@ -15,7 +15,9 @@ import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.features.fame.ReminderUtils
 import at.hannibal2.skyhanni.features.garden.GardenApi
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.ColorUtils.toColor
+import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.EntityUtils.getEntitiesNearby
 import at.hannibal2.skyhanni.utils.InventoryUtils
 import at.hannibal2.skyhanni.utils.ItemUtils.getInternalName
@@ -34,7 +36,6 @@ import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawLineToCrosshair
 import at.hannibal2.skyhanni.utils.render.WorldRenderUtils.drawWaypointFilled
 import net.minecraft.core.particles.ParticleTypes
 import net.minecraft.world.entity.projectile.FishingHook
-import kotlin.math.sign
 import kotlin.time.Duration.Companion.seconds
 
 @SkyHanniModule
@@ -43,9 +44,14 @@ object HoppityEggLocator {
     private val waypointsConfig get() = config.waypoints
     val locatorItem = "EGGLOCATOR".toInternalName()
 
+    private const val MAX_GUESS_DISTANCE = 5.0
+
     private var lastClick = SimpleTimeMark.farPast()
 
     private var drawLocations = false
+
+    @Volatile
+    private var warningPending = false
 
     var sharedEggLocation: LorenzVec? = null
     var possibleEggLocations = listOf<LorenzVec>()
@@ -53,12 +59,12 @@ object HoppityEggLocator {
     var currentEggNote: String? = null
 
     @HandleEvent
-    fun onEggFound(event: EggFoundEvent) {
+    private fun onEggFound(event: EggFoundEvent) {
         if (event.type.isResetting) resetData()
     }
 
     @HandleEvent
-    fun onWorldChange() {
+    private fun onWorldChange() {
         resetData()
     }
 
@@ -69,15 +75,16 @@ object HoppityEggLocator {
         currentEggType = null
         currentEggNote = null
         bezierFitter.reset()
+        warningPending = false
     }
 
     @HandleEvent
-    fun onEggSpawned(event: EggSpawnedEvent) {
+    private fun onEggSpawned(event: EggSpawnedEvent) {
         if (event.eggType == currentEggType) resetData()
     }
 
     @HandleEvent
-    fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
+    private fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
         if (!isEnabled()) return
 
         if (drawLocations) {
@@ -159,7 +166,7 @@ object HoppityEggLocator {
     private val bezierFitter = ParticlePathBezierFitter(3)
 
     @HandleEvent(onlyOnSkyblock = true, receiveCancelled = true)
-    fun onParticle(event: ParticleEvent) {
+    private fun onParticle(event: ParticleEvent) {
         if (!isEnabled()) return
         if (!event.isVillagerParticle()) return
         if (lastClick.passedSince() > 5.seconds) return
@@ -168,35 +175,45 @@ object HoppityEggLocator {
         if (!bezierFitter.tryAdd(event.location, maxDistanceToLast = 3.0, endCondition = endCondition)) return
 
         val guess = guessEggLocation() ?: return
-        if (!SkyBlockUtils.currentIsland.isInBounds(guess)) return
         possibleEggLocations = listOf(guess)
         drawLocations = true
-        if (possibleEggLocations.size == 1) {
-            trySendingGraph()
-        }
+        warningPending = false
+        trySendingGraph()
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onItemClick(event: ItemClickEvent) {
-        if (!isEnabled()) return
+    private fun onItemClick(event: ItemClickEvent) {
         val item = event.itemInHand ?: return
+        if (event.clickType != InteractClickType.RIGHT_CLICK || !item.isLocatorItem) return
 
-        if (event.clickType == InteractClickType.RIGHT_CLICK && item.isLocatorItem && lastClick.passedSince() >= 5.seconds) {
-            lastClick = SimpleTimeMark.now()
-            MythicRabbitPetWarning.check()
-            trySendingGraph()
-            bezierFitter.reset()
-        }
+        if (!isEnabled()) return
+        if (lastClick.passedSince() < 5.seconds) return
+
+        val clickTime = SimpleTimeMark.now()
+        lastClick = clickTime
+        warningPending = true
+        MythicRabbitPetWarning.check()
+        trySendingGraph()
+        bezierFitter.reset()
+        DelayedRun.runDelayed(5.5.seconds) { warnIfNoGuessFound(clickTime) }
+    }
+
+    /** Tells the player that the run produced nothing usable. Silent for an outdated use and on islands without known eggs. */
+    private fun warnIfNoGuessFound(clickTime: SimpleTimeMark) {
+        if (lastClick != clickTime) return
+        if (!warningPending) return
+        if (bezierFitter.isEmpty()) return
+        if (HoppityEggLocations.islandLocations.isEmpty()) return
+        ChatUtils.chat("Egg Locator result was unreliable, please use it again!")
     }
 
     private fun guessEggLocation(): LorenzVec? {
         val guessLocation = bezierFitter.solve() ?: return null
+        if (!SkyBlockUtils.currentIsland.isInBounds(guessLocation)) return null
 
-        val guessEgg = HoppityEggLocations.islandLocations.sortedWith { a, b ->
-            sign(a.distanceSq(guessLocation) - b.distanceSq(guessLocation)).toInt()
-        }.firstOrNull()
+        val closestEgg = HoppityEggLocations.islandLocations.minByOrNull { it.distanceSq(guessLocation) }
 
-        return guessEgg
+        return closestEgg?.takeIf { it.distance(guessLocation) <= MAX_GUESS_DISTANCE }
     }
 
     private fun trySendingGraph() {
@@ -224,7 +241,7 @@ object HoppityEggLocator {
     }
 
     @HandleEvent
-    fun onDebugDataCollect(event: DebugDataCollectEvent) {
+    private fun onDebugDataCollect(event: DebugDataCollectEvent) {
         event.title("Hoppity Eggs Locations")
 
         if (!isEnabled()) {
@@ -242,7 +259,7 @@ object HoppityEggLocator {
     }
 
     @HandleEvent
-    fun onCommandRegistration(event: CommandRegistrationEvent) {
+    private fun onCommandRegistration(event: CommandRegistrationEvent) {
         event.registerBrigadier("shtestrabbitpaths") {
             description = "Tests pathfinding to rabbit eggs. Use a number 0-14."
             category = CommandCategory.DEVELOPER_TEST

--- a/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/hoppity/HoppityEggLocator.kt
@@ -204,7 +204,7 @@ object HoppityEggLocator {
         if (!warningPending) return
         if (bezierFitter.isEmpty()) return
         if (HoppityEggLocations.islandLocations.isEmpty()) return
-        ChatUtils.chat("Egg Locator result was unreliable, please use it again!")
+        ChatUtils.chat("Egglocator result was unreliable, please use it again!")
     }
 
     private fun guessEggLocation(): LorenzVec? {

--- a/src/main/java/at/hannibal2/skyhanni/utils/PolynomialFitter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/PolynomialFitter.kt
@@ -89,12 +89,33 @@ open class BezierFitter(private val degree: Int) {
             return false
         }
         val distToLast = getLastPoint()?.distance(location) ?: return false
-        if (distToLast == 0.0) return false
         if (distToLast > maxDistanceToLast) return false
+        if (isAlreadyUsed(location)) return false
+        if (isMovingBackwards(location)) return false
         if (endCondition(location)) return false
 
         addPoint(location)
         return true
+    }
+
+    /**
+     * Hypixel can send the same particle position more than once. In a lag burst the copies can arrive
+     * interleaved (A, B, A, B), so comparing against the last point alone lets an already used position
+     * back in. A duplicated position makes the fit ill conditioned, with degree 3 the solution can end up
+     * thousands of blocks away.
+     */
+    private fun isAlreadyUsed(location: LorenzVec) = points.any { it.distanceSq(location) < REPEAT_TOLERANCE_SQ }
+
+    /** Assumes a particle path travels away from its first point, so anything not further from it than the last point is dropped. */
+    private fun isMovingBackwards(location: LorenzVec): Boolean {
+        val start = points.firstOrNull() ?: return false
+        val last = points.lastOrNull() ?: return false
+        return start.distanceSq(location) <= start.distanceSq(last)
+    }
+
+    companion object {
+        /** 0.01 blocks, squared. */
+        private const val REPEAT_TOLERANCE_SQ = 0.0001
     }
 }
 


### PR DESCRIPTION
ting at a completely wrong l## What
  `BezierFitter.tryAdd` got confused when Hypixel was sending particles in wrong order.

## Changelog Fixes
+ Fixed particle-tracking items sometimes pointing at a completely wrong location. - hannibal2
    * Especially noticeable with Hoppity Egg Locator in The End, Torrhus Canyon and Lotus Atoll.