### PR TITLE
Improvement: Add option to defer the contributor achievement

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/ContributorsJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/ContributorsJson.kt
@@ -13,6 +13,6 @@ data class ContributorJsonEntry(
     @Expose @SerializedName(value = "component_suffix", alternate = ["componentSuffix"]) val componentSuffix: Component? = null,
     @Expose val spinny: Boolean = false,
     @Expose @SerializedName(value = "upside_down", alternate = ["upsideDown"]) val upsideDown: Boolean = false,
-    @Expose @SerializedName(value = "defer_achievement", alternate = ["deferAchievement"]) val deferAchievement: Boolean = false,
+    @Expose @SerializedName(value = "defer_achievement") val deferAchievement: Boolean = false,
     @Expose @SerializedName("display_name") val displayName: String? = null,
 )

--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/ContributorsJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/ContributorsJson.kt
@@ -13,5 +13,6 @@ data class ContributorJsonEntry(
     @Expose @SerializedName(value = "component_suffix", alternate = ["componentSuffix"]) val componentSuffix: Component? = null,
     @Expose val spinny: Boolean = false,
     @Expose @SerializedName(value = "upside_down", alternate = ["upsideDown"]) val upsideDown: Boolean = false,
+    @Expose @SerializedName(value = "defer_achievement", alternate = ["deferAchievement"]) val deferAchievement: Boolean = false,
     @Expose @SerializedName("display_name") val displayName: String? = null,
 )

--- a/src/main/java/at/hannibal2/skyhanni/features/achievements/ContributorAchievement.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/achievements/ContributorAchievement.kt
@@ -8,6 +8,7 @@ import at.hannibal2.skyhanni.events.FriendAddEvent
 import at.hannibal2.skyhanni.events.FriendRequestDeclinedEvent
 import at.hannibal2.skyhanni.events.FriendRequestExpiredEvent
 import at.hannibal2.skyhanni.events.achievements.AchievementRegistrationEvent
