### PR TITLE
Improvement: Resolve pet item names with color rarity

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/ItemNameResolver.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ItemNameResolver.kt
@@ -6,6 +6,7 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NeuItems.getItemStackOrNull
 import at.hannibal2.skyhanni.utils.NumberUtil.romanToDecimalIfNecessary
+import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.StringUtils.allLettersFirstUppercase
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
@@ -89,13 +90,32 @@ object ItemNameResolver {
             else -> null
         }
 
-    private fun resolvePetWithRarity(itemName: String): NeuInternalName? {
+    private fun parsePetString(itemName: String): Pair<LorenzRarity, String>? {
+        // Parse pet string using color codes
+        val petPattern = ".*§(?<color>\\d)(?<pet>.+)$".toPattern()
+        val patternResult = petPattern.matchMatcher(itemName) {
+            val groupPet = groupOrNull("pet") ?: return@matchMatcher null
+            val groupColor = groupOrNull("color")?.first() ?: return@matchMatcher null
+            val petName = groupPet.removeColor().split(" ").joinToString("_").uppercase()
+            val petRarity = LorenzRarity.getByColorCode(groupColor) ?: return@matchMatcher null
+            petRarity to petName
+        }
+
+        if (patternResult != null) return patternResult
+
+        // fallback to parsing without color and rarity string
         val splits = itemName.split(" ").takeIf { it.size > 1 } ?: return null
         val rarityLocation = splits.indexOfFirst { LorenzRarity.getByName(it) != null }
         val expectedRarityLocations = listOf(0, splits.size - 1)
         if (rarityLocation !in expectedRarityLocations) return null
         val petName = splits.filterIndexed { index, _ -> index != rarityLocation }.joinToString("_").uppercase()
         val petRarity = LorenzRarity.getByName(splits[rarityLocation]) ?: return null
+
+        return petRarity to petName
+    }
+
+    private fun resolvePetWithRarity(itemName: String): NeuInternalName? {
+        val (petRarity, petName) = parsePetString(itemName) ?: return null
         val internalName = "$petName;${petRarity.id}".toInternalName()
         return internalName.takeIf { it.getItemStackOrNull() != null }
     }


### PR DESCRIPTION
<!-- remove all unused parts 

The title of your PR should be descriptive and concise.
It should be in the format of `Type: Description`. For example, `Feature: Add new command` or `Fix: Bug in command`.
If there are multiple types of changes these can be separated by a plus.
For example, `Feature + Fix: Add new command and fix bug in command`.
Commonly used labels are Improvement, Backend, Feature and Fix.

## PR Reviews

When your PR is marked as ready for review, some of our maintainers will look through your code to make sure everything is good to go.
In order to do this, they may request some changes you will need to do, **or fix smaller stuff (like merge conflicts) for you**.
If a maintainer has reviewed your PR, make sure to **pull any of their changes** into your local project before doing more work on your code.
Having maintainers fix small stuff for you helps us speed up the process of merging your PR,
so if some of your systems warrant further care, be sure to let us know (preferably with a code comment).

Make sure to only mark your PR as "Ready to review" when it is.
If you still want to do major changes, you can keep a draft PR open until then.

## Keyword Labels

Some labels and checks are controlled by keywords in this description.

Write `waiting_on_hypixel_alpha` if the feature your PR relies on is currently only available on the Hypixel alpha server.
This adds the "Waiting on Hypixel" label and blocks the PR from being merged until you remove the line again.

Write `exclude_from_changelog` if this PR has no changelog entries at all, for example when reverting a pull request,
or when fixing a pull request that was merged but not yet released in a beta. Explain the reason in the What section instead.

A keyword line has to match exactly, on its own line. Leading or trailing spaces, list markers such as `- `,
and a different capitalization all prevent it from being recognized. See CONTRIBUTING.md for details.
-->

## What
Adds pattern parsing of pet items with color support so `IternalNameResolver` can return correct internal names for pet drops, resolving missing pet drops from vacuum item tracking.

Maintains fallback function for handling non-color rare drop text.

<details>
<summary>Images</summary>

<!-- drop images here -->
<img width="652" height="50" alt="Screenshot 2026-09-07 004356" src="https://github.com/user-attachments/assets/e4f2546e-5641-4058-a8b4-c1a7744673ca" />
<img width="606" height="62" alt="Screenshot 2026-09-07 004345" src="https://github.com/user-attachments/assets/9dd8633a-be55-406a-8af8-34bb8293005f" />
<img width="352" height="163" alt="Screenshot 2026-09-07 004402" src="https://github.com/user-attachments/assets/7879619a-626f-4a36-b5a8-8e83b41806bc" />



</details>

## Changelog Improvements
+ Improved internal name resolving for color pet items. - brettt89
    * Added regex parsing for rarity when resolving pet names.
