### PR TITLE
Backend: patternGroup

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/SkyBlockXPApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/SkyBlockXPApi.kt
@@ -17,19 +17,19 @@ import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 @SkyHanniModule
 object SkyBlockXPApi {
 
-    private val group = RepoPattern.group("skyblockxpapi.inventory")
+    private val patternGroup = RepoPattern.group("skyblockxpapi.inventory")
 
-    private val itemNamePattern by group.pattern("itemname", "§aSkyBlock Leveling")
+    private val itemNamePattern by patternGroup.pattern("itemname", "§aSkyBlock Leveling")
 
     /**
      * REGEX-TEST: §7Your SkyBlock Level: §8[§9287§8]
      */
-    private val levelPattern by group.pattern("level", "§7Your SkyBlock Level: §8\\[§.(?<level>\\d+)§8\\]")
+    private val levelPattern by patternGroup.pattern("level", "§7Your SkyBlock Level: §8\\[§.(?<level>\\d+)§8\\]")
 
     /**
      * REGEX-TEST: §3§l§m      §f§l§m                   §r §b24§3/§b100 §bXP
      */
-    private val xpPattern by group.pattern("xp", "[§\\w\\s]+§b(?<xp>\\d+)§3\\/§b100 §bXP")
+    private val xpPattern by patternGroup.pattern("xp", "[§\\w\\s]+§b(?<xp>\\d+)§3\\/§b100 §bXP")
 
     val levelXPPair get() = storage?.toLevelXPPair()
 

--- a/src/main/java/at/hannibal2/skyhanni/data/CalendarApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/CalendarApi.kt
@@ -20,7 +20,6 @@ import kotlin.time.Duration
 
 @SkyHanniModule
 object CalendarApi {
-    private val group = RepoPattern.group("calendarapi")
 
     var inMainCalendar = false
         private set
@@ -32,10 +31,12 @@ object CalendarApi {
     var calendarMonth = 0
         private set
 
+    private val patternGroup = RepoPattern.group("calendarapi")
+
     /**
      * REGEX-TEST: Calendar and Events
      */
-    private val calendarGuiPattern by group.pattern(
+    private val calendarGuiPattern by patternGroup.pattern(
         "gui",
         "Calendar and Events",
     )
@@ -50,7 +51,7 @@ object CalendarApi {
      * REGEX-TEST: Winter, Year 498
      * REGEX-TEST: Late Winter, Year 498
      */
-    private val calendarSeasonPattern by group.pattern(
+    private val calendarSeasonPattern by patternGroup.pattern(
         "date",
         "(?<season>(?:Early |Late )?(?:Spring|Summer|Autumn|Winter)), Year (?<year>\\d+)"
     )
@@ -60,7 +61,7 @@ object CalendarApi {
      * REGEX-TEST: Day 2
      * REGEX-TEST: Day 1
      */
-    val dayHeaderPattern by group.pattern(
+    val dayHeaderPattern by patternGroup.pattern(
         "day-header",
         "Day (?<dayNum>\\d+)"
     )
@@ -75,7 +76,7 @@ object CalendarApi {
      * REGEX-TEST: 12:00 am-11:59 pm: Jacob's Farming Contest
      * REGEX-TEST: 12:00 am-12:41 am: 61,680th Dark Auction
      */
-    val eventLinePattern by group.pattern(
+    val eventLinePattern by patternGroup.pattern(
         "event-line",
         """^(?<timePrefix>.*?):\s+(?<eventName>.*?)(?:\s+\((?<countdown>\d+h)\))?$"""
     )
@@ -86,7 +87,7 @@ object CalendarApi {
      * REGEX-TEST: Starts in: 40s
      * REGEX-TEST: Starts in: 1d 2h 58m 40s
      */
-    val mainCalendarStartsInPattern by group.pattern(
+    val mainCalendarStartsInPattern by patternGroup.pattern(
         "main.startsin",
         "Starts in: (?<time>(?:\\d\\d?[dhms] ?)+)"
     )
@@ -95,7 +96,7 @@ object CalendarApi {
      * REGEX-TEST: Event lasts for 1h!
      * REGEX-TEST: Event lasts for 2h 40m!
      */
-    val mainCalendarDurationPattern by group.pattern(
+    val mainCalendarDurationPattern by patternGroup.pattern(
         "main.duration",
         "Event lasts for (?<time>(?:\\d\\d?[hms] ?)+)!"
     )

--- a/src/main/java/at/hannibal2/skyhanni/data/ElectionApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/ElectionApi.kt
@@ -44,14 +44,15 @@ import kotlin.time.Duration.Companion.minutes
 
 @SkyHanniModule
 object ElectionApi {
-    private val group = RepoPattern.group("mayorapi")
     private val config get() = SkyHanniMod.feature.dev.debug
     private val assumeMayorConfig get() = config.assumeMayor
+
+    private val patternGroup = RepoPattern.group("mayorapi")
 
     /**
      * REGEX-TEST: Schedules an extra §bFishing Festival §7event during the year.
      */
-    val foxyExtraEventPattern by group.pattern(
+    val foxyExtraEventPattern by patternGroup.pattern(
         "foxy.extraevent",
         "Schedules an extra §.(?<event>.*) §.event during the year\\.",
     )
@@ -59,7 +60,7 @@ object ElectionApi {
     /**
      * REGEX-TEST: The election room is now closed. Clerk Seraphine is doing a final count of the votes...
      */
-    private val electionOverPattern by group.pattern(
+    private val electionOverPattern by patternGroup.pattern(
         "election.over",
         "§eThe election room is now closed\\. Clerk Seraphine is doing a final count of the votes\\.\\.\\.",
     )
@@ -68,7 +69,7 @@ object ElectionApi {
      * REGEX-TEST: §dMayor Jerry
      * REGEX-TEST: §cMayor Aatrox
      */
-    private val mayorHeadPattern by group.pattern(
+    private val mayorHeadPattern by patternGroup.pattern(
         "mayor.head",
         "§.Mayor (?<name>.*)",
     )
@@ -76,7 +77,7 @@ object ElectionApi {
     /**
      * REGEX-TEST: §9Perkpocalypse Perks:
      */
-    private val perkpocalypsePerksPattern by group.pattern(
+    private val perkpocalypsePerksPattern by patternGroup.pattern(
         "perkpocalypse",
         "§9Perkpocalypse Perks:",
     )

--- a/src/main/java/at/hannibal2/skyhanni/data/MiningApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/MiningApi.kt
@@ -44,28 +44,28 @@ import kotlin.time.Duration.Companion.seconds
 @SkyHanniModule
 object MiningApi {
 
-    private val group = RepoPattern.group("data.miningapi")
+    private val patternGroup = RepoPattern.group("data.miningapi")
 
     /**
      * REGEX-TEST: Glacite Tunnels
      * REGEX-TEST: Great Glacite Lake
      */
-    private val glaciteAreaPattern by group.pattern("area.glacite", "Glacite Tunnels|Great Glacite Lake")
-    private val dwarvenBaseCampPattern by group.pattern("area.basecamp", "Dwarven Base Camp")
+    private val glaciteAreaPattern by patternGroup.pattern("area.glacite", "Glacite Tunnels|Great Glacite Lake")
+    private val dwarvenBaseCampPattern by patternGroup.pattern("area.basecamp", "Dwarven Base Camp")
 
     /**
      * REGEX-TEST: Mines of Divan
      */
-    private val minesOfDivanPattern by group.pattern("area.minesofdivan", "Mines of Divan")
+    private val minesOfDivanPattern by patternGroup.pattern("area.minesofdivan", "Mines of Divan")
 
-    private val icyBiomePattern by group.pattern("area.icybiome", "Icy Biome")
+    private val icyBiomePattern by patternGroup.pattern("area.icybiome", "Icy Biome")
 
     /**
      * REGEX-TEST: §6The warmth of the campfire reduced your §r§b Cold §r§6to §r§a0§r§6!
      * REGEX-TEST: §c ☠ §r§7You froze to death§r§7.
      */
     @Suppress("MaxLineLength")
-    private val coldResetPattern by group.pattern(
+    private val coldResetPattern by patternGroup.pattern(
         "cold.reset",
         "§6The warmth of the campfire reduced your §r§b${SkyblockStat.COLD_RESISTANCE.hypixelIcon} Cold §r§6to §r§a0§r§6!|§c ☠ §r§7You froze to death§r§7\\.",
     )
@@ -76,7 +76,7 @@ object MiningApi {
      * REGEX-TEST: Heat: §c14♨
      * REGEX-TEST: Heat: §c0♨
      */
-    val heatPattern by group.pattern(
+    val heatPattern by patternGroup.pattern(
         "heat.scoreboard",
         "^Heat: (?<scoreboard>§.(?<heat>\\d+|IMMUNE)♨?)\$",
     )
@@ -86,12 +86,12 @@ object MiningApi {
      * REGEX-TEST: Cold: §b-1❄
      * REGEX-TEST: Cold: §b-3❄
      */
-    val coldPattern by group.pattern(
+    val coldPattern by patternGroup.pattern(
         "cold",
         "(?:§.)*Cold: §.(?<cold>-?\\d+)❄",
     )
 
-    private val pickobulusGroup = group.group("pickobulus")
+    private val pickobulusGroup = patternGroup.group("pickobulus")
 
     /**
      * REGEX-TEST: §aYou used your §r§6Pickobulus §r§aPickaxe Ability!

--- a/src/main/java/at/hannibal2/skyhanni/data/QuiverApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/QuiverApi.kt
@@ -69,8 +69,8 @@ object QuiverApi {
     var NONE_ARROW_TYPE: ArrowType? = null
     private var FLINT_ARROW_TYPE: ArrowType? = null
 
-    private val group = RepoPattern.group("data.quiver")
-    private val chatGroup = group.group("chat")
+    private val patternGroup = RepoPattern.group("data.quiver")
+    private val chatGroup = patternGroup.group("chat")
 
     /**
      * REGEX-TEST: §aYou set your selected arrow type to §r§fFlint Arrow§r§a!
@@ -121,13 +121,13 @@ object QuiverApi {
      * REGEX-TEST: BOSS_SPIRIT_BOW
      * REGEX-TEST: CRYPT_BOW
      */
-    private val fakeBowsPattern by group.pattern("fakebows", "BOSS_SPIRIT_BOW|CRYPT_BOW")
-    private val quiverInventoryNamePattern by group.pattern("quivername", "Quiver")
+    private val fakeBowsPattern by patternGroup.pattern("fakebows", "BOSS_SPIRIT_BOW|CRYPT_BOW")
+    private val quiverInventoryNamePattern by patternGroup.pattern("quivername", "Quiver")
 
     /**
      * REGEX-TEST: Active Arrow: Flint Arrow (2880)
      */
-    private val quiverInventoryPattern by group.pattern(
+    private val quiverInventoryPattern by patternGroup.pattern(
         "quiver.inventory",
         "Active Arrow: (?<type>.*) \\((?<amount>[\\d,]+)\\)",
     )
@@ -135,7 +135,7 @@ object QuiverApi {
     /**
      * REGEX-TEST: Arrows Remaining: 1,327
      */
-    private val quiverPreviewAmountPattern by group.pattern(
+    private val quiverPreviewAmountPattern by patternGroup.pattern(
         "quiver.preview.amount",
         "Arrows Remaining: (?<amount>[\\d,]+)",
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/achievements/AchievementManager.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/achievements/AchievementManager.kt
@@ -40,7 +40,7 @@ import net.minecraft.world.item.Items
 object AchievementManager {
     private val config get() = SkyHanniMod.achievementStorage.achievements
     val shouldShowMessages get() = SkyHanniMod.feature.misc.achievementMessages
-    val group = RepoPattern.group("achievements")
+    val patternGroup = RepoPattern.group("achievements")
     private val achievementSound = SoundUtils.createSound("ui.toast.challenge_complete", 1f, .8f, isWarning = false)
 
     @HandleEvent

--- a/src/main/java/at/hannibal2/skyhanni/features/achievements/BestiaryAchievement.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/achievements/BestiaryAchievement.kt
@@ -17,7 +17,7 @@ object BestiaryAchievement {
      * REGEX-TEST: Bestiary Milestone CCCXX
      * REGEX-TEST: Bestiary Milestone 320
      */
-    private val bestiaryPattern by AchievementManager.group.pattern(
+    private val bestiaryPattern by AchievementManager.patternGroup.pattern(
         "bestiary",
         "Bestiary Milestone (?<milestone>.*)",
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/achievements/BlizzardAchievement.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/achievements/BlizzardAchievement.kt
@@ -15,7 +15,7 @@ object BlizzardAchievement {
     /**
      * REGEX-TEST: BLIZZARD! [MVP+] Throwpo opened a Blizzard in a Bottle, improving everyone's Fishing Stats for the next 10 minutes and causing it to snow!
      */
-    private val blizzardPattern by AchievementManager.group.pattern(
+    private val blizzardPattern by AchievementManager.patternGroup.pattern(
         "blizzard",
         "BLIZZARD! (?<name>.*) opened a Blizzard in a Bottle, improving everyone's " +
             "Fishing Stats for the next 10 minutes and causing it to snow!",

--- a/src/main/java/at/hannibal2/skyhanni/features/achievements/BoopAchievement.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/achievements/BoopAchievement.kt
@@ -20,7 +20,7 @@ object BoopAchievement {
      * REGEX-TEST: To [MVP+] Bloxigus: Boop!
      * REGEX-TEST: To qtLuna: Boop!
      */
-    private val boopPattern by AchievementManager.group.pattern(
+    private val boopPattern by AchievementManager.patternGroup.pattern(
         "boop",
         "To .*: Boop!",
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/achievements/CakeSoulAchievement.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/achievements/CakeSoulAchievement.kt
@@ -14,7 +14,7 @@ import net.minecraft.network.chat.Component
 @SkyHanniModule
 object CakeSoulAchievement {
 
-    private val cakeSoulPattern by AchievementManager.group.pattern(
+    private val cakeSoulPattern by AchievementManager.patternGroup.pattern(
         "cake-soul",
         "You found a Cake Soul!",
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/achievements/DungeonsAchievements.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/achievements/DungeonsAchievements.kt
@@ -15,7 +15,7 @@ object DungeonsAchievements {
     /**
      * REGEX-TEST: RNG METER! Reselected the Enchanted Book (Rejuvenate I) for Catacombs - Floor 1! CLICK HERE to select a new drop!
      */
-    private val woodRngPattern by AchievementManager.group.pattern(
+    private val woodRngPattern by AchievementManager.patternGroup.pattern(
         "wood-rng",
         "RNG METER! Reselected the Enchanted Book \\((?:Rejuvenate I|Infinite Quiver VI|Feather Falling VI|Bank I|Ultimate Jerry I)\\) for Catacombs - Floor 1! CLICK HERE to select a new drop!",
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/achievements/EggAchievement.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/achievements/EggAchievement.kt
@@ -12,7 +12,7 @@ import at.hannibal2.skyhanni.utils.chat.TextHelper.asComponent
 @SkyHanniModule
 object EggAchievement {
 
-    private val eggPatternPattern by AchievementManager.group.pattern(
+    private val eggPatternPattern by AchievementManager.patternGroup.pattern(
         "laid-egg",
         "You laid an egg!",
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/achievements/HeavyPearlAchievement.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/achievements/HeavyPearlAchievement.kt
@@ -10,12 +10,12 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matches
 @SkyHanniModule
 object HeavyPearlAchievement {
 
-    private val allCollectedPattern by AchievementManager.group.pattern(
+    private val allCollectedPattern by AchievementManager.patternGroup.pattern(
         "pearls.allcollected",
         "Find a way to reach the top of the stomach!",
     )
 
-    private val bonusPattern by AchievementManager.group.pattern(
+    private val bonusPattern by AchievementManager.patternGroup.pattern(
         "pearls.bonus",
         "Your Matriarch Cubs attribute has granted you 1 additional Heavy Pearl!",
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/achievements/HoppityAchievements.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/achievements/HoppityAchievements.kt
@@ -18,7 +18,7 @@ object HoppityAchievements {
     /**
      * REGEX-TEST: Rabbits Found: 95.7%
      */
-    private val rabbitsFoundPattern by AchievementManager.group.pattern(
+    private val rabbitsFoundPattern by AchievementManager.patternGroup.pattern(
         "rabbits-found",
         "Rabbits Found: (?<percent>[\\d.]+)%",
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/achievements/NpcSellLimitAchievement.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/achievements/NpcSellLimitAchievement.kt
@@ -10,7 +10,7 @@ import at.hannibal2.skyhanni.utils.RegexUtils.matches
 @SkyHanniModule
 object NpcSellLimitAchievement {
 
-    private val sellLimitPattern by AchievementManager.group.pattern(
+    private val sellLimitPattern by AchievementManager.patternGroup.pattern(
         "npc-sell-limit",
         "You've reached the daily limit of coins you may earn from NPC shops\\.",
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/achievements/PetAchievements.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/achievements/PetAchievements.kt
@@ -22,7 +22,7 @@ object PetAchievements {
     /**
      * REGEX-TEST: Your Pet Score: 435
      */
-    private val petScorePattern by AchievementManager.group.pattern(
+    private val petScorePattern by AchievementManager.patternGroup.pattern(
         "pet-score",
         "Your Pet Score: (?<score>\\d+)",
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/achievements/RecipeAchievement.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/achievements/RecipeAchievement.kt
@@ -17,7 +17,7 @@ object RecipeAchievement {
     /**
      * REGEX-TEST: Recipe Book Unlocked: 98.6%
      */
-    private val recipeBookPattern by AchievementManager.group.pattern(
+    private val recipeBookPattern by AchievementManager.patternGroup.pattern(
         "recipe-book",
         "Recipe Book Unlocked: (?<percent>[\\d.]+)%"
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/achievements/SealAchievement.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/achievements/SealAchievement.kt
@@ -14,7 +14,7 @@ object SealAchievement {
     /**
      * REGEX-TEST: INSANE! You kept the Bouncy Beach Ball in the air for 187 bounces and earned 20 Fishy Treats!
      */
-    private val sealBouncePattern by AchievementManager.group.pattern(
+    private val sealBouncePattern by AchievementManager.patternGroup.pattern(
         "seal-bounce",
         "INSANE! You kept the Bouncy Beach Ball in the air for (?<bounces>\\d+) bounces and earned \\d+ Fishy Treats!",
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/achievements/SiriusAchievement.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/achievements/SiriusAchievement.kt
@@ -14,7 +14,7 @@ object SiriusAchievement {
     /**
      * REGEX-TEST: [NPC] Lucius: You've purchased 15 items from the Dark Auction.
      */
-    private val daItemsPattern by AchievementManager.group.pattern(
+    private val daItemsPattern by AchievementManager.patternGroup.pattern(
         "da-item-count",
         "\\[NPC] Lucius: You've purchased (?<count>\\d+) items from the Dark Auction.",
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/achievements/SkillAchievements.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/achievements/SkillAchievements.kt
@@ -26,7 +26,7 @@ object SkillAchievements {
     /**
      * REGEX-TEST: Ores mined: 2,449,790
      */
-    private val oresPattern by AchievementManager.group.pattern(
+    private val oresPattern by AchievementManager.patternGroup.pattern(
         "ores",
         "Ores mined: (?<amount>[\\d,]+)",
     )
@@ -34,7 +34,7 @@ object SkillAchievements {
     /**
      * REGEX-TEST: Sea Creatures killed: 63,641
      */
-    private val seaCreaturesPattern by AchievementManager.group.pattern(
+    private val seaCreaturesPattern by AchievementManager.patternGroup.pattern(
         "sea-creatures",
         "Sea Creatures killed: (?<amount>[\\d,]+)",
     )
@@ -43,7 +43,7 @@ object SkillAchievements {
      * REGEX-TEST: Fishing Skill
      * REGEX-TEST: Mining Skill
      */
-    private val petSkillMenuPattern by AchievementManager.group.pattern(
+    private val petSkillMenuPattern by AchievementManager.patternGroup.pattern(
         "pet-skill-menu",
         "(?:Fishing|Mining) Skill",
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/achievements/SlayerAchievements.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/achievements/SlayerAchievements.kt
@@ -19,7 +19,7 @@ object SlayerAchievements {
     /**
      * WRAPPED-REGEX-TEST: "   RNG Meter - 728,269 Stored XP"
      */
-    private val rngMeterPattern by AchievementManager.group.pattern(
+    private val rngMeterPattern by AchievementManager.patternGroup.pattern(
         "rng-meter",
         "\\s*RNG Meter - (?<xp>[\\d,]+) Stored XP",
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/achievements/SowdustAchievement.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/achievements/SowdustAchievement.kt
@@ -15,7 +15,7 @@ object SowdustAchievement {
     /**
      * WRAPPED-REGEX-TEST: " - 250,000,000 Sowdust"
      */
-    private val maxSowdustPattern by AchievementManager.group.pattern(
+    private val maxSowdustPattern by AchievementManager.patternGroup.pattern(
         "sowdust",
         " - 250,000,000 Sowdust",
     )
@@ -23,7 +23,7 @@ object SowdustAchievement {
     /**
      * REGEX-TEST: Manage Chips
      */
-    private val manageChipsInventoryPattern by AchievementManager.group.pattern(
+    private val manageChipsInventoryPattern by AchievementManager.patternGroup.pattern(
         "manage-chips-inventory",
         "Manage Chips",
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/achievements/SpookyAchievement.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/achievements/SpookyAchievement.kt
@@ -17,7 +17,7 @@ object SpookyAchievement {
     /**
      * WRAPPED-REGEX-TEST: "                   Your Candy: 4,036 (Position #342)"
      */
-    private val candyPattern by AchievementManager.group.pattern(
+    private val candyPattern by AchievementManager.patternGroup.pattern(
         "spooky-candy",
         " +Your Candy: (?<candy>[\\d,]+) \\(Position #[\\d,]+\\)"
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/achievements/StarCultAchievement.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/achievements/StarCultAchievement.kt
@@ -15,7 +15,7 @@ object StarCultAchievement {
      * REGEX-TEST: [NPC] Dalir: You’ve now attended 8 meetings of the Cult of the Fallen Star! As a reward, here's some Starfall!
      * REGEX-TEST: [NPC] Dalir: You’ve now attended 4 meetings of the Cult of the Fallen Star! As a reward, here's some Starfall!
      */
-    private val starCultPattern by AchievementManager.group.pattern(
+    private val starCultPattern by AchievementManager.patternGroup.pattern(
         "starcult",
         "\\[NPC] Dalir: You’ve now attended (?<amount>\\d+) meetings of the Cult of the Fallen Star!" +
             " As a reward, here's some Starfall!"

--- a/src/main/java/at/hannibal2/skyhanni/features/achievements/VanquisherAchievement.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/achievements/VanquisherAchievement.kt
@@ -17,7 +17,7 @@ object VanquisherAchievement {
     /**
      * REGEX-TEST: A Vanquisher is spawning nearby!
      */
-    private val vanquisherSpawnPattern by AchievementManager.group.pattern(
+    private val vanquisherSpawnPattern by AchievementManager.patternGroup.pattern(
         "vanquisher",
         "A Vanquisher is spawning nearby!",
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/achievements/VincentAchievement.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/achievements/VincentAchievement.kt
@@ -15,7 +15,7 @@ object VincentAchievement {
     /**
      * REGEX-TEST: Vincent accepts your rose and is delighted to visit your Garden soon.
      */
-    private val vincentPattern by AchievementManager.group.pattern(
+    private val vincentPattern by AchievementManager.patternGroup.pattern(
         "vincent",
         "Vincent accepts your rose and is delighted to visit your Garden soon.",
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/end/DragonFightAPI.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/end/DragonFightAPI.kt
@@ -20,12 +20,12 @@ object DragonFightAPI {
     var currentHp: Int? = null
     private var yourDamage: Int? = null
 
-    private val group = RepoPattern.group("combat.end-dragon-fight")
+    private val patternGroup = RepoPattern.group("combat.end-dragon-fight")
 
     /**
      * REGEX-TEST: §5☬ §r§d§lThe §r§5§c§lOld Dragon§r§d§l has spawned!§r
      */
-    private val chatSpawnPattern by group.pattern(
+    private val chatSpawnPattern by patternGroup.pattern(
         "chat.spawn",
         "§5☬ §r§d§lThe §r§5§c§l(?<type>.*)§r§d§l has spawned!§r",
     )
@@ -33,7 +33,7 @@ object DragonFightAPI {
     /**
      * REGEX-TEST: §r§f                           §r§6§lOLD DRAGON DOWN!§r
      */
-    private val chatDeath by group.pattern(
+    private val chatDeath by patternGroup.pattern(
         "chat.death",
         "§r§f {27}§r§6§l(?<type>.*) DOWN!§r",
     )
@@ -41,7 +41,7 @@ object DragonFightAPI {
     /**
      * REGEX-TEST: Dragon HP: 4,824,217 
      */
-    private val scoreboardHPPattern by group.pattern(
+    private val scoreboardHPPattern by patternGroup.pattern(
         "scoreboard.hp",
         "Dragon HP: (?<hp>.*) ${SkyblockStat.HEALTH.hypixelIcon}",
     )
@@ -49,12 +49,12 @@ object DragonFightAPI {
     /**
      * REGEX-TEST: Your Damage: 0
      */
-    private val scoreboardYourDamagePattern by group.pattern(
+    private val scoreboardYourDamagePattern by patternGroup.pattern(
         "scoreboard.your-damage",
         "Your Damage: (?<damage>[\\d.,]+)",
     )
 
-    private val nestAreaPattern by group.pattern("area.nest", "Dragon's Nest")
+    private val nestAreaPattern by patternGroup.pattern("area.nest", "Dragon's Nest")
 
     fun inNestArea() = IslandType.THE_END.isInIsland() && nestAreaPattern.matches(SkyBlockUtils.graphArea)
 

--- a/src/main/java/at/hannibal2/skyhanni/features/event/diana/DianaApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/event/diana/DianaApi.kt
@@ -50,7 +50,7 @@ object DianaApi {
     var sphinxQuestions = emptyMap<String, String>()
         private set
 
-    private val group = RepoPattern.group("event-diana")
+    private val patternGroup = RepoPattern.group("event-diana")
 
     /**
      * REGEX-TEST: Minos Inquisitor
@@ -58,7 +58,7 @@ object DianaApi {
      * REGEX-TEST: King Minos
      * REGEX-TEST: Manticore
      */
-    private val rareDianaMobNamePattern by group.pattern(
+    private val rareDianaMobNamePattern by patternGroup.pattern(
         "rare-mob-name",
         "(?:Minos Inquisitor|Sphinx|King Minos|Manticore)\\s*",
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/LogBookStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/inventory/LogBookStats.kt
@@ -19,12 +19,12 @@ import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 @SkyHanniModule
 object LogBookStats {
 
-    private val groupPattern = RepoPattern.group("garden.inventory.logbook")
+    private val patternGroup = RepoPattern.group("garden.inventory.logbook")
 
     /**
      * REGEX-TEST: Times Visited: 22
      */
-    private val visitedPattern by groupPattern.pattern(
+    private val visitedPattern by patternGroup.pattern(
         "visited.colorless",
         "Times Visited: (?<timesVisited>[0-9,.]+)",
     )
@@ -32,7 +32,7 @@ object LogBookStats {
     /**
      * REGEX-TEST: Offers Accepted: 21
      */
-    private val acceptedPattern by groupPattern.pattern(
+    private val acceptedPattern by patternGroup.pattern(
         "accepted.colorless",
         "Offers Accepted: (?<timesAccepted>[0-9,.]+)",
     )
@@ -42,7 +42,7 @@ object LogBookStats {
      * REGEX-TEST: (1/5) Visitor's Logbook
      * REGEX-TEST: (10/11) Visitor's Logbook
      */
-    private val inventoryNamePattern by groupPattern.pattern(
+    private val inventoryNamePattern by patternGroup.pattern(
         "inventory-name",
         "(?:\\(\\d+/\\d+\\) )?Visitor's Logbook",
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/BeaconPower.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/BeaconPower.kt
@@ -33,9 +33,9 @@ object BeaconPower {
     private val storage get() = ProfileStorageData.profileSpecific?.beaconPower
     private val config get() = SkyHanniMod.feature.gui
 
-    private val group = RepoPattern.group("gui.beaconpower-no-color")
+    private val patternGroup = RepoPattern.group("gui.beaconpower-no-color")
 
-    private val deactivatedPattern by group.pattern(
+    private val deactivatedPattern by patternGroup.pattern(
         "deactivated",
         "Beacon Deactivated - No Power Remaining",
     )
@@ -43,7 +43,7 @@ object BeaconPower {
     /**
      * REGEX-TEST: Power Remaining: 0d 5h 53m 12s
      */
-    private val timeRemainingPattern by group.pattern(
+    private val timeRemainingPattern by patternGroup.pattern(
         "time",
         "Power Remaining: (?<time>.+)",
     )
@@ -51,7 +51,7 @@ object BeaconPower {
     /**
      * REGEX-TEST: Current Stat: +5✯ Magic Find
      */
-    private val boostedStatPattern by group.pattern(
+    private val boostedStatPattern by patternGroup.pattern(
         "stat",
         "Current Stat: (?<stat>.+)",
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/gui/customscoreboard/ScoreboardPattern.kt
@@ -9,10 +9,10 @@ import java.util.regex.Pattern
 
 @SkyHanniModule
 object ScoreboardPattern {
-    private val group = RepoPattern.group("features.gui.customscoreboard")
+    private val patternGroup = RepoPattern.group("features.gui.customscoreboard")
 
     // Lines from the scoreboard
-    private val scoreboardGroup by group.exclusiveGroup("scoreboard")
+    private val scoreboardGroup by patternGroup.exclusiveGroup("scoreboard")
 
     @HandleEvent(RepositoryReloadEvent::class)
     fun onRepoReload() {
@@ -1003,7 +1003,7 @@ object ScoreboardPattern {
      * REGEX-TEST: §d᠅ §fGemstone§f
      * REGEX-TEST: §d᠅ §fGemstone§f§e(+1)
      */
-    val brokenPatterns by group.list(
+    val brokenPatterns by patternGroup.list(
         "broken",
         "\\s*§.§l⚡ §cRedston",
         "\\s*§ce: §e§b\\d+%",
@@ -1012,7 +1012,7 @@ object ScoreboardPattern {
     )
 
     // Lines from the tablist
-    private val tablistGroup = group.group("tablist-no-color")
+    private val tablistGroup = patternGroup.group("tablist-no-color")
 
     /**
      * WRAPPED-REGEX-TEST: " Ends In: 27h"

--- a/src/main/java/at/hannibal2/skyhanni/features/inventory/PersonalCompactorOverlay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/inventory/PersonalCompactorOverlay.kt
@@ -33,13 +33,13 @@ object PersonalCompactorOverlay {
 
     private val config get() = SkyHanniMod.feature.inventory.personalCompactor
 
-    private val group = RepoPattern.group("inventory.personalcompactor")
+    private val patternGroup = RepoPattern.group("inventory.personalcompactor")
 
     /**
      * REGEX-TEST: PERSONAL_COMPACTOR_4000
      * REGEX-TEST: PERSONAL_DELETOR_7000
      */
-    private val internalNamePattern by group.pattern(
+    private val internalNamePattern by patternGroup.pattern(
         "internalname",
         "PERSONAL_(?<type>[^_]+)_(?<tier>\\d+)",
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/MineshaftPityDisplay.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/MineshaftPityDisplay.kt
@@ -99,13 +99,12 @@ object MineshaftPityDisplay {
 
     private const val MAX_COUNTER = 2000
 
-    private val group = RepoPattern.group("mineshaft.pity")
-
+    private val patternGroup = RepoPattern.group("mineshaft.pity")
 
     /**
      * WRAPPED-REGEX-TEST: " Glacite Mineshafts: 124/2,000"
      */
-    private val tabPityPattern by group.pattern(
+    private val tabPityPattern by patternGroup.pattern(
         "tablist",
         " Glacite Mineshafts: (?<pity>[\\d,]+)/2,000",
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalHollowsFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalHollowsFinder.kt
@@ -1,0 +1,104 @@
+package at.hannibal2.skyhanni.features.mining.crystalhollows
+
+import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.config.commands.CommandCategory
+import at.hannibal2.skyhanni.config.commands.CommandRegistrationEvent
+import at.hannibal2.skyhanni.data.IslandGraphs
+import at.hannibal2.skyhanni.data.IslandType
+import at.hannibal2.skyhanni.data.model.graph.Graph
+import at.hannibal2.skyhanni.data.model.graph.GraphNode
+import at.hannibal2.skyhanni.events.entity.EntityMoveEvent
+import at.hannibal2.skyhanni.features.misc.pathfind.AreaNode
+import at.hannibal2.skyhanni.features.misc.pathfind.IslandAreaBackend.getAreaTag
+import at.hannibal2.skyhanni.features.misc.pathfind.NavigateAllApi
+import at.hannibal2.skyhanni.features.misc.pathfind.NavigationCondition
+import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
+import at.hannibal2.skyhanni.utils.ChatUtils
+import at.hannibal2.skyhanni.utils.GraphUtils
+import at.hannibal2.skyhanni.utils.LorenzColor
+import at.hannibal2.skyhanni.utils.SimpleTimeMark
+import at.hannibal2.skyhanni.utils.collection.CollectionUtils.sorted
+import net.minecraft.client.player.LocalPlayer
+
+@SkyHanniModule
+object CrystalHollowsFinder {
+
+
+    @HandleEvent(onlyOnSkyblock = true)
+    private fun onLocalPlayerMove(event: EntityMoveEvent<LocalPlayer>) {
+        println("player move event")
+    }
+
+    @HandleEvent
+    private fun onCommandRegistration(event: CommandRegistrationEvent) {
+        event.registerBrigadier("shfindch") {
+            description = "Resets the Foraging Tracker."
+            category = CommandCategory.USERS_RESET
+            simpleCallback { doCommand() }
+        }
+    }
+
+    private fun doCommand() {
+        if (!IslandType.CRYSTAL_HOLLOWS.isInIsland()) {
+            ChatUtils.userError("Only works in Crystal Hollows!")
+            return
+        }
+        val graph = IslandGraphs.currentIslandGraph ?: run {
+            ChatUtils.userError("currentIslandGraph is null")
+            return
+        }
+
+        val closestNode = IslandGraphs.closestNode ?: run {
+            ChatUtils.userError("closestNode is null")
+            return
+        }
+
+        val name = abc(graph, closestNode)
+
+        val areaName = "Goblin Holdout"
+
+        ChatUtils.chat("first: $name")
+        val start = SimpleTimeMark.now()
+        val found = mutableListOf<GraphNode>()
+        for (node in graph) {
+            if (abc(graph, node) == "Goblin Holdout") {
+                found.add(node)
+            }
+        }
+        println(    "done checking nodes in ${start.passedSince()}")
+        if (found.isEmpty()) {
+            ChatUtils.userError("No $areaName nodes found!")
+            return
+        }
+        ChatUtils.chat("start navigating to all ${found.size} nodes of $areaName")
+
+        NavigateAllApi.navigateAll(
+            found,
+            "lol",
+            LorenzColor.LIGHT_PURPLE.toColor(),
+            onFinish = {
+                ChatUtils.chat("done")
+            },
+            continueNavigationCondition = NavigationCondition.None,
+            condition = { true },
+        )
+    }
+
+    private fun abc(
+        graph: Graph,
+        closestNode: GraphNode,
+    ): String? {
+        val (_, map) = GraphUtils.findFastestPaths(graph, closestNode) { it.getAreaTag() != null }
+        val seenAreas = mutableSetOf<String>()
+        val sorted = map.sorted()
+        val areaNodes = sorted.mapNotNull { (node, distance) ->
+            val name = node.name?.takeIf { it !in seenAreas } ?: return@mapNotNull null
+            val tag = node.getAreaTag() ?: return@mapNotNull null
+            seenAreas += name
+            AreaNode(node, name, tag, distance)
+        }
+        return areaNodes.firstOrNull()?.let {
+            it.name
+        }
+    }
+}

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalHollowsFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/crystalhollows/CrystalHollowsFinder.kt
@@ -65,7 +65,7 @@ object CrystalHollowsFinder {
                 found.add(node)
             }
         }
-        println(    "done checking nodes in ${start.passedSince()}")
+        println("done checking nodes in ${start.passedSince()}")
         if (found.isEmpty()) {
             ChatUtils.userError("No $areaName nodes found!")
             return

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/ColorfulItemStats.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/ColorfulItemStats.kt
@@ -14,7 +14,7 @@ import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 object ColorfulItemStats {
     private val config get() = SkyHanniMod.feature.misc.colorfulItemTooltips
 
-    private val group = RepoPattern.group("misc.itemstats")
+    private val patternGroup = RepoPattern.group("misc.itemstats")
 
     /**
      * REGEX-TEST: Crit Chance: +30%
@@ -23,7 +23,7 @@ object ColorfulItemStats {
      * REGEX-TEST: Strength: +60 (+20) (+40) (+199.2)
      * REGEX-FAIL: Health: +1000❤
      */
-    private val genericStat by group.pattern(
+    private val genericStat by patternGroup.pattern(
         "generic-stats-no-color",
         "(?<stat>[a-zA-Z ]+): (?<bonus>[-+]?[\\d.,%s]+)(?:\\s|$)",
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/misc/GFSPiggyBank.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/misc/GFSPiggyBank.kt
@@ -16,12 +16,12 @@ object GFSPiggyBank {
 
     private val ENCHANTED_PORK by lazy { "ENCHANTED_PORK".toInternalName().makePrimitiveStack(8) }
 
-    private val group = RepoPattern.group("misc.piggybank")
+    private val patternGroup = RepoPattern.group("misc.piggybank")
 
     /**
      * REGEX-TEST: §cYou died and your piggy bank cracked!
      */
-    private val crackedPattern by group.pattern(
+    private val crackedPattern by patternGroup.pattern(
         "cracked",
         "§cYou died and your piggy bank cracked!",
     )
@@ -29,7 +29,7 @@ object GFSPiggyBank {
     /**
      * REGEX-TEST: §cYou died, lost 50,000 coins and your piggy bank broke!
      */
-    private val brokePattern by group.pattern(
+    private val brokePattern by patternGroup.pattern(
         "broke",
         "§cYou died, lost [\\d.,]* coins and your piggy bank broke!",
     )

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/colosseum/BacteApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/colosseum/BacteApi.kt
@@ -15,13 +15,13 @@ import at.hannibal2.skyhanni.utils.repopatterns.RepoPattern
 @SkyHanniModule
 object BacteApi {
 
-    private val group = RepoPattern.group("rift.colosseum.bacte")
+    private val patternGroup = RepoPattern.group("rift.colosseum.bacte")
 
     /**
      * REGEX-TEST: §2﴾ §8[§7Lv10§8] §l§aBa§r §a800§f/§a1,000§c §2﴿
      */
     @Suppress("MaxLineLength")
-    private val namePattern by group.pattern(
+    private val namePattern by patternGroup.pattern(
         "name",
         "§2﴾ §8\\[§7Lv\\d+§8\\] §l§a(?<name>.*)§r §.[\\d.,]+§f\\/§a[\\d.,]+§c${SkyblockStat.HEALTH.hypixelIcon} §2﴿",
     )
@@ -30,7 +30,7 @@ object BacteApi {
      * REGEX-TEST: §aBac §r§eis growing into §r§aBact§r§e!
      * REGEX-TEST: §aB §r§eis growing into §r§aBa§r§e!
      */
-    private val nameChatPattern by group.pattern(
+    private val nameChatPattern by patternGroup.pattern(
         "chat.name",
         "§a(?<previousName>.*) §r§eis growing into §r§a(?<name>.*)§r§e!",
     )


### PR DESCRIPTION
## What
renamed all initial instances of RepoPatternGroup `patternGroup`.
Because consistency.

# reminder to future me: move the unrealted changed file into a new pr!!

## Changelog Technical Details
+ Renamed most variables of RepoPatternGroup. - hannibal2