+import at.hannibal2.skyhanni.events.minecraft.WorldChangeEvent
 import at.hannibal2.skyhanni.features.misc.ContributorManager
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
@@ -31,6 +32,8 @@ object ContributorAchievement {
     private const val CONTRIBUTOR_FAMOUS_ACHIEVEMENT = "Contrib Famous"
 
     const val CONTRIBUTOR_ACHIEVEMENT_GOT = "Achievement Get! EEEEKK!!"
+
+    private var contributorQueue = mutableListOf<GameProfile>()
 
     @HandleEvent
     private fun onAchievementRegistration(event: AchievementRegistrationEvent) {
@@ -130,7 +133,23 @@ object ContributorAchievement {
         }
     }
 
+    @HandleEvent
+    private fun onWorldChange(event: WorldChangeEvent) {
+        for (contributor in contributorQueue) {
+            grantAchievement(contributor)
+        }
+        contributorQueue.clear()
+    }
+
     fun onUniqueContributorSeen(profile: GameProfile) {
+        if (ContributorManager.shouldDeferAchievement(profile.id)) {
+            contributorQueue.add(profile)
+        } else {
+            grantAchievement(profile)
+        }
+    }
+
+    private fun grantAchievement(profile: GameProfile) {
         val completed = AchievementManager.completeAchievement(CONTRIBUTOR_ACHIEVEMENT)
         if (showContributorAchievement(profile, completed)) return
         showContributorDiscovered(profile)
@@ -160,6 +179,11 @@ object ContributorAchievement {
             append(player)
             appendWithColor(" ${profile.name}", ChatFormatting.AQUA)
             appendWithColor(" for the first time!", ChatFormatting.GRAY)
+            if (ContributorManager.shouldDeferAchievement(profile.id)) {
+                append("\n")
+                appendWithColor("However, they wanted to avoid the attention,\n", ChatFormatting.GRAY)
+                appendWithColor("so you have been notified with a delay.", ChatFormatting.GRAY)
+            }
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/achievements/ContributorAchievement.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/achievements/ContributorAchievement.kt
@@ -33,7 +33,7 @@ object ContributorAchievement {
 
     const val CONTRIBUTOR_ACHIEVEMENT_GOT = "Achievement Get! EEEEKK!!"
 
-    private var contributorQueue = mutableListOf<GameProfile>()
+    private val contributorQueue = mutableListOf<GameProfile>()
 
     @HandleEvent
     private fun onAchievementRegistration(event: AchievementRegistrationEvent) {
@@ -134,7 +134,7 @@ object ContributorAchievement {
     }
 
     @HandleEvent
-    private fun onWorldChange(event: WorldChangeEvent) {
+    private fun onWorldChange() {
         for (contributor in contributorQueue) {
             grantAchievement(contributor)
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ContributorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ContributorManager.kt
@@ -139,11 +139,11 @@ object ContributorManager {
                     ) { playerRef ->
                         callback {
                             val gameProfile = getArg(playerRef).gameProfile
-                            addTestContributor(gameProfile.id, gameProfile.name, null, true)
+                            addTestContributor(gameProfile.id, gameProfile.name, null)
                         }
                         argCallback("suffix", ComponentArgumentType.component(allowPlainText = true)) { suffix ->
                             val gameProfile = getArg(playerRef).gameProfile
-                            addTestContributor(gameProfile.id, gameProfile.name, suffix, true)
+                            addTestContributor(gameProfile.id, gameProfile.name, suffix)
                         }
                     }
                 }
@@ -154,14 +154,14 @@ object ContributorManager {
                                 addTestContributor(
                                     getArg(uuidRef),
                                     getArg(displayNameRef),
-                                    null, true
+                                    null,
                                 )
                             }
                             argCallback("suffix", ComponentArgumentType.component(allowPlainText = true)) { suffix ->
                                 addTestContributor(
                                     getArg(uuidRef),
                                     getArg(displayNameRef),
-                                    suffix, true
+                                    suffix,
                                 )
                             }
                         }
@@ -186,13 +186,12 @@ object ContributorManager {
         }
     }
 
-    private fun addTestContributor(uuid: UUID, displayName: String, suffix: Component?, deferAchievement: Boolean) {
+    private fun addTestContributor(uuid: UUID, displayName: String, suffix: Component?) {
         val alreadyExists = contributors.containsKey(uuid)
 
         val testEntry = ContributorJsonEntry(
             displayName = displayName,
             componentSuffix = suffix,
-            deferAchievement = deferAchievement,
         )
         contributors = contributors + (uuid to testEntry)
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ContributorManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ContributorManager.kt
@@ -139,11 +139,11 @@ object ContributorManager {
                     ) { playerRef ->
                         callback {
                             val gameProfile = getArg(playerRef).gameProfile
-                            addTestContributor(gameProfile.id, gameProfile.name, null)
+                            addTestContributor(gameProfile.id, gameProfile.name, null, true)
                         }
                         argCallback("suffix", ComponentArgumentType.component(allowPlainText = true)) { suffix ->
                             val gameProfile = getArg(playerRef).gameProfile
-                            addTestContributor(gameProfile.id, gameProfile.name, suffix)
+                            addTestContributor(gameProfile.id, gameProfile.name, suffix, true)
                         }
                     }
                 }
@@ -154,14 +154,14 @@ object ContributorManager {
                                 addTestContributor(
                                     getArg(uuidRef),
                                     getArg(displayNameRef),
-                                    null,
+                                    null, true
                                 )
                             }
                             argCallback("suffix", ComponentArgumentType.component(allowPlainText = true)) { suffix ->
                                 addTestContributor(
                                     getArg(uuidRef),
                                     getArg(displayNameRef),
-                                    suffix,
+                                    suffix, true
                                 )
                             }
                         }
@@ -186,12 +186,13 @@ object ContributorManager {
         }
     }
 
-    private fun addTestContributor(uuid: UUID, displayName: String, suffix: Component?) {
+    private fun addTestContributor(uuid: UUID, displayName: String, suffix: Component?, deferAchievement: Boolean) {
         val alreadyExists = contributors.containsKey(uuid)
 
         val testEntry = ContributorJsonEntry(
             displayName = displayName,
             componentSuffix = suffix,
+            deferAchievement = deferAchievement,
         )
         contributors = contributors + (uuid to testEntry)
 
@@ -352,6 +353,7 @@ object ContributorManager {
 
     fun shouldSpin(uuid: UUID): Boolean = contributors[uuid]?.spinny ?: false
     fun shouldBeUpsideDown(uuid: UUID): Boolean = contributors[uuid]?.upsideDown ?: false
+    fun shouldDeferAchievement(uuid: UUID): Boolean = contributors[uuid]?.deferAchievement ?: false
 
     fun isSelfContributor(): Boolean {
         isContributor?.let { return it }


### PR DESCRIPTION
## What
Contributors who add their name to ContributorList.json could choose to make it so SkyHanni users only get notified of their presence after they leave the lobby, in order to minimize unwanted attention.

## Changelog Improvements
+ Add option to defer the contributor notification per contributor

## Changelog Technical Details
+ Add optional `deferAchievement` field for each contributor in ContributorList.json in the SkyHanni repo
