### PR TITLE
Backend: Bump Render Chest to 1.0.3

### DIFF
--- a/sharedVariables/src/ProjectTarget.kt
+++ b/sharedVariables/src/ProjectTarget.kt
@@ -31,7 +31,7 @@ enum class ProjectTarget(
         // There is no 26.2 version; the 26.1 version works on 26.2.
         hypixelModApiFabricVersion = "maven.modrinth:hypixel-mod-api:1.0.2+build.1+mc26.1",
         modMenuVersion = "20.0.0-beta.4",
-        renderChestVersion = "1.0.2+26.2",
+        renderChestVersion = "1.0.3+26.2",
         modrinthInfo = ModrinthInfo.FABRIC_26_2,
     ),
 


### PR DESCRIPTION
## What
Bumps render chest to 1.0.3.
This fixes the glow being XRAY with specifically intel GPUs
This is not a fix due to uh, being dangerous to be in changelog

## Changelog Technical Details
+ Bumped Render Chest to 1.0.3. - Avrg