### PR TITLE
Backend: Detect item names that cannot be resolved back to an internal name

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/NeuItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NeuItems.kt
@@ -125,6 +125,7 @@ object NeuItems {
         val tempAllItemCache = mutableMapOf<String, NeuInternalName>()
         val tempNoColor = TreeMap<String, NeuInternalName>()
         val duplicates = mutableMapOf<String, MutableList<NeuInternalName>>()
+        val nonPetsWithPetSuffix = mutableListOf<NeuInternalName>()
 
         allNeuRepoItems().forEach { (internalName, itemInfo) ->
             allInternalNames[internalName.asString()] = internalName
@@ -135,12 +136,17 @@ object NeuItems {
             // Every ignored item is named "§cBugged Item", see ItemUtils.getSpecialRepoItemName.
             if (ignoreItemsFilter.match(internalName.asString())) return@forEach
 
-            // Pet repo names carry a " Pet" suffix, which NeuInternalName.fromItemNameOrNull strips before the lookup.
+            // The " Pet" suffix is added by ItemUtils.getSpecialRepoItemName, and
+            // NeuInternalName.fromItemNameOrNull strips it from every query before the lookup.
+            // Stripping it from a non-pet would cache that item under a key no query can reach.
+            val isKnownPet = PetUtils.isKnownPetInternalName(internalName)
             val cleanName = internalName.getRepoItemNameFromJson(itemInfo)?.lowercase()?.removePrefix(neuPetLevelRegex)
-                ?.removeSuffix(" pet")?.takeIf { it.isNotEmpty() } ?: run {
+                ?.let { if (isKnownPet) it.removeSuffix(" pet") else it }?.takeIf { it.isNotEmpty() } ?: run {
                 ChatUtils.debug("skipped `$internalName` from readAllNeuItems")
                 return@forEach
             }
+
+            if (!isKnownPet && cleanName.endsWith(" pet")) nonPetsWithPetSuffix.add(internalName)
 
             if (cleanName.contains("[lvl 1➡100]")) {
                 if (PlatformUtils.isDevEnvironment) error("wrong name: '$cleanName'")
@@ -163,6 +169,7 @@ object NeuItems {
         NeuInternalName.clearItemNameCache()
         ChatUtils.debug("Cleared the NEUItems stack resolution cache")
         reportDuplicateDisplayNames(duplicates)
+        reportNonPetsWithPetSuffix(nonPetsWithPetSuffix)
     }
 
     /**
@@ -176,6 +183,21 @@ object NeuItems {
             val all = internalNames.joinToString(", ") { it.asString() }
             println("duplicate item display name '$displayName': $all")
         }
+    }
+
+    /**
+     * Only known pets are expected to end in " Pet", ItemUtils.getSpecialRepoItemName adds the suffix there.
+     * Any other item named this way cannot be resolved through NeuInternalName.fromItemNameOrNull,
+     * since that strips the suffix from every query.
+     */
+    private fun reportNonPetsWithPetSuffix(nonPetsWithPetSuffix: List<NeuInternalName>) {
+        if (nonPetsWithPetSuffix.isEmpty()) return
+        ErrorManager.logErrorStateWithData(
+            "Found non-pet items ending in ' Pet', please report this in discord",
+            "Non-pet items ending in ' Pet' cannot be resolved via NeuInternalName.fromItemNameOrNull",
+            "internal names" to nonPetsWithPetSuffix.sorted().map { it.asString() },
+            betaOnly = true,
+        )
     }
 
     fun getInternalName(itemStack: SafeItemStack): NeuInternalName? = ItemResolutionQuery()

--- a/src/main/java/at/hannibal2/skyhanni/utils/NeuItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NeuItems.kt
@@ -18,6 +18,7 @@ import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NeuItems.allItemsCache
 import at.hannibal2.skyhanni.utils.NeuItems.ambiguousDisplayNames
 import at.hannibal2.skyhanni.utils.PrimitiveItemStack.Companion.makePrimitiveStack
+import at.hannibal2.skyhanni.utils.RegexUtils.find
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.SkyBlockItemModifierUtils.isVanillaItem
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
@@ -28,7 +29,6 @@ import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
 import at.hannibal2.skyhanni.utils.compat.getVanillaItem
 import at.hannibal2.skyhanni.utils.json.fromJsonOrNull
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
-import at.hannibal2.skyhanni.utils.system.PlatformUtils
 import com.google.gson.JsonPrimitive
 import net.minecraft.world.item.Item
 import net.minecraft.world.item.Items
@@ -65,9 +65,21 @@ object NeuItems {
      * WRAPPED-REGEX-TEST: "§f§f§7[lvl 1➡100] "
      * WRAPPED-REGEX-TEST: "§f§f§7[Lvl {LVL}] "
      */
-    private val neuPetLevelRegex by patternGroup.pattern(
+    private val neuPetLevelPattern by patternGroup.pattern(
         "pet-level",
         "(?i)(?:§.)+\\[lvl (?:\\d+➡\\d+|\\{lvl})\\] ",
+    )
+
+    /**
+     * Deliberately looser than [neuPetLevelPattern]: a marker that is still in the name is one
+     * that pattern did not match at the start of the name.
+     * REGEX-TEST: [lvl 1➡100]
+     * REGEX-TEST: [Lvl 1➡200]
+     * REGEX-TEST: [lvl {lvl}]
+     */
+    private val leftoverPetLevelPattern by patternGroup.pattern(
+        "pet-level-leftover",
+        "(?i)\\[lvl (?:\\d+➡\\d+|\\{lvl})\\]",
     )
 
     /** Keys are internal names as String */
@@ -141,7 +153,7 @@ object NeuItems {
             // NeuInternalName.fromItemNameOrNull strips it from every query before the lookup.
             // Stripping it from a non-pet would cache that item under a key no query can reach.
             val isKnownPet = PetUtils.isKnownPetInternalName(internalName)
-            val cleanName = internalName.getRepoItemNameFromJson(itemInfo)?.lowercase()?.removePrefix(neuPetLevelRegex)
+            val cleanName = internalName.getRepoItemNameFromJson(itemInfo)?.lowercase()?.removePrefix(neuPetLevelPattern)
                 ?.let { if (isKnownPet) it.removeSuffix(" pet") else it }?.takeIf { it.isNotEmpty() } ?: run {
                 ChatUtils.debug("skipped `$internalName` from readAllNeuItems")
                 return@forEach
@@ -149,7 +161,7 @@ object NeuItems {
 
             if (!isKnownPet && cleanName.endsWith(" pet")) nonPetsWithPetSuffix.add(internalName)
 
-            if (cleanName.contains("[lvl 1➡100]")) leftoverLevelNames.add("${internalName.asString()}: '$cleanName'")
+            if (leftoverPetLevelPattern.find(cleanName)) leftoverLevelNames.add("${internalName.asString()}: '$cleanName'")
 
             val newCleanName = normalizeDisplayName(cleanName)
             if (newCleanName in ambiguousDisplayNames) return@forEach
@@ -200,7 +212,8 @@ object NeuItems {
     }
 
     /**
-     * A name that still contains the "[lvl 1➡100]" marker slipped past [neuPetLevelRegex].
+     * A pet level marker [neuPetLevelPattern] did not strip, either because it does not match
+     * or because the marker does not sit at the start of the name.
      * [normalizeDisplayName] then drops the non-ASCII arrow, and the lookup side never applies
      * that normalization to a query, so the item is cached under a key nothing can ask for.
      */
@@ -208,7 +221,7 @@ object NeuItems {
         if (leftoverLevelNames.isEmpty()) return
         ErrorManager.logErrorStateWithData(
             "Found item names with a leftover pet level marker, please report this in discord",
-            "Item names still contain '[lvl 1➡100]', which neuPetLevelRegex should have removed",
+            "Item names still contain a pet level marker that neuPetLevelPattern did not strip",
             "names" to leftoverLevelNames.sorted(),
             betaOnly = true,
         )

--- a/src/main/java/at/hannibal2/skyhanni/utils/NeuItems.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NeuItems.kt
@@ -126,6 +126,7 @@ object NeuItems {
         val tempNoColor = TreeMap<String, NeuInternalName>()
         val duplicates = mutableMapOf<String, MutableList<NeuInternalName>>()
         val nonPetsWithPetSuffix = mutableListOf<NeuInternalName>()
+        val leftoverLevelNames = mutableListOf<String>()
 
         allNeuRepoItems().forEach { (internalName, itemInfo) ->
             allInternalNames[internalName.asString()] = internalName
@@ -148,10 +149,7 @@ object NeuItems {
 
             if (!isKnownPet && cleanName.endsWith(" pet")) nonPetsWithPetSuffix.add(internalName)
 
-            if (cleanName.contains("[lvl 1➡100]")) {
-                if (PlatformUtils.isDevEnvironment) error("wrong name: '$cleanName'")
-                else println("wrong name: '$cleanName'")
-            }
+            if (cleanName.contains("[lvl 1➡100]")) leftoverLevelNames.add("${internalName.asString()}: '$cleanName'")
 
             val newCleanName = normalizeDisplayName(cleanName)
             if (newCleanName in ambiguousDisplayNames) return@forEach
@@ -170,6 +168,7 @@ object NeuItems {
         ChatUtils.debug("Cleared the NEUItems stack resolution cache")
         reportDuplicateDisplayNames(duplicates)
         reportNonPetsWithPetSuffix(nonPetsWithPetSuffix)
+        reportLeftoverLevelNames(leftoverLevelNames)
     }
 
     /**
@@ -196,6 +195,21 @@ object NeuItems {
             "Found non-pet items ending in ' Pet', please report this in discord",
             "Non-pet items ending in ' Pet' cannot be resolved via NeuInternalName.fromItemNameOrNull",
             "internal names" to nonPetsWithPetSuffix.sorted().map { it.asString() },
+            betaOnly = true,
+        )
+    }
+
+    /**
+     * A name that still contains the "[lvl 1➡100]" marker slipped past [neuPetLevelRegex].
+     * [normalizeDisplayName] then drops the non-ASCII arrow, and the lookup side never applies
+     * that normalization to a query, so the item is cached under a key nothing can ask for.
+     */
+    private fun reportLeftoverLevelNames(leftoverLevelNames: List<String>) {
+        if (leftoverLevelNames.isEmpty()) return
+        ErrorManager.logErrorStateWithData(
+            "Found item names with a leftover pet level marker, please report this in discord",
+            "Item names still contain '[lvl 1➡100]', which neuPetLevelRegex should have removed",
+            "names" to leftoverLevelNames.sorted(),
             betaOnly = true,
         )
     }


### PR DESCRIPTION
## What

`readAllNeuItems` strips a " Pet" suffix and a pet level marker from display names before caching
them, and both steps can store an item under a key that no lookup can reach. Those cases are now
collected during the rebuild and reported once through `ErrorManager` in beta builds. A run against
the current NEU repo stays silent, while forcing the pet check to fail reported all 313 pets.

## Changelog Technical Details
+ Added detection for item names that end up in the item name cache under a key no lookup can reach. - hannibal2