### PR TITLE
Fix: Currency ID check sometimes running before NEU item name cache rebuild

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyblockCurrency.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyblockCurrency.kt
@@ -126,7 +126,7 @@ enum class SkyblockCurrency(
     // the lore only writes "Tokens", the island is what makes it unambiguous
     KUUDRA_TOKEN(
         "KUUDRA_TOKEN".toInternalName(), "Tokens", DARK_PURPLE, loreNames = setOf("token", "tokens"),
-        island = IslandType.KUUDRA_ARENA,
+        island = KUUDRA_ARENA,
         ownedAmount = { getFromStorage() },
     ),
 
@@ -183,7 +183,6 @@ enum class SkyblockCurrency(
 
     @SkyHanniModule
     companion object {
-
         /**
          * REGEX-TEST: 5,000 Bits
          * REGEX-TEST: 40 Pests
@@ -220,8 +219,9 @@ enum class SkyblockCurrency(
          */
         @HandleEvent
         private fun onNeuRepoReload() {
-            // the item name lookup needs NeuItems.allItemsCache, which is filled by another handler of this event
-            DelayedRun.runNextTick {
+            // The item name lookup needs NeuItems.allItemsCache, which another handler of this event rebuilds
+            // on the next tick. Running at the end of that tick puts this check after the rebuild.
+            DelayedRun.runNextTickEnd {
                 val conflicts = entries.mapNotNull { currency ->
                     val id = currency.internalName
                     val resolved = ItemNameResolver.getInternalNameOrNull(currency.displayName)
@@ -233,7 +233,7 @@ enum class SkyblockCurrency(
                         else -> null
                     }
                 }
-                if (conflicts.isEmpty()) return@runNextTick
+                if (conflicts.isEmpty()) return@runNextTickEnd
 
                 ErrorManager.logErrorStateWithData(
                     "A SkyHanni currency uses a wrong id, please report this in discord",


### PR DESCRIPTION
## What
`NeuItems` and `SkyblockCurrency` are both at default priority and both queue a task for the next tick using `DelayedRun.run(Or)NextTick`, making their execution order depend on the order KSP generated the registrations in `LoadedModules.kt` in, which is random but generally stays unchanged within a worktree until the cache is deleted or invalidated. If `SkyblockCurrency` executes before `NeuItems`, it would lead to errors like this:

```
SkyHanni 7.54.0 26.2: A SkyHanni currency uses a wrong id, please report this in discord
 
Caused by java.lang.IllegalStateException: SkyblockCurrency entries do not match the repo item behind their name
    at SH.test.command.ErrorManager.logErrorStateWithData(ErrorManager.kt:195)
    at SH.test.command.ErrorManager.logErrorStateWithData$default(ErrorManager.kt:182)
    at SH.utils.SkyblockCurrency$Companion.onNeuRepoReload$lambda$0(SkyblockCurrency.kt:238)
    at SH.utils.DelayedRun.withErrorHandling$lambda$0$0(DelayedRun.kt:95)
    at SH.utils.DelayedRun.runWithErrorHandling(DelayedRun.kt:79)
    at SH.utils.DelayedRun.withErrorHandling$lambda$0(DelayedRun.kt:95)
    at MC.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:173)
    at MC.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:23)
    at MC.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:147)
    at MC.util.thread.BlockableEventLoop.runAllTasks(BlockableEventLoop.java:127)
    at MC.client.Minecraft.runTick(Minecraft.java:1235)
    at MC.client.Minecraft.run(Minecraft.java:959)
    at MC.client.main.Main.main(Main.java:292)
    at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:514)
    at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:72)
    at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23)
    at org.prismlauncher.launcher.impl.StandardLauncher.launch(StandardLauncher.java:115)
    at org.prismlauncher.EntryPoint.listen(EntryPoint.java:129)
    at org.prismlauncher.EntryPoint.main(EntryPoint.java:70)

Extra data:
conflicts: 
 - 'GOLD_MEDAL uses SKYBLOCK_GOLD_MEDAL, which is a different repo item'
 - 'SILVER_MEDAL uses SKYBLOCK_SILVER_MEDAL, which is a different repo item'
 - 'BRONZE_MEDAL uses SKYBLOCK_BRONZE_MEDAL, which is a different repo item'
```

Making it use `runNextTickEnd` ensures it's queued after the cache rebuild and stops this error from occurring.

## Changelog Fixes
+ Fixed the "A SkyHanni currency uses a wrong id" error sometimes appearing when joining Hypixel. - Luna