### PR TITLE
Fix: Navigation stop messages and stale Path Finder highlight

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/IslandGraphs.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/IslandGraphs.kt
@@ -136,7 +136,10 @@ object IslandGraphs {
     private var lastCacheUpdate = SimpleTimeMark.farPast()
 
     private var currentTarget: LorenzVec? = null
-    private var currentTargetNode: GraphNode? = null
+
+    var currentTargetNode: GraphNode? = null
+        private set
+
     private var navigationLabel = ""
     private var lastDisplayedDistance = 0.0
     private var totalDistance = 0.0
@@ -189,7 +192,9 @@ object IslandGraphs {
     @HandleEvent
     private fun onWorldChange() {
         currentIslandGraph = null
-        if (currentTarget != null) NavigationFeedback.sendPathFindMessage("§e[SkyHanni] Navigation stopped because of world switch!")
+        if (currentTarget != null) {
+            NavigationFeedback.sendPathFindMessage("§e[SkyHanni] Navigation stopped because of world switch!", force = true)
+        }
         resetNavigation()
     }
 
@@ -346,11 +351,13 @@ object IslandGraphs {
         GraphUtils.updatePlayerPosition()
         currentTarget?.let {
             if (distanceSqToPlayer(it) < TARGET_REACHED_DISTANCE_SQ) {
-                NavigationFeedback.sendPathFindMessage("§e[SkyHanni] Navigation reached §r$navigationLabel§e!")
+                NavigationFeedback.sendPathFindMessage("§e[SkyHanni] Navigation reached §r$navigationLabel§e!", force = true)
                 resetNavigation()
                 onFound()
+                return@let
             }
             if (!activeCondition()) {
+                NavigationFeedback.sendPathFindMessage("§e[SkyHanni] Navigation stopped!", force = true)
                 resetNavigation()
             }
         }
@@ -454,11 +461,12 @@ object IslandGraphs {
         }
     }
 
+    /**
+     * Resets the navigation state silently. Aborting an active navigation and telling the player about it
+     * is up to the caller.
+     */
     fun stopNavigation() {
-        if (currentTarget != null) {
-            NavigationFeedback.sendPathFindMessage("§e[SkyHanni] Navigation stopped!")
-            currentTarget = null
-        }
+        currentTarget = null
         goal = null
         pathRenderer = null
         currentTargetNode = null
@@ -469,14 +477,17 @@ object IslandGraphs {
     }
 
     fun manualCancel() {
-        if (currentTarget == null) {
+        val hadOwnTarget = currentTarget != null
+        if (!hadOwnTarget && !NavigateAllApi.currentlyNavigating) {
             ChatUtils.userError("No navigation is currently active.")
             return
         }
 
+        // sent before stopNavigation(), which marks the feedback as inactive
+        NavigationFeedback.sendPathFindMessage("§e[SkyHanni] Navigation stopped!", force = true)
         stopNavigation()
-        NavigateAllApi.handleStop(errorMessage = false)
-        onManualCancel()
+        NavigateAllApi.handleStop()
+        if (hadOwnTarget) onManualCancel()
     }
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/IslandAreaBackend.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/IslandAreaBackend.kt
@@ -67,12 +67,16 @@ object IslandAreaBackend {
     }
 
     private var hasMoved = false
+    private var lastDrawnTarget: GraphNode? = null
 
     @HandleEvent
     fun onTick(event: SkyHanniTickEvent) {
-        if (!isEnabled() || !event.isMod(2) || !hasMoved) return
-        update()
+        if (!isEnabled() || !event.isMod(2)) return
+        val target = IslandGraphs.currentTargetNode
+        if (!hasMoved && target == lastDrawnTarget) return
+        lastDrawnTarget = target
         hasMoved = false
+        update()
     }
 
     @HandleEvent(onlyOnSkyblock = true)

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/IslandAreaFeatures.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/IslandAreaFeatures.kt
@@ -42,7 +42,6 @@ object IslandAreaFeatures {
 
     var display: Renderable? = null
     private var smallAreas = setOf<String>()
-    private var targetNode: GraphNode? = null
     private val textInput = SearchTextInput()
     private val areaNodes get() = IslandAreaBackend.areaNodes
     private var visibleAreaNodes = listOf<AreaNode>()
@@ -50,17 +49,13 @@ object IslandAreaFeatures {
     private var lastTitleTime = SimpleTimeMark.farPast()
 
     private fun setTarget(node: GraphNode) {
-        targetNode = node
         val tag = node.getAreaTag() ?: return
         val displayName = tag.color.getChatColor() + node.name
         val color = areaListConfig.color.get().toColor()
         node.pathFind(
             displayName,
             color,
-            onFound = {
-                targetNode = null
-                IslandAreaBackend.update()
-            },
+            onFound = { IslandAreaBackend.update() },
             allowRerouting = true,
             condition = ::isAreaListEnabled,
         )
@@ -135,7 +130,7 @@ object IslandAreaFeatures {
     fun onConfigLoad() {
         with(areaListConfig) {
             ConditionalUtils.onToggle(color) {
-                targetNode?.let { setTarget(it) }
+                IslandGraphs.currentTargetNode?.let { setTarget(it) }
             }
         }
     }
@@ -143,7 +138,6 @@ object IslandAreaFeatures {
     @HandleEvent
     fun onWorldChange() {
         display = null
-        targetNode = null
         currentTitle?.stop()
     }
 
@@ -193,15 +187,16 @@ object IslandAreaFeatures {
 
         addSearchString("§eAreas nearby:")
         for (area in visibleNearby) {
-            // Compare by name as multiple nodes can share names
-            val isTarget = area.name == targetNode?.name
-            val color = if (isTarget) LorenzColor.GOLD else area.tag.color
+            val color = if (area.isNavigationTarget()) LorenzColor.GOLD else area.tag.color
             val coloredName = "${color.getChatColor()}${area.name}"
             val distance = area.distance.roundTo(0).toInt()
 
             add(buildAreaEntry(coloredName, area, distance))
         }
     }
+
+    // Compared by name, not identity: rerouting can move the target to another node with the same name
+    private fun AreaNode.isNavigationTarget(): Boolean = name == IslandGraphs.currentTargetNode?.name
 
     private fun buildAreaEntry(displayText: String, area: AreaNode, distance: Int): Searchable = Renderable.clickable(
         "$displayText§7: §e$distance",
@@ -210,7 +205,7 @@ object IslandAreaFeatures {
             add("§7Type: ${area.tag.displayName}")
             add("§7Distance: §e$distance blocks")
             add("")
-            if (area.node == targetNode) {
+            if (area.isNavigationTarget()) {
                 add("§aPath Finder points to this!")
                 add("")
                 add("§eClick to stop navigating!")
@@ -219,9 +214,8 @@ object IslandAreaFeatures {
             }
         },
         onLeftClick = {
-            if (area.node == targetNode) {
-                targetNode = null
-                IslandGraphs.stopNavigation()
+            if (area.isNavigationTarget()) {
+                IslandGraphs.manualCancel()
                 IslandAreaBackend.update()
             } else {
                 setTarget(area.node)

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigateAllApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigateAllApi.kt
@@ -31,7 +31,8 @@ import kotlin.time.Duration.Companion.seconds
  * Drives a navigation over a list of nodes, one after the other.
  *
  * Holds the state of the single navigation that can run at a time. Features start one via `navigateAll` and
- * add their own command entry points that delegate to `handleSkip`, `handleStop` and `handleUndo`.
+ * add their own command entry points that delegate to `handleSkip`, `handleUndo` and, for stopping,
+ * `IslandGraphs.manualCancel`.
  *
  * The route stays untouched once it is calculated, the position inside it is tracked by an index. Skipping and
  * going back therefore only move that index, and a skipped node can be returned to.
@@ -48,7 +49,7 @@ object NavigateAllApi {
 
     private val defaultTargetLocation: (GraphNode) -> LorenzVec = { it.position }
 
-    private val currentlyNavigating get() = currentTargetName != null
+    val currentlyNavigating get() = currentTargetName != null
     private val currentTarget get() = route.getOrNull(currentIndex)
 
     private var navigationId = 0
@@ -178,20 +179,10 @@ object NavigateAllApi {
         navigateToCurrent()
     }
 
-    fun handleStop(manual: Boolean = false, errorMessage: Boolean = true) {
-        if (!currentlyNavigating) {
-            if (errorMessage) {
-                ChatUtils.userError("No current navigation to stop. §eUse /shnavigateall to start navigation")
-            }
-            return
-        }
-
-        if (manual) {
-            ChatUtils.userError("Manually stopped navigation")
-        }
+    fun handleStop() {
+        if (!currentlyNavigating) return
 
         resetState()
-
         IslandGraphs.stopNavigation()
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigateAllCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigateAllCommand.kt
@@ -78,7 +78,7 @@ object NavigateAllCommand {
                 NavigateAllApi.handleSkip()
             }
             literalCallback("stop") {
-                NavigateAllApi.handleStop(manual = true)
+                IslandGraphs.manualCancel()
             }
             literalCallback("undo") {
                 NavigateAllApi.handleUndo()

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigateClipboardCommand.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigateClipboardCommand.kt
@@ -145,7 +145,7 @@ object NavigateClipboardCommand {
                 NavigateAllApi.handleSkip()
             }
             literalCallback("stop") {
-                NavigateAllApi.handleStop(manual = true)
+                IslandGraphs.manualCancel()
             }
             literalCallback("undo") {
                 NavigateAllApi.handleUndo()

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigationFeedback.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/pathfind/NavigationFeedback.kt
@@ -42,20 +42,25 @@ object NavigationFeedback {
         navActive = false
     }
 
-    fun sendPathFindMessage(message: String) = sendPathFindMessage(message.asComponent())
-    fun sendPathFindMessage(component: Component): Boolean {
+    fun sendPathFindMessage(message: String, force: Boolean = false) = sendPathFindMessage(message.asComponent(), force)
+
+    /**
+     * @param force Skips the chat update interval. Set for messages that report the end of a navigation,
+     *  since those are shown once and would otherwise be dropped right after a progress update.
+     */
+    fun sendPathFindMessage(component: Component, force: Boolean = false): Boolean {
         navActive = true
         navLastActive = SimpleTimeMark.now()
         return when (config.feedbackMode.get()) {
             PathfindConfig.FeedbackMode.NONE -> false
-            PathfindConfig.FeedbackMode.CHAT -> sendChatFeedback(component)
+            PathfindConfig.FeedbackMode.CHAT -> sendChatFeedback(component, force)
             PathfindConfig.FeedbackMode.GUI -> sendGuiFeedback(component)
             else -> false
         }
     }
 
-    private fun sendChatFeedback(component: Component): Boolean {
-        if (lastChatMessageSent.passedSince() < config.chatUpdateInterval.duration) return false
+    private fun sendChatFeedback(component: Component, force: Boolean): Boolean {
+        if (!force && lastChatMessageSent.passedSince() < config.chatUpdateInterval.duration) return false
         component.send(pathFindMessageId)
         lastChatMessageSent = SimpleTimeMark.now()
         return true


### PR DESCRIPTION
## What
The stop message was sent from `IslandGraphs.stopNavigation()`, which is also the shared cleanup path for arriving at a target and switching targets, so it fired when nothing was aborted and never fired when only a `/shnavall` route was waiting. It is silent now, every caller that actually aborts sends its own message, and `IslandAreaFeatures` reads `IslandGraphs.currentTargetNode` instead of keeping its own copy of the target.

## Changelog Fixes
+ Fixed multiple small Path Finder issues. - hannibal2
    * Wrong and missing messages when stopping, arriving at or switching targets, and the Island Areas list keeping a location highlighted after the navigation to it ended.