### PR TITLE
Feature: Season Locked Messages

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/EventConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/EventConfig.kt
@@ -38,6 +38,11 @@ class EventConfig {
     @Category(name = "Hoppity Eggs", desc = "Features for the Hoppity event that happens every SkyBlock spring.")
     val hoppityEggs: HoppityEggsConfig = HoppityEggsConfig()
 
+    @ConfigOption(name = "Event Timings", desc = "")
+    @Accordion
+    @Expose
+    val timing: EventTimingConfig = EventTimingConfig()
+
     @ConfigOption(name = "City Project", desc = "")
     @Accordion
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/config/features/event/EventTimingConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/event/EventTimingConfig.kt
@@ -1,0 +1,19 @@
+package at.hannibal2.skyhanni.config.features.event
+
+import at.hannibal2.skyhanni.config.FeatureToggle
+import com.google.gson.annotations.Expose
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption
+
+class EventTimingConfig {
+
+    @Expose
+    @ConfigOption(
+        name = "Season Locked Messages",
+        desc = "When Hypixel says that something is only available during a specific season, " +
+            "show how long it takes until that season starts.",
+    )
+    @ConfigEditorBoolean
+    @FeatureToggle
+    var seasonLockedMessages: Boolean = true
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/event/timing/SeasonLockedChat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/timing/SeasonLockedChat.kt
@@ -34,7 +34,7 @@ object SeasonLockedChat {
             if (month == 0) return
             val start = nextStartOfMonth(month)
             // delayed so the line ends up below the message that triggered it
-            DelayedRun.runNextTickEnd {
+            DelayedRun.runNextTick {
                 ChatUtils.chat("§e$name §7opens in §b${start.formatTimeUntilWithDate()}")
             }
         }

--- a/src/main/java/at/hannibal2/skyhanni/features/event/timing/SeasonLockedChat.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/timing/SeasonLockedChat.kt
@@ -1,0 +1,49 @@
+package at.hannibal2.skyhanni.features.event.timing
+
+import at.hannibal2.skyhanni.SkyHanniMod
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.DelayedRun
+import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.SkyBlockTime
+import at.hannibal2.skyhanni.utils.TimeUtils.formatTimeUntilWithDate
+import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+
+@SkyHanniModule
+object SeasonLockedChat {
+
+    private val config get() = SkyHanniMod.feature.event.timing
+
+    /**
+     * REGEX-TEST: Jerry's Workshop is only available during the season of Late Winter!
+     */
+    private val seasonLockedPattern by RepoPattern.pattern(
+        "event.timing.season.locked",
+        "^(?<name>.+) is only available during the season of (?<season>.+)!$",
+    )
+
+    @HandleEvent(onlyOnSkyblock = true)
+    private fun onChat(event: SkyHanniChatEvent.Allow) {
+        if (!config.seasonLockedMessages) return
+        seasonLockedPattern.matchMatcher(event.cleanMessage) {
+            val name = group("name")
+            val month = SkyBlockTime.getSBMonthByName(group("season"))
+            if (month == 0) return
+            val start = nextStartOfMonth(month)
+            // delayed so the line ends up below the message that triggered it
+            DelayedRun.runNextTickEnd {
+                ChatUtils.chat("§e$name §7opens in §b${start.formatTimeUntilWithDate()}")
+            }
+        }
+    }
+
+    private fun nextStartOfMonth(month: Int): SimpleTimeMark {
+        val now = SkyBlockTime.now()
+        // the start of the current month has already passed, so that month is only due again next year
+        val year = if (month > now.month) now.year else now.year + 1
+        return SkyBlockTime(year = year, month = month).toTimeMark()
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/utils/TimeUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/TimeUtils.kt
@@ -33,6 +33,8 @@ import kotlin.time.DurationUnit
 object TimeUtils {
     private val patternGroup = RepoPattern.group("timeutils")
 
+    private const val TIME_UNTIL_DATE_FORMAT = "dd MMM, hh:mm a"
+
     val isAprilFoolsDay: Boolean by RecalculatingValue(1.seconds) {
         val itsTime = LocalDate.now().let { it.month == Month.APRIL && it.dayOfMonth == 1 }
         val (always, never) = SkyHanniMod.feature.dev.debug.let { it.alwaysFunnyTime to it.neverFunnyTime }
@@ -206,6 +208,13 @@ object TimeUtils {
             },
         ).formattedTextCompat()
     }
+
+    /**
+     * Formats how long it takes until [this], plus the real life date, e.g. `4d 3h (14 Jan, 09:32 PM)`.
+     * The time part follows the 24-hour setting in the config.
+     */
+    fun SimpleTimeMark.formatTimeUntilWithDate(): String =
+        "${timeUntil().format(maxUnits = 2)} (${formattedDate(TIME_UNTIL_DATE_FORMAT)})"
 
     fun getCurrentLocalDate(): LocalDate = LocalDate.now(ZoneId.of("UTC"))
 


### PR DESCRIPTION
## What
Made it generic, hopefully it will be used outside of jerry workshop anytime. future proof.

<details>
<summary>Images</summary>

<img width="661" height="71" alt="image" src="https://github.com/user-attachments/assets/cc43b3bf-9918-4bd5-8ff4-b0fc444f6abb" />


</details>


## Changelog New Features
+ Added Season-Locked Messages. - hannibal2
    * When trying to enter Jerry's Workshop outside of Late Winter, the remaining time and the date until it opens are now shown in chat.