### PR TITLE
Improvement + Fix: Support the Grand Bakery and fix currency plurals in NPC Trade Helper

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/CurrencyApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/CurrencyApi.kt
@@ -7,6 +7,7 @@ import at.hannibal2.skyhanni.events.InventoryFullyOpenedEvent
 import at.hannibal2.skyhanni.events.InventoryUpdatedEvent
 import at.hannibal2.skyhanni.events.ScoreboardUpdateEvent
 import at.hannibal2.skyhanni.events.WidgetUpdateEvent
+import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.inventory.NpcTradeEvent
 import at.hannibal2.skyhanni.features.gui.customscoreboard.ScoreboardPattern
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
@@ -20,11 +21,13 @@ import at.hannibal2.skyhanni.utils.NumberUtil.formatLongOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.groupOrNull
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.SafeItemStack
 import at.hannibal2.skyhanni.utils.SkyblockCurrency
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
 import at.hannibal2.skyhanni.utils.StringUtils.removeResets
 import at.hannibal2.skyhanni.utils.StringUtils.trimWhiteSpace
 import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
+import java.util.regex.Pattern
 
 /**
  * Remembers how much of a currency the player owns, for currencies that Hypixel only shows on
@@ -106,6 +109,34 @@ object CurrencyApi {
     )
 
     /**
+     * The Grand Bakery item states how many kernels the player owns.
+     *
+     * REGEX-TEST: Grand Bakery
+     */
+    private val kernelItemPattern by patternGroup.pattern(
+        "kernel.item",
+        "Grand Bakery",
+    )
+
+    /**
+     * REGEX-TEST: Your Kernels: 12
+     */
+    private val kernelAmountPattern by patternGroup.pattern(
+        "kernel.amount",
+        "Your Kernels: (?<amount>[\\d,]+)",
+    )
+
+    /**
+     * Only Ted is confirmed, the npc name is left open so another feast chef still matches.
+     *
+     * REGEX-TEST: [NPC] Feast Chef Ted: Thanks for the donation! I've added a Kernel to your purse.
+     */
+    private val kernelGainPattern by patternGroup.pattern(
+        "kernel.gain",
+        "\\[NPC] [\\w ]+: Thanks for the donation! I've added a Kernel to your purse\\.",
+    )
+
+    /**
      * The type is read as written, so a new kind of essence needs no code change.
      *
      * REGEX-TEST: Your Undead Essence: 28,439
@@ -136,6 +167,12 @@ object CurrencyApi {
 
     private fun SkyblockCurrency.setAmount(amount: Long) {
         storage?.put(this, amount)
+    }
+
+    // an unknown amount stays unknown, counting up from a guessed zero would show a wrong total
+    private fun SkyblockCurrency.addAmount(amount: Long) {
+        val owned = getFromStorage() ?: return
+        setAmount(owned + amount)
     }
 
     fun SkyblockCurrency.getFromStorage(): Long? = storage?.get(this)
@@ -223,15 +260,34 @@ object CurrencyApi {
         }
     }
 
-    // unlocking an upgrade sends no chat message, the new amount only shows in the updated item
+    // unlocking a carnival upgrade sends no chat message, the new amount only shows in the updated
+    // item. this event also fires once right after the menu opened, so it covers the initial read too.
     @HandleEvent(onlyOnSkyblock = true)
     private fun onInventoryUpdated(event: InventoryUpdatedEvent) {
-        val item = event.inventoryItems.values.firstOrNull { carnivalTokenItemPattern.matches(it.cleanName) } ?: return
-        for (line in item.getCleanLore()) {
-            carnivalTokenAmountPattern.matchMatcher(line) {
-                SkyblockCurrency.CARNIVAL_TOKEN.setAmount(group("amount").formatLong())
+        for (item in event.inventoryItems.values) {
+            val name = item.cleanName
+            when {
+                carnivalTokenItemPattern.matches(name) ->
+                    item.readOwnedAmount(carnivalTokenAmountPattern, SkyblockCurrency.CARNIVAL_TOKEN)
+
+                kernelItemPattern.matches(name) -> item.readOwnedAmount(kernelAmountPattern, SkyblockCurrency.KERNEL)
             }
         }
+    }
+
+    private fun SafeItemStack.readOwnedAmount(pattern: Pattern, currency: SkyblockCurrency) {
+        for (line in getCleanLore()) {
+            pattern.matchMatcher(line) {
+                currency.setAmount(group("amount").formatLong())
+            }
+        }
+    }
+
+    // one kernel per donated Seasoning, this keeps the amount current between two menu visits
+    @HandleEvent(onlyOnSkyblock = true)
+    private fun onChat(event: SkyHanniChatEvent.Allow) {
+        if (!kernelGainPattern.matches(event.cleanMessage)) return
+        SkyblockCurrency.KERNEL.addAmount(1)
     }
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/utils/LoreCostUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/LoreCostUtils.kt
@@ -61,13 +61,14 @@ object LoreCostUtils {
      * REGEX-TEST: Click to level up!
      * REGEX-TEST: Click to buy!
      * REGEX-TEST: Click to donate!
+     * REGEX-TEST: Click to bake!
      * REGEX-TEST: Left Click to unlock!
      * REGEX-TEST: You can't afford this upgrade!
      * REGEX-FAIL: Right Click to preview!
      */
     private val tradeLinePattern by patternGroup.pattern(
         "trade.click",
-        "(?:Left )?Click to (?:trade|unlock|level up|buy|donate)!|You can't afford this upgrade!",
+        "(?:Left )?Click to (?:trade|unlock|level up|buy|donate|bake)!|You can't afford this upgrade!",
     )
 
     /**

--- a/src/main/java/at/hannibal2/skyhanni/utils/NeuInternalName.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/NeuInternalName.kt
@@ -76,6 +76,7 @@ value class NeuInternalName private constructor(private val internalName: String
         val SKYBLOCK_BRONZE_MEDAL = "SKYBLOCK_BRONZE_MEDAL".toInternalName()
         val SKYBLOCK_COPPER = "SKYBLOCK_COPPER".toInternalName()
         val SKYBLOCK_MOTE = "SKYBLOCK_MOTE".toInternalName()
+        val SKYBLOCK_KERNEL = "SKYBLOCK_KERNEL".toInternalName()
 
         val WISP_POTION = "WISP_POTION".toInternalName()
         val ENCHANTED_HAY_BLOCK = "ENCHANTED_HAY_BLOCK".toInternalName()

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyblockCurrency.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyblockCurrency.kt
@@ -184,6 +184,8 @@ enum class SkyblockCurrency(
     // TODO add these currencies, each one needs a real cost line from its shop first
     //  - North Stars, waiting on the winter event
     //  - Bingo Points, waiting on the bingo event
+    // not missing: essence has a bazaar price and its own map in CurrencyApi, and the powders and
+    // whispers only show up in the perk trees, which NpcTradeApi skips entirely
     ;
 
     val coloredName: String = color.getChatColor() + displayName

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyblockCurrency.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyblockCurrency.kt
@@ -160,6 +160,12 @@ enum class SkyblockCurrency(
         ownedAmount = { getFromStorage() },
     ),
 
+    // Grand Bakery from Feast Baker Scott in the Hub, earned by donating Seasonings during a Grand Feast
+    KERNEL(
+        NeuInternalName.SKYBLOCK_KERNEL, "Kernel", GOLD, loreNames = setOf("kernel", "kernels"),
+        ownedAmount = { getFromStorage() },
+    ),
+
     // TODO add these currencies, each one needs a real cost line from its shop first
     //  - North Stars, waiting on the winter event
     //  - Bingo Points, waiting on the bingo event

--- a/src/main/java/at/hannibal2/skyhanni/utils/SkyblockCurrency.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/SkyblockCurrency.kt
@@ -10,7 +10,6 @@ import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.test.command.ErrorManager
 import at.hannibal2.skyhanni.utils.NeuInternalName.Companion.toInternalName
 import at.hannibal2.skyhanni.utils.NeuItems.getItemStackOrNull
-import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.NumberUtil.formatLong
 import at.hannibal2.skyhanni.utils.RegexUtils.matchMatcher
 import at.hannibal2.skyhanni.utils.StringUtils.removeColor
@@ -36,6 +35,13 @@ enum class SkyblockCurrency(
     val color: LorenzColor,
     val coinValue: Double? = null,
     private val loreNames: Set<String>,
+    /** Set when [displayName] is the plural, as with "Bits". */
+    private val singularName: String? = null,
+    /**
+     * Set when [displayName] is the singular and its plural is not an s away, as with "Chocolate".
+     * Never set together with [singularName], [displayName] always covers the other form.
+     */
+    private val pluralName: String? = null,
     /** Set when the lore name alone is ambiguous and only unique on one island. */
     private val island: IslandType? = null,
     /** True when the amount belongs to the account instead of the current profile. */
