### PR TITLE
Fix: Harvest in-season crops timer not updating.

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/elitedev/EliteFeastJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/elitedev/EliteFeastJson.kt
@@ -44,8 +44,8 @@ data class EliteFeastJson(
 
 @KSerializable
 data class EliteFeastData(
-    @Expose var year: Int,
-    @Expose var month: Int,
+    @Expose val year: Int,
+    @Expose val month: Int,
     @Expose val complete: Boolean,
     @Expose val current: List<String>,
     @Expose @SerializedName("next") private val _next: Map<String, Long?>,

--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/elitedev/EliteFeastJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/elitedev/EliteFeastJson.kt
@@ -44,8 +44,8 @@ data class EliteFeastJson(
 
 @KSerializable
 data class EliteFeastData(
-    @Expose val year: Int,
-    @Expose val month: Int,
+    @Expose var year: Int,
+    @Expose var month: Int,
     @Expose val complete: Boolean,
     @Expose val current: List<String>,
     @Expose @SerializedName("next") private val _next: Map<String, Long?>,
@@ -53,8 +53,12 @@ data class EliteFeastData(
 ) {
     val next: Map<String, SimpleTimeMark?> = _next.mapValues { it.value?.let(SimpleTimeMark::fromUnixSeconds) }
 
-    private val monthEndTime: SimpleTimeMark
-        get() = SkyBlockTime(year, month + 1, 1).toTimeMark()
+    private fun monthEndTime(): SimpleTimeMark {
+        val now = SkyBlockTime.now()
+        year = now.year
+        month = now.month
+        return SkyBlockTime(year, month + 1, 1).toTimeMark()
+    }
 
     fun getBody(): String = ApiUtils.serializeNullsGson.toJson(this)
 
@@ -68,12 +72,12 @@ data class EliteFeastData(
     }
 
     fun getActiveDuration(): Duration {
-        if (next.values.all { it == null }) return monthEndTime.timeUntil()
+        if (next.values.all { it == null }) return monthEndTime().timeUntil()
 
         return getDurations()
             .filter(Duration::isPositive)
             .minByOrNull { it.inWholeMilliseconds }
-            ?: monthEndTime.timeUntil()
+            ?: monthEndTime().timeUntil()
     }
 
     fun getCurrentCrops(): List<CropType> {

--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/elitedev/EliteFeastJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/elitedev/EliteFeastJson.kt
@@ -53,12 +53,11 @@ data class EliteFeastData(
 ) {
     val next: Map<String, SimpleTimeMark?> = _next.mapValues { it.value?.let(SimpleTimeMark::fromUnixSeconds) }
 
-    private fun monthEndTime(): SimpleTimeMark {
-        val now = SkyBlockTime.now()
-        year = now.year
-        month = now.month
-        return SkyBlockTime(year, month + 1, 1).toTimeMark()
-    }
+    private val monthEndTime: SimpleTimeMark
+        get() {
+            val now = SkyBlockTime.now()
+            return SkyBlockTime(now.year, now.month + 1, 1).toTimeMark()
+        }
 
     fun getBody(): String = ApiUtils.serializeNullsGson.toJson(this)
 
@@ -72,12 +71,12 @@ data class EliteFeastData(
     }
 
     fun getActiveDuration(): Duration {
-        if (next.values.all { it == null }) return monthEndTime().timeUntil()
+        if (next.values.all { it == null }) return monthEndTime.timeUntil()
 
         return getDurations()
             .filter(Duration::isPositive)
             .minByOrNull { it.inWholeMilliseconds }
-            ?: monthEndTime().timeUntil()
+            ?: monthEndTime.timeUntil()
     }
 
     fun getCurrentCrops(): List<CropType> {


### PR DESCRIPTION
## What
Fixed the current month used by the timer's "end of month" variable only updating when you open the 'all crops' menu in Feast Chef Ted. It now generates the current month directly from SkyBlockTime.now() whenever required.

## Changelog Fixes
+ Fixed the Harvest Feast in-season timer sometimes incorrectly displaying 'soon'. - VK3DNS
    * Occurred after a month change until Feast Chef Ted's 'All Crops' menu was opened.