### PR TITLE
Backend: Disable FallenStarCultConfig by default

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/mining/dwarves/FallenStarCultConfig.kt
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/mining/dwarves/FallenStarCultConfig.kt
@@ -16,7 +16,7 @@ class FallenStarCultConfig {
     )
     @ConfigEditorBoolean
     @FeatureToggle
-    var enabled: Boolean = true
+    var enabled: Boolean = false
 
     @Expose
     @ConfigOption(


### PR DESCRIPTION
## What
It shouldn't be default enabled. :pleading_face: 
exclude_from_changelog