### PR TITLE
Remove isMovingBackwards from BezierFitter

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/PolynomialFitter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/PolynomialFitter.kt
@@ -91,7 +91,6 @@ open class BezierFitter(private val degree: Int) {
         val distToLast = getLastPoint()?.distance(location) ?: return false
         if (distToLast > maxDistanceToLast) return false
         if (isAlreadyUsed(location)) return false
-        if (isMovingBackwards(location)) return false
         if (endCondition(location)) return false
 
         addPoint(location)
@@ -99,19 +98,13 @@ open class BezierFitter(private val degree: Int) {
     }
 
     /**
-     * Hypixel can send the same particle position more than once. In a lag burst the copies can arrive
-     * interleaved (A, B, A, B), so comparing against the last point alone lets an already used position
-     * back in. A duplicated position makes the fit ill conditioned, with degree 3 the solution can end up
-     * thousands of blocks away.
+     * Hypixel repeats particle positions, usually right after each other, sometimes interleaved as A, B, A, B.
+     * Comparing against the last point alone therefore lets a used position back in, so every point is checked.
+     * [addPoint] uses a point's position in the list as its curve parameter, so a repeat stalls the curve and
+     * distorts the derivative at the start that [ParticlePathBezierFitter.solve] extrapolates from. With degree 3
+     * the result can land thousands of blocks away.
      */
     private fun isAlreadyUsed(location: LorenzVec) = points.any { it.distanceSq(location) < REPEAT_TOLERANCE_SQ }
-
-    /** Assumes a particle path travels away from its first point, so anything not further from it than the last point is dropped. */
-    private fun isMovingBackwards(location: LorenzVec): Boolean {
-        val start = points.firstOrNull() ?: return false
-        val last = points.lastOrNull() ?: return false
-        return start.distanceSq(location) <= start.distanceSq(last)
-    }
 
     companion object {
         /** 0.01 blocks, squared. */


### PR DESCRIPTION

exclude_from_changelog

## What

#6504 added `isMovingBackwards` to `BezierFitter.tryAdd`, which assumed a particle path always travels away from its own first point.

That is wrong. The path follows the player look vector first and curves toward the target only after that, so it reverses close to its own start when the player looks away from the target. Measured with the Fishing Hotspot Radar: in one run the check dropped a legitimate point and the guess landed 1154 blocks off target, while a second fitter running in parallel without the check hit the target exactly.

The repeat check from #6504 stays. It caught every repeated position on its own in all measured runs.

The KDoc on it is rewritten as well. It blamed a lag burst for the repeated positions, and lag cannot reorder an ordered stream. Thanks to blux for both points.

No changelog entry because #6504 is merged but has not been released in a beta.