### PR TITLE
  Backend: Split up StringUtils and TextHelper

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/utils/ComponentMatcherUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/ComponentMatcherUtils.kt
@@ -67,6 +67,9 @@ object ComponentMatcherUtils {
      */
     inline fun <T> Pattern.findStyledMatcher(span: ComponentSpan, consumer: ComponentMatcher.() -> T) =
         styledMatcher(span).let { if (it.find()) consumer(it) else null }
+
+    fun String.applyFormattingFrom(original: ComponentSpan): Component =
+        asComponent { style = original.sampleStyleAtStart() }
 }
 
 /**

--- a/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
@@ -8,12 +8,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.findAll
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
 import at.hannibal2.skyhanni.utils.chat.ChatComponentUtils
 import at.hannibal2.skyhanni.utils.chat.TextHelper
-import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
-import at.hannibal2.skyhanni.utils.compat.toChatFormatting
-import net.minecraft.client.Minecraft
-import net.minecraft.client.gui.components.ComponentRenderUtils
 import net.minecraft.network.chat.Component
-import net.minecraft.network.chat.TextColor
 import java.net.URLEncoder
 import java.util.Base64
 import java.util.Locale
@@ -192,46 +187,12 @@ object StringUtils {
     fun String.removeWordsAtEnd(i: Int) = split(" ").dropLast(i).joinToString(" ")
     fun Double.removeUnusedDecimal() = if (this % 1 == 0.0) toInt().toString() else toString()
 
-    fun String.splitLines(width: Int): String = splitText(
-        this,
-        width,
-    ).joinToString("\n") { it.removePrefix("§r") }
-
-    private fun splitText(text: String, width: Int): List<String> {
-        val lines = ComponentRenderUtils.wrapComponents(Component.literal(text), width, Minecraft.getInstance().font)
-        val strings: MutableList<String> = ArrayList(lines.size)
-        for (line in lines) {
-            var newLine = ""
-            var lastColor: TextColor? = null
-            var lastFormatting = ""
-            line.accept { _, style, codePoint ->
-                val color = style.color
-                if (color != lastColor) {
-                    lastColor = color
-                    lastFormatting = ""
-                    if (color != null) {
-                        newLine += color.toChatFormatting()
-                    }
-                }
-                var newFormatting = ""
-                newFormatting = if (style.isBold) "§l"
-                else if (style.isItalic) "§o"
-                else if (style.isUnderlined) "§n"
-                else if (style.isStrikethrough) "§m"
-                else if (style.isObfuscated) "§k"
-                else ""
-
-                if (newFormatting != lastFormatting) {
-                    lastFormatting = newFormatting
-                    newLine += newFormatting
-                }
-                newLine += codePoint.toChar()
-                true
-            }
-            strings.add(newLine)
-        }
-        return strings
-    }
+    // TODO remove this deprecated alias in November 2026
+    @Deprecated(
+        "Moved to TextHelper",
+        ReplaceWith("this.splitLines(width)", "at.hannibal2.skyhanni.utils.chat.TextHelper.splitLines"),
+    )
+    fun String.splitLines(width: Int): String = with(TextHelper) { splitLines(width) }
 
     /**
      * Creates a comma-separated list using natural formatting (a, b, and c).
@@ -280,17 +241,15 @@ object StringUtils {
         return builder.toString()
     }
 
-    fun String.capAtMinecraftLength(limit: Int) = capAtLength(limit) {
-        Minecraft.getInstance().font.width(it.toString())
-    }
-
-    private fun String.capAtLength(limit: Int, lengthJudger: (Char) -> Int): String {
-        var i = 0
-        return takeWhile {
-            i += lengthJudger(it)
-            i < limit
-        }
-    }
+    // TODO remove this deprecated alias in November 2026
+    @Deprecated(
+        "Moved to TextHelper",
+        ReplaceWith(
+            "this.capAtMinecraftLength(limit)",
+            "at.hannibal2.skyhanni.utils.chat.TextHelper.capAtMinecraftLength",
+        ),
+    )
+    fun String.capAtMinecraftLength(limit: Int) = with(TextHelper) { capAtMinecraftLength(limit) }
 
     fun String.getPlayerNameFromChatMessage(): String? = matchPlayerChatMessage(this)?.group("username")
 
@@ -440,7 +399,12 @@ object StringUtils {
     )
     fun Component.startsWith(other: String): Boolean = with(TextHelper) { startsWith(other) }
 
-    fun String.width(): Int = Minecraft.getInstance().font.width(this)
+    // TODO remove this deprecated alias in November 2026
+    @Deprecated(
+        "Moved to TextHelper",
+        ReplaceWith("this.width()", "at.hannibal2.skyhanni.utils.chat.TextHelper.width"),
+    )
+    fun String.width(): Int = with(TextHelper) { width() }
 
     private val vowels = "aeiouAEIOU".toSet()
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt
@@ -6,21 +6,13 @@ import at.hannibal2.skyhanni.utils.ColorUtils.getFirstColorCode
 import at.hannibal2.skyhanni.utils.NumberUtil.addSeparators
 import at.hannibal2.skyhanni.utils.RegexUtils.findAll
 import at.hannibal2.skyhanni.utils.RegexUtils.matches
+import at.hannibal2.skyhanni.utils.chat.ChatComponentUtils
+import at.hannibal2.skyhanni.utils.chat.TextHelper
 import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
-import at.hannibal2.skyhanni.utils.compat.command
-import at.hannibal2.skyhanni.utils.compat.defaultStyleConstructor
-import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
-import at.hannibal2.skyhanni.utils.compat.hover
 import at.hannibal2.skyhanni.utils.compat.toChatFormatting
-import at.hannibal2.skyhanni.utils.compat.unformattedTextForChatCompat
-import at.hannibal2.skyhanni.utils.compat.value
-import net.minecraft.ChatFormatting
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.components.ComponentRenderUtils
-import net.minecraft.network.chat.ClickEvent
 import net.minecraft.network.chat.Component
-import net.minecraft.network.chat.HoverEvent
-import net.minecraft.network.chat.Style
 import net.minecraft.network.chat.TextColor
 import java.net.URLEncoder
 import java.util.Base64
@@ -43,7 +35,6 @@ object StringUtils {
     private val lettersAndNumbersPattern = "(§.)|[^a-zA-Z0-9 ]".toPattern()
     private val formattingChars = "kmolnrKMOLNR".toSet()
     private val colorChars = "abcdefABCDEF0123456789zZ".toSet()
-    private val colorMap = ChatFormatting.entries.associateBy { it.toString()[1] }
 
     fun String.removeAllNonLettersAndNumbers(): String = lettersAndNumbersPattern.matcher(this).replaceAll("")
     fun String.cleanString(): String = removeAllNonLettersAndNumbers().trimWhiteSpaceAndResets().lowercase()
@@ -350,122 +341,42 @@ object StringUtils {
     fun String.insert(pos: Int, char: Char): String =
         substring(0, pos) + char + substring(pos)
 
+    // TODO remove this deprecated alias in November 2026
+    @Deprecated(
+        "Moved to ChatComponentUtils",
+        ReplaceWith(
+            "ChatComponentUtils.replaceIfNeeded(original, newText)",
+            "at.hannibal2.skyhanni.utils.chat.ChatComponentUtils",
+        ),
+    )
     fun replaceIfNeeded(original: Component, newText: String): Component? =
-        replaceIfNeeded(original, newText.asComponent())
+        ChatComponentUtils.replaceIfNeeded(original, newText)
 
-    fun enumChatFormattingByCode(char: Char): ChatFormatting? = colorMap[char]
-
-    fun doLookTheSame(left: Component, right: Component): Boolean {
-        class ChatIterator(var component: Component) {
-            var queue = mutableListOf<Component>()
-            var idx = 0
-            var colorOverride = defaultStyleConstructor
-            fun next(): Pair<Char, Style>? {
-                while (true) {
-                    while (idx >= component.unformattedTextForChatCompat().length) {
-                        queue.addAll(0, component.siblings)
-                        colorOverride = defaultStyleConstructor
-                        component = queue.removeFirstOrNull() ?: return null
-                    }
-                    val char = component.unformattedTextForChatCompat()[idx++]
-                    if (char == '§' && idx < component.unformattedTextForChatCompat().length) {
-                        val formattingChar = component.unformattedTextForChatCompat()[idx++]
-                        val formatting = enumChatFormattingByCode(formattingChar) ?: continue
-                        when (formatting) {
-                            ChatFormatting.OBFUSCATED -> {
-                                colorOverride.withObfuscated(true)
-                            }
-
-                            ChatFormatting.BOLD -> {
-                                colorOverride.withBold(true)
-                            }
-
-                            ChatFormatting.STRIKETHROUGH -> {
-                                colorOverride.withStrikethrough(true)
-                            }
-
-                            ChatFormatting.UNDERLINE -> {
-                                colorOverride.withUnderlined(true)
-                            }
-
-                            ChatFormatting.ITALIC -> {
-                                colorOverride.withItalic(true)
-                            }
-
-                            else -> {
-                                colorOverride = defaultStyleConstructor.withColor(formatting)
-                            }
-                        }
-                    } else {
-                        return Pair(char, colorOverride.applyTo(component.style))
-                    }
-                }
-            }
-        }
-
-        val leftIt = ChatIterator(left)
-        val rightIt = ChatIterator(right)
-        while (true) {
-            val leftChar = leftIt.next()
-            val rightChar = rightIt.next()
-            if (leftChar == null && rightChar == null) return true
-            if (leftChar != rightChar) return false
-        }
-    }
-
+    // TODO remove in November 2026
+    @Deprecated(
+        "Moved to ChatComponentUtils",
+        ReplaceWith(
+            "ChatComponentUtils.replaceIfNeeded(original, newText)",
+            "at.hannibal2.skyhanni.utils.chat.ChatComponentUtils",
+        ),
+    )
     fun <T : Component> replaceIfNeeded(
         original: T,
         newText: T,
-    ): T? {
-        if (doLookTheSame(original, newText)) return null
-        return newText
-    }
+    ): T? = ChatComponentUtils.replaceIfNeeded(original, newText)
 
-    /**
-     * Applies a transformation on the message of a SystemMessageEvent if possible.
-     */
+    // TODO remove in November 2026
+    @Deprecated(
+        "Moved to ChatComponentUtils",
+        ReplaceWith(
+            "this.applyIfPossible(transformationReason, transform)",
+            "at.hannibal2.skyhanni.utils.chat.ChatComponentUtils.applyIfPossible",
+        ),
+    )
     fun SystemMessageEvent.Modify.applyIfPossible(
         transformationReason: String? = null,
         transform: (String) -> String,
-    ) {
-        val original = chatComponent.formattedTextCompat()
-        val new = transform(original)
-        if (new == original) return
-
-        val clickEvents = mutableListOf<ClickEvent>()
-        val hoverEvents = mutableListOf<HoverEvent>()
-        chatComponent.findAllEvents(clickEvents, hoverEvents)
-
-        if (clickEvents.size > 1 || hoverEvents.size > 1) return
-
-        val newComponent = new.asComponent().apply {
-            if (clickEvents.size == 1) command = clickEvents.first().value()
-            if (hoverEvents.size == 1) hover = hoverEvents.first().value()
-        }
-
-        replaceComponent(newComponent, transformationReason.orEmpty())
-    }
-
-    private fun Component.findAllEvents(
-        clickEvents: MutableList<ClickEvent>,
-        hoverEvents: MutableList<HoverEvent>,
-    ) {
-        siblings.forEach { it.findAllEvents(clickEvents, hoverEvents) }
-
-        val clickEvent = style.clickEvent
-        val hoverEvent = style.hoverEvent
-
-        if (clickEvent?.action() != null && clickEvents.none { it.value() == clickEvent.value() }) {
-            clickEvents.add(clickEvent)
-        }
-
-        if (hoverEvent?.action() != null && hoverEvents.none {
-                it.value() == hoverEvent.value()
-            }
-        ) {
-            hoverEvents.add(hoverEvent)
-        }
-    }
+    ) = with(ChatComponentUtils) { applyIfPossible(transformationReason, transform) }
 
     fun String.replaceAll(oldValue: String, newValue: String, ignoreCase: Boolean = false): String {
         var text = this
@@ -493,15 +404,41 @@ object StringUtils {
         return message
     }
 
+    // TODO remove this deprecated alias in November 2026
+    @Deprecated(
+        "Moved to ComponentMatcherUtils",
+        ReplaceWith(
+            "this.applyFormattingFrom(original)",
+            "at.hannibal2.skyhanni.utils.ComponentMatcherUtils.applyFormattingFrom",
+        ),
+    )
     fun String.applyFormattingFrom(original: ComponentSpan): Component =
-        asComponent { style = original.sampleStyleAtStart() }
+        with(ComponentMatcherUtils) { applyFormattingFrom(original) }
 
+    // TODO remove this deprecated alias in November 2026
+    @Deprecated(
+        "Moved to TextHelper",
+        ReplaceWith(
+            "this.applyFormattingFrom(original)",
+            "at.hannibal2.skyhanni.utils.chat.TextHelper.applyFormattingFrom",
+        ),
+    )
     fun String.applyFormattingFrom(original: Component): Component =
-        asComponent { style = original.style }
+        with(TextHelper) { applyFormattingFrom(original) }
 
-    fun Component.contains(other: String): Boolean = string.contains(other)
+    // TODO remove this deprecated alias in November 2026
+    @Deprecated(
+        "Moved to TextHelper",
+        ReplaceWith("this.contains(other)", "at.hannibal2.skyhanni.utils.chat.TextHelper.contains"),
+    )
+    fun Component.contains(other: String): Boolean = with(TextHelper) { contains(other) }
 
-    fun Component.startsWith(other: String): Boolean = string.startsWith(other)
+    // TODO remove this deprecated alias in November 2026
+    @Deprecated(
+        "Moved to TextHelper",
+        ReplaceWith("this.startsWith(other)", "at.hannibal2.skyhanni.utils.chat.TextHelper.startsWith"),
+    )
+    fun Component.startsWith(other: String): Boolean = with(TextHelper) { startsWith(other) }
 
     fun String.width(): Int = Minecraft.getInstance().font.width(this)
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/chat/ChatComponentUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/chat/ChatComponentUtils.kt
@@ -48,23 +48,23 @@ object ChatComponentUtils {
                         val formattingChar = component.unformattedTextForChatCompat()[idx++]
                         val formatting = enumChatFormattingByCode(formattingChar) ?: continue
                         when (formatting) {
-                            ChatFormatting.OBFUSCATED -> {
+                            OBFUSCATED -> {
                                 colorOverride.withObfuscated(true)
                             }
 
-                            ChatFormatting.BOLD -> {
+                            BOLD -> {
                                 colorOverride.withBold(true)
                             }
 
-                            ChatFormatting.STRIKETHROUGH -> {
+                            STRIKETHROUGH -> {
                                 colorOverride.withStrikethrough(true)
                             }
 
-                            ChatFormatting.UNDERLINE -> {
+                            UNDERLINE -> {
                                 colorOverride.withUnderlined(true)
                             }
 
-                            ChatFormatting.ITALIC -> {
+                            ITALIC -> {
                                 colorOverride.withItalic(true)
                             }
 

--- a/src/main/java/at/hannibal2/skyhanni/utils/chat/ChatComponentUtils.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/chat/ChatComponentUtils.kt
@@ -1,0 +1,137 @@
+package at.hannibal2.skyhanni.utils.chat
+
+import at.hannibal2.skyhanni.data.hypixel.chat.event.SystemMessageEvent
+import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
+import at.hannibal2.skyhanni.utils.compat.command
+import at.hannibal2.skyhanni.utils.compat.defaultStyleConstructor
+import at.hannibal2.skyhanni.utils.compat.formattedTextCompat
+import at.hannibal2.skyhanni.utils.compat.hover
+import at.hannibal2.skyhanni.utils.compat.unformattedTextForChatCompat
+import at.hannibal2.skyhanni.utils.compat.value
+import net.minecraft.ChatFormatting
+import net.minecraft.network.chat.ClickEvent
+import net.minecraft.network.chat.Component
+import net.minecraft.network.chat.HoverEvent
+import net.minecraft.network.chat.Style
+
+object ChatComponentUtils {
+
+    private val colorMap = ChatFormatting.entries.associateBy { it.toString()[1] }
+
+    private fun enumChatFormattingByCode(char: Char): ChatFormatting? = colorMap[char]
+
+    fun replaceIfNeeded(original: Component, newText: String): Component? =
+        replaceIfNeeded(original, newText.asComponent())
+
+    fun <T : Component> replaceIfNeeded(
+        original: T,
+        newText: T,
+    ): T? {
+        if (doLookTheSame(original, newText)) return null
+        return newText
+    }
+
+    private fun doLookTheSame(left: Component, right: Component): Boolean {
+        class ChatIterator(var component: Component) {
+            var queue = mutableListOf<Component>()
+            var idx = 0
+            var colorOverride = defaultStyleConstructor
+            fun next(): Pair<Char, Style>? {
+                while (true) {
+                    while (idx >= component.unformattedTextForChatCompat().length) {
+                        queue.addAll(0, component.siblings)
+                        colorOverride = defaultStyleConstructor
+                        component = queue.removeFirstOrNull() ?: return null
+                    }
+                    val char = component.unformattedTextForChatCompat()[idx++]
+                    if (char == '§' && idx < component.unformattedTextForChatCompat().length) {
+                        val formattingChar = component.unformattedTextForChatCompat()[idx++]
+                        val formatting = enumChatFormattingByCode(formattingChar) ?: continue
+                        when (formatting) {
+                            ChatFormatting.OBFUSCATED -> {
+                                colorOverride.withObfuscated(true)
+                            }
+
+                            ChatFormatting.BOLD -> {
+                                colorOverride.withBold(true)
+                            }
+
+                            ChatFormatting.STRIKETHROUGH -> {
+                                colorOverride.withStrikethrough(true)
+                            }
+
+                            ChatFormatting.UNDERLINE -> {
+                                colorOverride.withUnderlined(true)
+                            }
+
+                            ChatFormatting.ITALIC -> {
+                                colorOverride.withItalic(true)
+                            }
+
+                            else -> {
+                                colorOverride = defaultStyleConstructor.withColor(formatting)
+                            }
+                        }
+                    } else {
+                        return Pair(char, colorOverride.applyTo(component.style))
+                    }
+                }
+            }
+        }
+
+        val leftIt = ChatIterator(left)
+        val rightIt = ChatIterator(right)
+        while (true) {
+            val leftChar = leftIt.next()
+            val rightChar = rightIt.next()
+            if (leftChar == null && rightChar == null) return true
+            if (leftChar != rightChar) return false
+        }
+    }
+
+    /**
+     * Applies a transformation on the message of a SystemMessageEvent if possible.
+     */
+    fun SystemMessageEvent.Modify.applyIfPossible(
+        transformationReason: String? = null,
+        transform: (String) -> String,
+    ) {
+        val original = chatComponent.formattedTextCompat()
+        val new = transform(original)
+        if (new == original) return
+
+        val clickEvents = mutableListOf<ClickEvent>()
+        val hoverEvents = mutableListOf<HoverEvent>()
+        chatComponent.findAllEvents(clickEvents, hoverEvents)
+
+        if (clickEvents.size > 1 || hoverEvents.size > 1) return
+
+        val newComponent = new.asComponent().apply {
+            if (clickEvents.size == 1) command = clickEvents.first().value()
+            if (hoverEvents.size == 1) hover = hoverEvents.first().value()
+        }
+
+        replaceComponent(newComponent, transformationReason.orEmpty())
+    }
+
+    private fun Component.findAllEvents(
+        clickEvents: MutableList<ClickEvent>,
+        hoverEvents: MutableList<HoverEvent>,
+    ) {
+        siblings.forEach { it.findAllEvents(clickEvents, hoverEvents) }
+
+        val clickEvent = style.clickEvent
+        val hoverEvent = style.hoverEvent
+
+        if (clickEvent?.action() != null && clickEvents.none { it.value() == clickEvent.value() }) {
+            clickEvents.add(clickEvent)
+        }
+
+        if (hoverEvent?.action() != null && hoverEvents.none {
+                it.value() == hoverEvent.value()
+            }
+        ) {
+            hoverEvents.add(hoverEvent)
+        }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/utils/chat/PaginatedList.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/chat/PaginatedList.kt
@@ -1,0 +1,90 @@
+package at.hannibal2.skyhanni.utils.chat
+
+import at.hannibal2.skyhanni.utils.DelayedRun
+import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
+import at.hannibal2.skyhanni.utils.chat.TextHelper.center
+import at.hannibal2.skyhanni.utils.chat.TextHelper.fitToChat
+import at.hannibal2.skyhanni.utils.chat.TextHelper.onClick
+import at.hannibal2.skyhanni.utils.chat.TextHelper.send
+import at.hannibal2.skyhanni.utils.chat.TextHelper.style
+import at.hannibal2.skyhanni.utils.compat.hover
+import net.minecraft.ChatFormatting
+import net.minecraft.network.chat.Component
+
+object PaginatedList {
+
+    fun createDivider(dividerColor: ChatFormatting = ChatFormatting.BLUE) = TextHelper.HYPHEN.fitToChat().style {
+        withStrikethrough(true)
+        withColor(dividerColor)
+    }
+
+    /**
+     * Displays a paginated list of entries in the chat.
+     *
+     * @param title The title of the paginated list.
+     * @param list The list of entries to paginate and display.
+     * @param chatLineId The ID of the chat line for message updates.
+     * @param emptyMessage The message to display if the list is empty.
+     * @param currentPage The current page to display.
+     * @param maxPerPage The number of entries to display per page.
+     * @param dividerColor The color of the divider lines.
+     * @param formatter A function to format each entry into a Component.
+     */
+    fun <T> displayPaginatedList(
+        title: String,
+        list: List<T>,
+        chatLineId: Int,
+        emptyMessage: String,
+        currentPage: Int = 1,
+        maxPerPage: Int = 15,
+        dividerColor: ChatFormatting = ChatFormatting.BLUE,
+        formatter: (T) -> Component,
+    ): Unit = DelayedRun.runOrNextTick("paginated list: $title") {
+        val text = mutableListOf<Component>()
+
+        val totalPages = (list.size + maxPerPage - 1) / maxPerPage
+        val page = if (totalPages == 0) 0 else currentPage
+
+        text.add(createDivider(dividerColor))
+        text.add("§6$title".asComponent().center())
+
+        if (totalPages > 1) {
+            text.add(
+                TextHelper.join(
+                    if (page > 1) "§6§l<<".asComponent {
+                        hover = "§eClick to view page ${page - 1}".asComponent()
+                        onClick {
+                            displayPaginatedList(title, list, chatLineId, emptyMessage, page - 1, maxPerPage, dividerColor, formatter)
+                        }
+                    } else null,
+                    " ",
+                    "§6(Page $page of $totalPages)",
+                    " ",
+                    if (page < totalPages) "§6§l>>".asComponent {
+                        hover = "§eClick to view page ${page + 1}".asComponent()
+                        onClick {
+                            displayPaginatedList(title, list, chatLineId, emptyMessage, page + 1, maxPerPage, dividerColor, formatter)
+                        }
+                    } else null,
+                ).center(),
+            )
+        }
+
+        text.add(createDivider(dividerColor))
+
+        if (list.isNotEmpty()) {
+            val start = (page - 1) * maxPerPage
+            val end = (page * maxPerPage).coerceAtMost(list.size)
+            for (i in start until end) {
+                text.add(formatter(list[i]))
+            }
+        } else {
+            text.add(TextHelper.EMPTY)
+            text.add("§c$emptyMessage".asComponent().center())
+            text.add(TextHelper.EMPTY)
+        }
+
+        text.add(createDivider(dividerColor))
+        TextHelper.multiline(text).send(chatLineId)
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/utils/chat/PaginatedList.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/chat/PaginatedList.kt
@@ -37,7 +37,7 @@ object PaginatedList {
         emptyMessage: String,
         currentPage: Int = 1,
         maxPerPage: Int = 15,
-        dividerColor: ChatFormatting = ChatFormatting.BLUE,
+        dividerColor: ChatFormatting = BLUE,
         formatter: (T) -> Component,
     ): Unit = DelayedRun.runOrNextTick("paginated list: $title") {
         val text = mutableListOf<Component>()

--- a/src/main/java/at/hannibal2/skyhanni/utils/chat/TextHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/chat/TextHelper.kt
@@ -9,10 +9,12 @@ import at.hannibal2.skyhanni.utils.compat.append
 import at.hannibal2.skyhanni.utils.compat.command
 import at.hannibal2.skyhanni.utils.compat.componentBuilder
 import at.hannibal2.skyhanni.utils.compat.hover
+import at.hannibal2.skyhanni.utils.compat.toChatFormatting
 import at.hannibal2.skyhanni.utils.compat.withColor
 import com.mojang.authlib.GameProfile
 import net.minecraft.ChatFormatting
 import net.minecraft.client.Minecraft
+import net.minecraft.client.gui.components.ComponentRenderUtils
 import net.minecraft.network.chat.Component
 import net.minecraft.network.chat.MutableComponent
 import net.minecraft.network.chat.Style
@@ -74,6 +76,8 @@ object TextHelper {
 
     fun Component.width(): Int = Minecraft.getInstance().font.width(this.string)
 
+    fun String.width(): Int = Minecraft.getInstance().font.width(this)
+
     fun Component.fitToChat(): Component {
         val width = this.width()
         val maxWidth = MinecraftCompat.hud.chat.width
@@ -91,6 +95,59 @@ object TextHelper {
         val spaceWidth = SPACE.width().coerceAtLeast(1)
         val padding = (width - textWidth).coerceAtLeast(0) / 2
         return join(" ".repeat(padding / spaceWidth), this)
+    }
+
+    fun String.capAtMinecraftLength(limit: Int) = capAtLength(limit) {
+        Minecraft.getInstance().font.width(it.toString())
+    }
+
+    private fun String.capAtLength(limit: Int, lengthJudger: (Char) -> Int): String {
+        var i = 0
+        return takeWhile {
+            i += lengthJudger(it)
+            i < limit
+        }
+    }
+
+    fun String.splitLines(width: Int): String = splitText(
+        this,
+        width,
+    ).joinToString("\n") { it.removePrefix("§r") }
+
+    private fun splitText(text: String, width: Int): List<String> {
+        val lines = ComponentRenderUtils.wrapComponents(Component.literal(text), width, Minecraft.getInstance().font)
+        val strings: MutableList<String> = ArrayList(lines.size)
+        for (line in lines) {
+            var newLine = ""
+            var lastColor: TextColor? = null
+            var lastFormatting = ""
+            line.accept { _, style, codePoint ->
+                val color = style.color
+                if (color != lastColor) {
+                    lastColor = color
+                    lastFormatting = ""
+                    if (color != null) {
+                        newLine += color.toChatFormatting()
+                    }
+                }
+                var newFormatting = ""
+                newFormatting = if (style.isBold) "§l"
+                else if (style.isItalic) "§o"
+                else if (style.isUnderlined) "§n"
+                else if (style.isStrikethrough) "§m"
+                else if (style.isObfuscated) "§k"
+                else ""
+
+                if (newFormatting != lastFormatting) {
+                    lastFormatting = newFormatting
+                    newLine += newFormatting
+                }
+                newLine += codePoint.toChar()
+                true
+            }
+            strings.add(newLine)
+        }
+        return strings
     }
 
     fun Component.send(id: Int = 0, bypassSelfMessages: Boolean = false) =

--- a/src/main/java/at/hannibal2/skyhanni/utils/chat/TextHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/chat/TextHelper.kt
@@ -1,7 +1,6 @@
 package at.hannibal2.skyhanni.utils.chat
 
 import at.hannibal2.skyhanni.utils.ColorUtils
-import at.hannibal2.skyhanni.utils.DelayedRun
 import at.hannibal2.skyhanni.utils.LorenzColor
 import at.hannibal2.skyhanni.utils.SimpleTimeMark
 import at.hannibal2.skyhanni.utils.compat.MinecraftCompat
@@ -120,23 +119,25 @@ object TextHelper {
         this.hover = tips.joinToString("\n").asComponent()
     }
 
-    fun createDivider(dividerColor: ChatFormatting = ChatFormatting.BLUE) = HYPHEN.fitToChat().style {
-        withStrikethrough(true)
-        withColor(dividerColor)
-    }
+    // TODO remove this deprecated alias in November 2026
+    @Deprecated(
+        "Moved to PaginatedList",
+        ReplaceWith(
+            "PaginatedList.createDivider(dividerColor)",
+            "at.hannibal2.skyhanni.utils.chat.PaginatedList",
+        ),
+    )
+    fun createDivider(dividerColor: ChatFormatting = ChatFormatting.BLUE) =
+        PaginatedList.createDivider(dividerColor)
 
-    /**
-     * Displays a paginated list of entries in the chat.
-     *
-     * @param title The title of the paginated list.
-     * @param list The list of entries to paginate and display.
-     * @param chatLineId The ID of the chat line for message updates.
-     * @param emptyMessage The message to display if the list is empty.
-     * @param currentPage The current page to display.
-     * @param maxPerPage The number of entries to display per page.
-     * @param dividerColor The color of the divider lines.
-     * @param formatter A function to format each entry into an IChatComponent.
-     */
+    // TODO remove this deprecated alias in November 2026
+    @Deprecated(
+        "Moved to PaginatedList",
+        ReplaceWith(
+            "PaginatedList.displayPaginatedList(title, list, chatLineId, emptyMessage, currentPage, maxPerPage, dividerColor, formatter)",
+            "at.hannibal2.skyhanni.utils.chat.PaginatedList",
+        ),
+    )
     fun <T> displayPaginatedList(
         title: String,
         list: List<T>,
@@ -146,54 +147,9 @@ object TextHelper {
         maxPerPage: Int = 15,
         dividerColor: ChatFormatting = ChatFormatting.BLUE,
         formatter: (T) -> Component,
-    ): Unit = DelayedRun.runOrNextTick("paginated list: $title") {
-        val text = mutableListOf<Component>()
-
-        val totalPages = (list.size + maxPerPage - 1) / maxPerPage
-        val page = if (totalPages == 0) 0 else currentPage
-
-        text.add(createDivider(dividerColor))
-        text.add("§6$title".asComponent().center())
-
-        if (totalPages > 1) {
-            text.add(
-                join(
-                    if (page > 1) "§6§l<<".asComponent {
-                        hover = "§eClick to view page ${page - 1}".asComponent()
-                        onClick {
-                            displayPaginatedList(title, list, chatLineId, emptyMessage, page - 1, maxPerPage, dividerColor, formatter)
-                        }
-                    } else null,
-                    " ",
-                    "§6(Page $page of $totalPages)",
-                    " ",
-                    if (page < totalPages) "§6§l>>".asComponent {
-                        hover = "§eClick to view page ${page + 1}".asComponent()
-                        onClick {
-                            displayPaginatedList(title, list, chatLineId, emptyMessage, page + 1, maxPerPage, dividerColor, formatter)
-                        }
-                    } else null,
-                ).center(),
-            )
-        }
-
-        text.add(createDivider(dividerColor))
-
-        if (list.isNotEmpty()) {
-            val start = (page - 1) * maxPerPage
-            val end = (page * maxPerPage).coerceAtMost(list.size)
-            for (i in start until end) {
-                text.add(formatter(list[i]))
-            }
-        } else {
-            text.add(EMPTY)
-            text.add("§c$emptyMessage".asComponent().center())
-            text.add(EMPTY)
-        }
-
-        text.add(createDivider(dividerColor))
-        multiline(text).send(chatLineId)
-    }
+    ): Unit = PaginatedList.displayPaginatedList(
+        title, list, chatLineId, emptyMessage, currentPage, maxPerPage, dividerColor, formatter,
+    )
 
     fun createGradientText(start: LorenzColor, end: LorenzColor, string: String): Component {
         return createGradientText(start.toColor(), end.toColor(), string)

--- a/src/main/java/at/hannibal2/skyhanni/utils/chat/TextHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/chat/TextHelper.kt
@@ -115,7 +115,7 @@ object TextHelper {
     ).joinToString("\n") { it.removePrefix("§r") }
 
     private fun splitText(text: String, width: Int): List<String> {
-        val lines = ComponentRenderUtils.wrapComponents(Component.literal(text), width, Minecraft.getInstance().font)
+        val lines = ComponentRenderUtils.wrapComponents(text.asComponent(), width, Minecraft.getInstance().font)
         val strings: MutableList<String> = ArrayList(lines.size)
         for (line in lines) {
             var newLine = ""

--- a/src/main/java/at/hannibal2/skyhanni/utils/chat/TextHelper.kt
+++ b/src/main/java/at/hannibal2/skyhanni/utils/chat/TextHelper.kt
@@ -66,6 +66,13 @@ object TextHelper {
     fun Component.suffix(suffix: String): Component = join(this, suffix)
     fun Component.wrap(prefix: String, suffix: String) = this.prefix(prefix).suffix(suffix)
 
+    fun String.applyFormattingFrom(original: Component): Component =
+        asComponent { style = original.style }
+
+    fun Component.contains(other: String): Boolean = string.contains(other)
+
+    fun Component.startsWith(other: String): Boolean = string.startsWith(other)
+
     fun Component.width(): Int = Minecraft.getInstance().font.width(this.string)
 
     fun Component.fitToChat(): Component {


### PR DESCRIPTION
## What
Trying to split up large utils files.

## Changelog Technical Details
+ Split up StringUtils and TextHelper. - hannibal2
    * Moved chat component helpers into the new ChatComponentUtils.
    * Moved the paginated chat list from TextHelper into the new PaginatedListHelper.
    * Moved font-dependent text helpers from StringUtils into TextHelper.
    * Kept the old names as deprecated aliases until November 2026.