@@ -53,12 +59,14 @@ enum class SkyblockCurrency(
         GOLD,
         coinValue = 1.0,
         loreNames = setOf("coin", "coins", "skyblock coin", "skyblock coins", "skyblock_coin", "skyblock_coins"),
+        singularName = "Coin",
         ownedAmount = { PurseApi.currentPurse.toLong() },
     ),
 
     // Bits Shop from Elisabeth
     BITS(
         "BITS".toInternalName(), "Bits", AQUA, loreNames = setOf("bit", "bits"),
+        singularName = "Bit",
         accountWide = true,
         ownedAmount = { BitsApi.bits.toLong() },
     ),
@@ -66,6 +74,7 @@ enum class SkyblockCurrency(
     // Pesthunter's Wares in Garden
     PESTS(
         "PESTS".toInternalName(), "Pests", DARK_GREEN, loreNames = setOf("pest", "pests"),
+        singularName = "Pest",
         ownedAmount = { getFromStorage() },
     ),
 
@@ -75,12 +84,14 @@ enum class SkyblockCurrency(
         "Chocolate",
         GOLD,
         loreNames = setOf("chocolate"),
+        pluralName = "Chocolate",
         ownedAmount = { ChocolateAmount.CURRENT.chocolate() + ChocolateAmount.chocolateSinceUpdate() },
     ),
 
     // SkyMart in Garden
     COPPER(
         NeuInternalName.SKYBLOCK_COPPER, "Copper", RED, loreNames = setOf("copper"),
+        pluralName = "Copper",
         ownedAmount = { getFromStorage() },
     ),
 
@@ -101,12 +112,14 @@ enum class SkyblockCurrency(
     // Tony's Shop in the Farming Islands
     PELTS(
         "PELTS".toInternalName(), "Pelts", DARK_PURPLE, loreNames = setOf("pelt", "pelts"),
+        singularName = "Pelt",
         ownedAmount = { getFromStorage() },
     ),
 
     // Cosmetics in various shops
     GEMS(
         "GEMS".toInternalName(), "Gems", GREEN, loreNames = setOf("gem", "gems"),
+        singularName = "Gem",
         accountWide = true,
         ownedAmount = { getFromStorage() },
     ),
@@ -114,6 +127,7 @@ enum class SkyblockCurrency(
     // no shop sells for sowdust yet, this only tracks the amount
     SOWDUST(
         "SOWDUST".toInternalName(), "Sowdust", DARK_GREEN, loreNames = setOf("sowdust"),
+        pluralName = "Sowdust",
         ownedAmount = { getFromStorage() },
     ),
 
@@ -126,6 +140,7 @@ enum class SkyblockCurrency(
     // the lore only writes "Tokens", the island is what makes it unambiguous
     KUUDRA_TOKEN(
         "KUUDRA_TOKEN".toInternalName(), "Tokens", DARK_PURPLE, loreNames = setOf("token", "tokens"),
+        singularName = "Token",
         island = KUUDRA_ARENA,
         ownedAmount = { getFromStorage() },
     ),
@@ -185,7 +200,11 @@ enum class SkyblockCurrency(
     private fun isAvailable(): Boolean = island?.isInIsland() ?: true
 
     /** Formats an amount the way it appears in a cost lore, for example "§b5,000 Bits". */
-    fun formatAmount(amount: Long): String = "${color.getChatColor()}${amount.addSeparators()} $displayName"
+    fun formatAmount(amount: Long): String {
+        // displayName is the plural when a singular is stated, otherwise pluralName, and null appends the s
+        val plural = if (singularName == null) pluralName else displayName
+        return color.getChatColor() + StringUtils.pluralize(amount, singularName ?: displayName, plural, withNumber = true)
+    }
 
     @SkyHanniModule
     companion object {

--- a/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
@@ -259,9 +259,12 @@ object StringUtils {
 
     fun String.pluralize(number: Int) = pluralize(number, this)
 
-    fun pluralize(number: Int, singular: String, plural: String? = null, withNumber: Boolean = false): String {
+    fun pluralize(number: Int, singular: String, plural: String? = null, withNumber: Boolean = false): String =
+        pluralize(number.toLong(), singular, plural, withNumber)
+
+    fun pluralize(number: Long, singular: String, plural: String? = null, withNumber: Boolean = false): String {
         val pluralForm = plural ?: "${singular}s"
-        var str = if (number == 1 || number == -1) singular else pluralForm
+        var str = if (number == 1L || number == -1L) singular else pluralForm
         if (withNumber) str = "${number.addSeparators()} $str"
         return str
     }


### PR DESCRIPTION

<details>
<summary>Images</summary>

<img width="732" height="451" alt="image" src="https://github.com/user-attachments/assets/476f8825-8136-40fe-9fa6-1ac8d8e261b3" />

</details>

## Changelog Improvements
+ Added support for the Grand Bakery to the NPC Trade Helper. - hannibal2
    * Cost lines now show the Kernel price and how many Kernels you own.

## Changelog Fixes
+ Fixed wrong singular and plural currency names in NPC Trade Helper cost lines. - hannibal2
    * For example "500 Kernel" instead of "500 Kernels", or "1 Bits" instead of "1 Bit".