### PR TITLE
Fix: Sea Creature catch messages not using proper articles

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
@@ -525,9 +525,10 @@ object StringUtils {
 
     fun String.isValidUuid(): Boolean = runCatching(UUID::fromString).isSuccess
 
-    fun optionalAn(string: String): String {
-        if (string.isEmpty()) return ""
-        return if (string[0] in "aeiou") "an" else "a"
+    fun optionalAn(string: String): String = when {
+        string.isEmpty() -> ""
+        string.first().isVowel() -> "an"
+        else -> "a"
     }
 
     fun String.hasWhitespace(): Boolean = any { it.isWhitespace() }

--- a/src/test/java/at/hannibal2/skyhanni/test/StringUtilsTest.kt
+++ b/src/test/java/at/hannibal2/skyhanni/test/StringUtilsTest.kt
@@ -1,0 +1,18 @@
+package at.hannibal2.skyhanni.test
+
+import at.hannibal2.skyhanni.utils.StringUtils
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class StringUtilsTest {
+    @Test
+    fun `optionalAn returns the correct article`() {
+        assertEquals("an", StringUtils.optionalAn("apple"))
+        assertEquals("an", StringUtils.optionalAn("Apple"))
+        assertEquals("a", StringUtils.optionalAn("pear"))
+        assertEquals("a", StringUtils.optionalAn("Pear"))
+        assertEquals("a", StringUtils.optionalAn("yeti"))
+        assertEquals("a", StringUtils.optionalAn("Yeti"))
+        assertEquals("", StringUtils.optionalAn(""))
+    }
+}


### PR DESCRIPTION
## What
`StringUtils.optionalAn` was only returning `"an"` if the string starts with a *lowercase* vowel; otherwise it would return `"a"`. The only practical user-facing effect of this today is that Sea Creature catch messages are wrong: "I caught a Oasis Sheep!" rather than "I caught an Oasis Sheep!".

## Changelog Fixes
+ Fixed Sea Creature catch messages incorrectly saying "a" instead of "an" (e.g. "a Oasis Sheep"). - Luna