### PR TITLE
Fix: Pets not resolving from display names

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/NeuItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NeuItems.kt
@@ -135,9 +135,9 @@ object NeuItems {
             // Every ignored item is named "§cBugged Item", see ItemUtils.getSpecialRepoItemName.
             if (ignoreItemsFilter.match(internalName.asString())) return@forEach
 
-            val cleanName = internalName.getRepoItemNameFromJson(itemInfo)?.lowercase()?.removePrefix(neuPetLevelRegex)?.takeIf {
-                it.isNotEmpty()
-            } ?: run {
+            // Pet repo names carry a " Pet" suffix, which NeuInternalName.fromItemNameOrNull strips before the lookup.
+            val cleanName = internalName.getRepoItemNameFromJson(itemInfo)?.lowercase()?.removePrefix(neuPetLevelRegex)
+                ?.removeSuffix(" pet")?.takeIf { it.isNotEmpty() } ?: run {
                 ChatUtils.debug("skipped `$internalName` from readAllNeuItems")
                 return@forEach
             }


### PR DESCRIPTION
## What
#5971 silently changed the behavior of item resolution: previously, the item name cache keyed pets with names like "Slug", because it took the name from `stack.hoverName`, after stripping the level prefix. In an effort to avoid unnecessarily creating `ItemStack`s, we switched to `internalName.getRepoItemNameFromJson`. However, this method adds a " Pet" suffix to the end of the display name for pets, meaning item resolution failed to match the actual display name (which, after stripping an optional level prefix, is just "Slug" – no "Pet") to the corresponding item. So for example, resolving the item name from a `PET DROP!` chat message failed, and pets stopped getting added to profit trackers.

Tested with (on Garden, holding a vacuum, with Pest Profit Tracker visible):
* 2x `/shtestmessage &6&lPET DROP! &5Slug &e(&e+141.4)`
* 1x `/shtestmessage &6&lPET DROP! &6Slug &e(&e+141.4)`
* 1x actual Epic Slug drop
* 1x actual Legendary Rat drop

Drop detected and resolved to the correct rarity in all cases.

## Changelog Fixes
+ Fixed pet drops from chat messages (e.g. Baby Yeti, Flying Fish, Slug) not being added to Profit Trackers. - Luna