### PR TITLE
Backend: No Tick Event to get Max Health updates

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/api/DataWatcherApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/DataWatcherApi.kt
@@ -2,35 +2,21 @@ package at.hannibal2.skyhanni.api
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.ElectionApi.derpy
+import at.hannibal2.skyhanni.data.EntityData
 import at.hannibal2.skyhanni.events.DataWatcherUpdatedEvent
 import at.hannibal2.skyhanni.events.entity.EntityCustomNameUpdateEvent
 import at.hannibal2.skyhanni.events.entity.EntityHealthUpdateEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.EntityUtils
-import net.minecraft.client.player.LocalPlayer
-import net.minecraft.client.player.RemotePlayer
 import net.minecraft.world.entity.Entity
-import net.minecraft.world.entity.ExperienceOrb
 import net.minecraft.world.entity.LivingEntity
 import net.minecraft.world.entity.boss.wither.WitherBoss
-import net.minecraft.world.entity.decoration.ArmorStand
-import net.minecraft.world.entity.decoration.ItemFrame
-import net.minecraft.world.entity.item.ItemEntity
 
 @SkyHanniModule
 object DataWatcherApi {
 
-    private val ignoredEntities = setOf(
-        ArmorStand::class.java,
-        ExperienceOrb::class.java,
-        ItemEntity::class.java,
-        ItemFrame::class.java,
-        RemotePlayer::class.java,
-        LocalPlayer::class.java,
-    )
-
     @HandleEvent
-    fun onDataWatcherUpdate(event: DataWatcherUpdatedEvent<Entity>) {
+    private fun onDataWatcherUpdate(event: DataWatcherUpdatedEvent<Entity>) {
         for (updatedEntry in event.updatedEntries) {
             if (updatedEntry.accessor == Entity.DATA_CUSTOM_NAME) {
                 EntityCustomNameUpdateEvent(event.entity, event.entity.customName).post()
@@ -40,7 +26,7 @@ object DataWatcherApi {
                 val health = (updatedEntry.value as? Float)?.toInt() ?: continue
 
                 val entity = EntityUtils.getEntityByID(event.entity.id) ?: continue
-                if (entity.javaClass in ignoredEntities) continue
+                if (entity.javaClass in EntityData.ignoredEntities) continue
 
                 if (event.entity is WitherBoss && health == 300 && event.entity.id < 0) continue
                 if (event.entity is LivingEntity) {

--- a/src/main/java/at/hannibal2/skyhanni/api/DataWatcherApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/DataWatcherApi.kt
@@ -2,7 +2,6 @@ package at.hannibal2.skyhanni.api
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.ElectionApi.derpy
-import at.hannibal2.skyhanni.data.EntityData
 import at.hannibal2.skyhanni.events.DataWatcherUpdatedEvent
 import at.hannibal2.skyhanni.events.entity.EntityCustomNameUpdateEvent
 import at.hannibal2.skyhanni.events.entity.EntityHealthUpdateEvent

--- a/src/main/java/at/hannibal2/skyhanni/api/DataWatcherApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/DataWatcherApi.kt
@@ -8,12 +8,27 @@ import at.hannibal2.skyhanni.events.entity.EntityCustomNameUpdateEvent
 import at.hannibal2.skyhanni.events.entity.EntityHealthUpdateEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.EntityUtils
+import net.minecraft.client.player.LocalPlayer
+import net.minecraft.client.player.RemotePlayer
 import net.minecraft.world.entity.Entity
+import net.minecraft.world.entity.ExperienceOrb
 import net.minecraft.world.entity.LivingEntity
 import net.minecraft.world.entity.boss.wither.WitherBoss
+import net.minecraft.world.entity.decoration.ArmorStand
+import net.minecraft.world.entity.decoration.ItemFrame
+import net.minecraft.world.entity.item.ItemEntity
 
 @SkyHanniModule
 object DataWatcherApi {
+
+    val ignoredEntities = setOf(
+        ArmorStand::class.java,
+        ExperienceOrb::class.java,
+        ItemEntity::class.java,
+        ItemFrame::class.java,
+        RemotePlayer::class.java,
+        LocalPlayer::class.java,
+    )
 
     @HandleEvent
     private fun onDataWatcherUpdate(event: DataWatcherUpdatedEvent<Entity>) {
@@ -26,7 +41,7 @@ object DataWatcherApi {
                 val health = (updatedEntry.value as? Float)?.toInt() ?: continue
 
                 val entity = EntityUtils.getEntityByID(event.entity.id) ?: continue
-                if (entity.javaClass in EntityData.ignoredEntities) continue
+                if (entity.javaClass in ignoredEntities) continue
 
                 if (event.entity is WitherBoss && health == 300 && event.entity.id < 0) continue
                 if (event.entity is LivingEntity) {

--- a/src/main/java/at/hannibal2/skyhanni/api/DataWatcherApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/DataWatcherApi.kt
@@ -21,7 +21,7 @@ import net.minecraft.world.entity.item.ItemEntity
 @SkyHanniModule
 object DataWatcherApi {
 
-    val ignoredEntities = setOf(
+    private val ignoredEntities = setOf(
         ArmorStand::class.java,
         ExperienceOrb::class.java,
         ItemEntity::class.java,

--- a/src/main/java/at/hannibal2/skyhanni/api/VanquisherApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/VanquisherApi.kt
@@ -9,7 +9,7 @@ import at.hannibal2.skyhanni.events.MobEvent
 import at.hannibal2.skyhanni.events.PlaySoundEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.combat.VanquisherEvent
-import at.hannibal2.skyhanni.events.entity.EntityMaxHealthUpdateEvent
+import at.hannibal2.skyhanni.events.entity.EntityEquipmentChangeEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.DelayedRun
@@ -73,7 +73,7 @@ object VanquisherApi {
     private val vanquisherLongTimeout = 5.seconds
 
     @HandleEvent(onlyOnIsland = IslandType.CRIMSON_ISLE)
-    fun onChat(event: SkyHanniChatEvent.Allow) {
+    private fun onChat(event: SkyHanniChatEvent.Allow) {
         if (spawnPattern.matches(event.cleanMessage)) {
             lastOwnTime = SimpleTimeMark.now()
             VanquisherOwnMessageEvent.post()
@@ -82,7 +82,7 @@ object VanquisherApi {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.CRIMSON_ISLE)
-    fun onPlaySound(event: PlaySoundEvent) {
+    private fun onPlaySound(event: PlaySoundEvent) {
         if (event.soundName != "entity.wither.spawn" || event.pitch != 1f || event.volume != 2f) return
         lastSoundPos = event.location
         lastSoundTime = SimpleTimeMark.now()
@@ -90,8 +90,8 @@ object VanquisherApi {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.CRIMSON_ISLE)
-    fun onEntityHealthUpdate(event: EntityMaxHealthUpdateEvent) {
-        val entity = event.entity as? ArmorStand ?: return
+    private fun onEntityEquipmentChange(event: EntityEquipmentChangeEvent<ArmorStand>) {
+        val entity = event.entity
         val helmet = entity.getStandHelmet() ?: return
         if (!helmet.`is`(Items.WITHER_SKELETON_SKULL)) return
         lastSpawnEntityPos = entity.getLorenzVec()

--- a/src/main/java/at/hannibal2/skyhanni/api/VanquisherApi.kt
+++ b/src/main/java/at/hannibal2/skyhanni/api/VanquisherApi.kt
@@ -9,7 +9,7 @@ import at.hannibal2.skyhanni.events.MobEvent
 import at.hannibal2.skyhanni.events.PlaySoundEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.combat.VanquisherEvent
-import at.hannibal2.skyhanni.events.entity.EntityEquipmentChangeEvent
+import at.hannibal2.skyhanni.events.entity.EntityMaxHealthUpdateEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.ChatUtils
 import at.hannibal2.skyhanni.utils.DelayedRun
@@ -90,7 +90,7 @@ object VanquisherApi {
     }
 
     @HandleEvent(onlyOnIsland = IslandType.CRIMSON_ISLE)
-    private fun onEntityEquipmentChange(event: EntityEquipmentChangeEvent<ArmorStand>) {
+    private fun onEntityMaxHealthUpdate(event: EntityMaxHealthUpdateEvent<ArmorStand>) {
         val entity = event.entity
         val helmet = entity.getStandHelmet() ?: return
         if (!helmet.`is`(Items.WITHER_SKELETON_SKULL)) return

--- a/src/main/java/at/hannibal2/skyhanni/data/EntityData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/EntityData.kt
@@ -11,17 +11,11 @@ import at.hannibal2.skyhanni.events.entity.EntityMaxHealthUpdateEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
 import at.hannibal2.skyhanni.utils.EntityUtils.baseMaxHealth
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
-import net.minecraft.client.player.LocalPlayer
-import net.minecraft.client.player.RemotePlayer
 import net.minecraft.network.chat.Component
 import net.minecraft.world.entity.Display
 import net.minecraft.world.entity.Entity
-import net.minecraft.world.entity.ExperienceOrb
 import net.minecraft.world.entity.LivingEntity
 import net.minecraft.world.entity.ai.attributes.Attributes
-import net.minecraft.world.entity.decoration.ArmorStand
-import net.minecraft.world.entity.decoration.ItemFrame
-import net.minecraft.world.entity.item.ItemEntity
 import java.util.UUID
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -32,19 +26,9 @@ object EntityData {
     private val healthDisplayCache = TimeLimitedCache<Component, Component>(50.milliseconds)
     private val lastVisibilityCheck = TimeLimitedCache<Int, Boolean>(200.milliseconds)
 
-    val ignoredEntities = setOf(
-        ArmorStand::class.java,
-        ExperienceOrb::class.java,
-        ItemEntity::class.java,
-        ItemFrame::class.java,
-        RemotePlayer::class.java,
-        LocalPlayer::class.java,
-    )
-
     @HandleEvent
     private fun onEntityAttributeUpdate(event: EntityAttributeUpdateEvent<LivingEntity>) {
         val entity = event.entity
-        if (entity.javaClass in ignoredEntities) return
         val attribute = event.attribute
         if (attribute.`is`(Attributes.MAX_HEALTH)) {
             val maxHealth = entity.baseMaxHealth

--- a/src/main/java/at/hannibal2/skyhanni/data/EntityData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/EntityData.kt
@@ -2,8 +2,8 @@ package at.hannibal2.skyhanni.data
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.ElectionApi.derpy
-import at.hannibal2.skyhanni.events.AttributeWatcherUpdateEvent
 import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
+import at.hannibal2.skyhanni.events.entity.EntityAttributeUpdateEvent
 import at.hannibal2.skyhanni.events.entity.EntityDisplayNameEvent
 import at.hannibal2.skyhanni.events.entity.EntityHealthDisplayEvent
 import at.hannibal2.skyhanni.events.entity.EntityLeaveWorldEvent
@@ -42,7 +42,7 @@ object EntityData {
     )
 
     @HandleEvent
-    private fun onAttributeWatcherUpdate(event: AttributeWatcherUpdateEvent<LivingEntity>) {
+    private fun onEntityAttributeUpdate(event: EntityAttributeUpdateEvent<LivingEntity>) {
         val entity = event.entity
         if (entity.javaClass in ignoredEntities) return
         val attribute = event.attribute

--- a/src/main/java/at/hannibal2/skyhanni/data/EntityData.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/EntityData.kt
@@ -2,54 +2,54 @@ package at.hannibal2.skyhanni.data
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
 import at.hannibal2.skyhanni.data.ElectionApi.derpy
+import at.hannibal2.skyhanni.events.AttributeWatcherUpdateEvent
 import at.hannibal2.skyhanni.events.CheckRenderEntityEvent
 import at.hannibal2.skyhanni.events.entity.EntityDisplayNameEvent
 import at.hannibal2.skyhanni.events.entity.EntityHealthDisplayEvent
 import at.hannibal2.skyhanni.events.entity.EntityLeaveWorldEvent
 import at.hannibal2.skyhanni.events.entity.EntityMaxHealthUpdateEvent
 import at.hannibal2.skyhanni.skyhannimodule.SkyHanniModule
-import at.hannibal2.skyhanni.utils.AllEntitiesGetter
-import at.hannibal2.skyhanni.utils.EntityUtils
 import at.hannibal2.skyhanni.utils.EntityUtils.baseMaxHealth
 import at.hannibal2.skyhanni.utils.collection.TimeLimitedCache
+import net.minecraft.client.player.LocalPlayer
+import net.minecraft.client.player.RemotePlayer
 import net.minecraft.network.chat.Component
 import net.minecraft.world.entity.Display
 import net.minecraft.world.entity.Entity
+import net.minecraft.world.entity.ExperienceOrb
 import net.minecraft.world.entity.LivingEntity
+import net.minecraft.world.entity.ai.attributes.Attributes
+import net.minecraft.world.entity.decoration.ArmorStand
+import net.minecraft.world.entity.decoration.ItemFrame
+import net.minecraft.world.entity.item.ItemEntity
 import java.util.UUID
 import kotlin.time.Duration.Companion.milliseconds
 
 @SkyHanniModule
 object EntityData {
 
-    private val maxHealthMap = mutableMapOf<Int, Int>()
     private val nametagCache = TimeLimitedCache<UUID, Component>(50.milliseconds)
     private val healthDisplayCache = TimeLimitedCache<Component, Component>(50.milliseconds)
     private val lastVisibilityCheck = TimeLimitedCache<Int, Boolean>(200.milliseconds)
 
-    // TODO replace with packet detection
-    @OptIn(AllEntitiesGetter::class)
+    val ignoredEntities = setOf(
+        ArmorStand::class.java,
+        ExperienceOrb::class.java,
+        ItemEntity::class.java,
+        ItemFrame::class.java,
+        RemotePlayer::class.java,
+        LocalPlayer::class.java,
+    )
+
     @HandleEvent
-    fun onTick() {
-        for (entity in EntityUtils.getEntities<LivingEntity>()) { // this completely ignores the ignored entities list?
+    private fun onAttributeWatcherUpdate(event: AttributeWatcherUpdateEvent<LivingEntity>) {
+        val entity = event.entity
+        if (entity.javaClass in ignoredEntities) return
+        val attribute = event.attribute
+        if (attribute.`is`(Attributes.MAX_HEALTH)) {
             val maxHealth = entity.baseMaxHealth
-            val id = entity.id
-            val oldMaxHealth = maxHealthMap.getOrDefault(id, -1)
-            if (oldMaxHealth != maxHealth) {
-                maxHealthMap[id] = maxHealth
-                EntityMaxHealthUpdateEvent(entity, maxHealth.derpy()).post()
-            }
+            EntityMaxHealthUpdateEvent(entity, maxHealth.derpy()).post()
         }
-    }
-
-    @HandleEvent
-    fun onEntityLeaveWorld(event: EntityLeaveWorldEvent<LivingEntity>) {
-        maxHealthMap -= event.entity.id
-    }
-
-    @HandleEvent
-    fun onWorldChange() {
-        maxHealthMap.clear()
     }
 
     @JvmStatic

--- a/src/main/java/at/hannibal2/skyhanni/events/AttributeWatcherUpdateEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/AttributeWatcherUpdateEvent.kt
@@ -9,5 +9,5 @@ import net.minecraft.world.entity.ai.attributes.Attribute
 @PrimaryFunction("onAttributeWatcherUpdate")
 data class AttributeWatcherUpdateEvent<T : LivingEntity>(
     val entity: T,
-    val attribute: Holder<Attribute>
-): GenericSkyHanniEvent<T>(entity.javaClass)
+    val attribute: Holder<Attribute>,
+) : GenericSkyHanniEvent<T>(entity.javaClass)

--- a/src/main/java/at/hannibal2/skyhanni/events/AttributeWatcherUpdateEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/AttributeWatcherUpdateEvent.kt
@@ -1,0 +1,13 @@
+package at.hannibal2.skyhanni.events
+
+import at.hannibal2.skyhanni.api.event.GenericSkyHanniEvent
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
+import net.minecraft.core.Holder
+import net.minecraft.world.entity.LivingEntity
+import net.minecraft.world.entity.ai.attributes.Attribute
+
+@PrimaryFunction("onAttributeWatcherUpdate")
+data class AttributeWatcherUpdateEvent<T : LivingEntity>(
+    val entity: T,
+    val attribute: Holder<Attribute>
+): GenericSkyHanniEvent<T>(entity.javaClass)

--- a/src/main/java/at/hannibal2/skyhanni/events/entity/EntityAttributeUpdateEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/entity/EntityAttributeUpdateEvent.kt
@@ -6,6 +6,14 @@ import net.minecraft.core.Holder
 import net.minecraft.world.entity.LivingEntity
 import net.minecraft.world.entity.ai.attributes.Attribute
 
+/**
+ * Event that is called when an entity's attribute is updated.
+ * Like max health, movement speed, absorption etc.
+ *
+ * @param T The type of the entity whose attribute was updated.
+ * @property entity The entity whose attribute was updated.
+ * @property attribute The attribute that was updated.
+ */
 @PrimaryFunction("onEntityAttributeUpdate")
 data class EntityAttributeUpdateEvent<T : LivingEntity>(
     val entity: T,

--- a/src/main/java/at/hannibal2/skyhanni/events/entity/EntityAttributeUpdateEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/entity/EntityAttributeUpdateEvent.kt
@@ -10,7 +10,7 @@ import net.minecraft.world.entity.ai.attributes.Attribute
  * Event that is called when an entity's attribute is updated.
  * Like max health, movement speed, absorption etc.
  *
- * @param T The type of the entity whose attribute was updated.
+ * @param T The type of the entity.
  * @property entity The entity whose attribute was updated.
  * @property attribute The attribute that was updated.
  */

--- a/src/main/java/at/hannibal2/skyhanni/events/entity/EntityAttributeUpdateEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/entity/EntityAttributeUpdateEvent.kt
@@ -1,4 +1,4 @@
-package at.hannibal2.skyhanni.events
+package at.hannibal2.skyhanni.events.entity
 
 import at.hannibal2.skyhanni.api.event.GenericSkyHanniEvent
 import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
@@ -6,8 +6,8 @@ import net.minecraft.core.Holder
 import net.minecraft.world.entity.LivingEntity
 import net.minecraft.world.entity.ai.attributes.Attribute
 
-@PrimaryFunction("onAttributeWatcherUpdate")
-data class AttributeWatcherUpdateEvent<T : LivingEntity>(
+@PrimaryFunction("onEntityAttributeUpdate")
+data class EntityAttributeUpdateEvent<T : LivingEntity>(
     val entity: T,
     val attribute: Holder<Attribute>,
 ) : GenericSkyHanniEvent<T>(entity.javaClass)

--- a/src/main/java/at/hannibal2/skyhanni/events/entity/EntityDeathEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/entity/EntityDeathEvent.kt
@@ -1,8 +1,8 @@
 package at.hannibal2.skyhanni.events.entity
 
 import at.hannibal2.skyhanni.api.event.GenericSkyHanniEvent
-import net.minecraft.world.entity.LivingEntity
 import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
+import net.minecraft.world.entity.LivingEntity
 
 @PrimaryFunction("onEntityDeath")
 class EntityDeathEvent<T : LivingEntity>(val entity: T) : GenericSkyHanniEvent<T>(entity.javaClass)

--- a/src/main/java/at/hannibal2/skyhanni/events/entity/EntityDeathEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/entity/EntityDeathEvent.kt
@@ -4,5 +4,13 @@ import at.hannibal2.skyhanni.api.event.GenericSkyHanniEvent
 import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 import net.minecraft.world.entity.LivingEntity
 
+/**
+ * Event that is called when an entity dies.
+ * This event is only for entities which are actually killed, not removed.
+ * use [EntityLeaveWorldEvent] if you need a removed entity event.
+ *
+ * @param T The type of the entity that died.
+ * @property entity The entity that died.
+ */
 @PrimaryFunction("onEntityDeath")
 class EntityDeathEvent<T : LivingEntity>(val entity: T) : GenericSkyHanniEvent<T>(entity.javaClass)

--- a/src/main/java/at/hannibal2/skyhanni/events/entity/EntityDeathEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/entity/EntityDeathEvent.kt
@@ -1,6 +1,8 @@
 package at.hannibal2.skyhanni.events.entity
 
 import at.hannibal2.skyhanni.api.event.GenericSkyHanniEvent
-import net.minecraft.world.entity.Entity
+import net.minecraft.world.entity.LivingEntity
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 
-class EntityDeathEvent<T : Entity>(val entity: T) : GenericSkyHanniEvent<T>(entity.javaClass)
+@PrimaryFunction("onEntityDeath")
+class EntityDeathEvent<T : LivingEntity>(val entity: T) : GenericSkyHanniEvent<T>(entity.javaClass)

--- a/src/main/java/at/hannibal2/skyhanni/events/entity/EntityEnterWorldEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/entity/EntityEnterWorldEvent.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.events.entity
 
 import at.hannibal2.skyhanni.api.event.GenericSkyHanniEvent
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 import net.minecraft.world.entity.Entity
 
 /**
@@ -14,4 +15,5 @@ import net.minecraft.world.entity.Entity
  * @param T the type of entity
  * @param entity the entity that was added to the world
  */
+@PrimaryFunction("onEntityEnterWorld")
 class EntityEnterWorldEvent<T : Entity>(val entity: T) : GenericSkyHanniEvent<T>(entity.javaClass)

--- a/src/main/java/at/hannibal2/skyhanni/events/entity/EntityEquipmentChangeEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/entity/EntityEquipmentChangeEvent.kt
@@ -3,10 +3,10 @@ package at.hannibal2.skyhanni.events.entity
 import at.hannibal2.skyhanni.api.event.GenericSkyHanniEvent
 import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 import at.hannibal2.skyhanni.utils.SafeItemStack
-import net.minecraft.world.entity.Entity
+import net.minecraft.world.entity.LivingEntity
 
 @PrimaryFunction("onEntityEquipmentChange")
-data class EntityEquipmentChangeEvent<T : Entity>(
+data class EntityEquipmentChangeEvent<T : LivingEntity>(
     val entity: T,
     val equipmentSlot: Int,
     val newItemStack: SafeItemStack?,

--- a/src/main/java/at/hannibal2/skyhanni/events/entity/EntityEquipmentChangeEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/entity/EntityEquipmentChangeEvent.kt
@@ -5,6 +5,15 @@ import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 import at.hannibal2.skyhanni.utils.SafeItemStack
 import net.minecraft.world.entity.LivingEntity
 
+/**
+ * Event that is called when an entity's equipment changes.
+ * This refers to armor and held item, not SkyBlock equipment.
+ *
+ * @param T The type of the entity.
+ * @property entity The entity whose equipment changed.
+ * @property equipmentSlot The slot of the equipment that changed.
+ * @property newItemStack The new item stack that was equipped, or null if the slot was cleared.
+ */
 @PrimaryFunction("onEntityEquipmentChange")
 data class EntityEquipmentChangeEvent<T : LivingEntity>(
     val entity: T,

--- a/src/main/java/at/hannibal2/skyhanni/events/entity/EntityMaxHealthUpdateEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/entity/EntityMaxHealthUpdateEvent.kt
@@ -6,6 +6,7 @@ import net.minecraft.world.entity.LivingEntity
 
 /**
  * Event that is called when an entity's max health is updated.
+ * [maxHealth] accounts for global health modifiers, such as Derpy mayor.
  *
  * @property entity The entity whose max health was updated.
  * @property maxHealth The new max health of the entity.
@@ -13,5 +14,5 @@ import net.minecraft.world.entity.LivingEntity
 @PrimaryFunction("onEntityMaxHealthUpdate")
 data class EntityMaxHealthUpdateEvent<T : LivingEntity>(
     val entity: T,
-    val maxHealth: Int
+    val maxHealth: Int,
 ) : GenericSkyHanniEvent<T>(entity.javaClass)

--- a/src/main/java/at/hannibal2/skyhanni/events/entity/EntityMaxHealthUpdateEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/entity/EntityMaxHealthUpdateEvent.kt
@@ -2,5 +2,7 @@ package at.hannibal2.skyhanni.events.entity
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
 import net.minecraft.world.entity.LivingEntity
+import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 
+@PrimaryFunction("onEntityMaxHealthUpdate")
 class EntityMaxHealthUpdateEvent(val entity: LivingEntity, val maxHealth: Int) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/events/entity/EntityMaxHealthUpdateEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/entity/EntityMaxHealthUpdateEvent.kt
@@ -1,8 +1,17 @@
 package at.hannibal2.skyhanni.events.entity
 
-import at.hannibal2.skyhanni.api.event.SkyHanniEvent
+import at.hannibal2.skyhanni.api.event.GenericSkyHanniEvent
 import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
 import net.minecraft.world.entity.LivingEntity
 
+/**
+ * Event that is called when an entity's max health is updated.
+ *
+ * @property entity The entity whose max health was updated.
+ * @property maxHealth The new max health of the entity.
+ */
 @PrimaryFunction("onEntityMaxHealthUpdate")
-class EntityMaxHealthUpdateEvent(val entity: LivingEntity, val maxHealth: Int) : SkyHanniEvent()
+data class EntityMaxHealthUpdateEvent<T : LivingEntity>(
+    val entity: T,
+    val maxHealth: Int
+) : GenericSkyHanniEvent<T>(entity.javaClass)

--- a/src/main/java/at/hannibal2/skyhanni/events/entity/EntityMaxHealthUpdateEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/entity/EntityMaxHealthUpdateEvent.kt
@@ -8,6 +8,7 @@ import net.minecraft.world.entity.LivingEntity
  * Event that is called when an entity's max health is updated.
  * [maxHealth] accounts for global health modifiers, such as Derpy mayor.
  *
+ * @param T The type of the entity.
  * @property entity The entity whose max health was updated.
  * @property maxHealth The new max health of the entity.
  */

--- a/src/main/java/at/hannibal2/skyhanni/events/entity/EntityMaxHealthUpdateEvent.kt
+++ b/src/main/java/at/hannibal2/skyhanni/events/entity/EntityMaxHealthUpdateEvent.kt
@@ -1,8 +1,8 @@
 package at.hannibal2.skyhanni.events.entity
 
 import at.hannibal2.skyhanni.api.event.SkyHanniEvent
-import net.minecraft.world.entity.LivingEntity
 import at.hannibal2.skyhanni.skyhannimodule.PrimaryFunction
+import net.minecraft.world.entity.LivingEntity
 
 @PrimaryFunction("onEntityMaxHealthUpdate")
 class EntityMaxHealthUpdateEvent(val entity: LivingEntity, val maxHealth: Int) : SkyHanniEvent()

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/MobHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/MobHighlight.kt
@@ -94,7 +94,7 @@ object MobHighlight {
             heldBlock == Blocks.ENDER_CHEST ->
                 Triple(LorenzColor.GREEN, 127, config::chestZealotHighlighter)
 
-            event.maxHealth.isZealotOrBruiser() ->
+            entity.isZealotOrBruiser() ->
                 Triple(LorenzColor.DARK_AQUA, 127, config::zealotBruiserHighlighter)
 
             else -> return
@@ -122,6 +122,6 @@ object MobHighlight {
         )
     }
 
-    private fun Int.isZealotOrBruiser() = this == 13_000 || this == 65_000 ||
-        this == 13_000 * 4 || this == 65_000 * 4 // runic
+    private fun LivingEntity.isZealotOrBruiser() = baseMaxHealth == 13_000 || baseMaxHealth == 65_000 ||
+        baseMaxHealth == 13_000 * 4 || baseMaxHealth == 65_000 * 4 // runic
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/MobHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/MobHighlight.kt
@@ -94,7 +94,7 @@ object MobHighlight {
             heldBlock == Blocks.ENDER_CHEST ->
                 Triple(LorenzColor.GREEN, 127, config::chestZealotHighlighter)
 
-            entity.isZealotOrBruiser() ->
+            event.maxHealth.isZealotOrBruiser() ->
                 Triple(LorenzColor.DARK_AQUA, 127, config::zealotBruiserHighlighter)
 
             else -> return
@@ -122,6 +122,6 @@ object MobHighlight {
         )
     }
 
-    private fun LivingEntity.isZealotOrBruiser() = baseMaxHealth == 13_000 || baseMaxHealth == 65_000 ||
-        baseMaxHealth == 13_000 * 4 || baseMaxHealth == 65_000 * 4 // runic
+    private fun Int.isZealotOrBruiser() = this == 13_000 || this == 65_000 ||
+        this == 13_000 * 4 || this == 65_000 * 4 // runic
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/MobHighlight.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/mobs/MobHighlight.kt
@@ -27,7 +27,7 @@ object MobHighlight {
     private var arachne: Mob? = null
 
     @HandleEvent
-    fun onMobSpawn(event: MobEvent.Spawn.SkyblockMob) {
+    private fun onMobSpawn(event: MobEvent.Spawn.SkyblockMob) {
         val mob = event.mob
         val name = mob.name
 
@@ -59,14 +59,14 @@ object MobHighlight {
     }
 
     @HandleEvent
-    fun onMobDespawn(event: MobEvent.DeSpawn.SkyblockMob) {
+    private fun onMobDespawn(event: MobEvent.DeSpawn.SkyblockMob) {
         if (arachne == event.mob) arachne = null
     }
 
     // TODO: change to use nametags instead
     // as this method does not work for mobs that spawn corrupted naturally
     @HandleEvent(onlyOnSkyblock = true)
-    fun onEntityHealthUpdate(event: EntityHealthUpdateEvent) {
+    private fun onEntityHealthUpdate(event: EntityHealthUpdateEvent) {
         if (!config.corruptedMobHighlight) return
 
         val entity = event.entity
@@ -80,9 +80,7 @@ object MobHighlight {
 
     // Mob detection isn't used here to allow for highlighting Zealots from further away.
     @HandleEvent(onlyOnIsland = IslandType.THE_END)
-    fun onEntityHealthUpdate(event: EntityMaxHealthUpdateEvent) {
-        if (event.entity !is EnderMan) return
-
+    private fun onEntityMaxHealthUpdate(event: EntityMaxHealthUpdateEvent<EnderMan>) {
         val entity = event.entity
 
         val heldBlock = entity.getBlockInHand()?.block
@@ -107,7 +105,7 @@ object MobHighlight {
     }
 
     @HandleEvent(onlyOnSkyblock = true)
-    fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
+    private fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
         if (!config.lineToArachne) return
 
         val arachne = arachne ?: return

--- a/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/GoldenFishTimer.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/fishing/trophy/GoldenFishTimer.kt
@@ -9,7 +9,6 @@ import at.hannibal2.skyhanni.data.title.TitleManager
 import at.hannibal2.skyhanni.events.DebugDataCollectEvent
 import at.hannibal2.skyhanni.events.chat.SkyHanniChatEvent
 import at.hannibal2.skyhanni.events.entity.EntityMaxHealthUpdateEvent
-import at.hannibal2.skyhanni.events.fishing.FishingBobberCastEvent
 import at.hannibal2.skyhanni.events.minecraft.SkyHanniRenderWorldEvent
 import at.hannibal2.skyhanni.features.fishing.FishingApi
 import at.hannibal2.skyhanni.features.fishing.FishingApi.isLavaRod
@@ -142,7 +141,7 @@ object GoldenFishTimer {
     private var display: Renderable? = null
 
     @HandleEvent
-    fun onChat(event: SkyHanniChatEvent.Allow) {
+    private fun onChat(event: SkyHanniChatEvent.Allow) {
         if (!isActive()) return
         if (spawnPattern.matches(event.message)) {
             lastChatMessage = SimpleTimeMark.now()
@@ -178,7 +177,7 @@ object GoldenFishTimer {
     }
 
     @HandleEvent
-    fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
+    private fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
         if (!isActive()) return
         if (!config.nametag) return
         val entity = confirmedGoldenFishEntity ?: return
@@ -191,7 +190,7 @@ object GoldenFishTimer {
     }
 
     @HandleEvent
-    fun onGuiRenderOverlay() {
+    private fun onGuiRenderOverlay() {
         if (!isActive()) return
         display?.let {
             config.position.renderRenderable(it, posLabel = "Golden Fish Timer")
@@ -288,7 +287,7 @@ object GoldenFishTimer {
     }
 
     @HandleEvent
-    fun onSecondPassed() {
+    private fun onSecondPassed() {
         if (!isEnabled()) return
         hasLavaRodInInventory = InventoryUtils.containsInLowerInventoryInternalName { it.isLavaRod() }
 
@@ -313,7 +312,7 @@ object GoldenFishTimer {
     }
 
     @HandleEvent
-    fun onTick() {
+    private fun onTick() {
         if (!isActive()) return
         // This makes it only count as the rod being throw into lava if the rod goes down, up, and down again.
         // Not confirmed that this is correct, but it's the best solution found.
@@ -328,24 +327,24 @@ object GoldenFishTimer {
         }
     }
 
-    @HandleEvent(FishingBobberCastEvent::class)
-    fun onBobberThrow() {
+    @HandleEvent
+    private fun onBobberCast() {
         if (!isActive()) return
         goingDownInit = true
         goingDownPost = false
     }
 
     @HandleEvent
-    fun onEntityHealthUpdate(event: EntityMaxHealthUpdateEvent) {
+    private fun onEntityMaxHealthUpdate(event: EntityMaxHealthUpdateEvent<ArmorStand>) {
         if (!isActive()) return
         if (isGoldenFishActive()) return
-        val entity = event.entity as? ArmorStand ?: return
+        val entity = event.entity
 
         DelayedRun.runDelayed(1.seconds) { checkGoldenFish(entity) }
     }
 
     @HandleEvent
-    fun onWorldChange() {
+    private fun onWorldChange() {
         lastChatMessage = SimpleTimeMark.farPast()
         lastFishEntity = SimpleTimeMark.farPast()
         lastGoldenFishTime = ServerTimeMark.farPast()
@@ -358,7 +357,7 @@ object GoldenFishTimer {
     }
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(
             97,
             "fishing.trophyFishing.goldenFishTimer.showHead",
@@ -371,7 +370,7 @@ object GoldenFishTimer {
     }
 
     @HandleEvent
-    fun onDebugDataCollect(event: DebugDataCollectEvent) {
+    private fun onDebugDataCollect(event: DebugDataCollectEvent) {
         event.title("Golden Fish Timer")
         if (!isEnabled()) {
             event.addIrrelevant("Not Enabled")

--- a/src/main/java/at/hannibal2/skyhanni/features/mining/HighlightMiningCommissionMobs.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/mining/HighlightMiningCommissionMobs.kt
@@ -54,8 +54,8 @@ object HighlightMiningCommissionMobs {
     )
 
     @OptIn(AllEntitiesGetter::class)
-    @HandleEvent
-    fun onSecondPassed(event: SecondPassedEvent) {
+    @HandleEvent(onlyOnIslandTypeTag = [ADVANCED_MINING])
+    private fun onSecondPassed(event: SecondPassedEvent) {
         if (!isEnabled()) return
         if (!event.repeatSeconds(2)) return
 
@@ -73,8 +73,8 @@ object HighlightMiningCommissionMobs {
         }
     }
 
-    @HandleEvent
-    fun onTabListUpdate(event: TabListUpdateEvent) {
+    @HandleEvent(onlyOnIslandTypeTag = [ADVANCED_MINING])
+    private fun onTabListUpdate(event: TabListUpdateEvent) {
         if (!isEnabled()) return
 
         // TODO Commission API
@@ -84,8 +84,8 @@ object HighlightMiningCommissionMobs {
         }.values.toList()
     }
 
-    @HandleEvent
-    fun onEntityHealthUpdate(event: EntityMaxHealthUpdateEvent) {
+    @HandleEvent(onlyOnIslandTypeTag = [ADVANCED_MINING])
+    private fun onEntityMaxHealthUpdate(event: EntityMaxHealthUpdateEvent<LivingEntity>) {
         if (!isEnabled()) return
 
         val entity = event.entity
@@ -100,7 +100,7 @@ object HighlightMiningCommissionMobs {
     }
 
     @HandleEvent
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(2, "misc.mining", "mining")
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/dreadfarm/VoltHighlighter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/dreadfarm/VoltHighlighter.kt
@@ -43,7 +43,7 @@ object VoltHighlighter {
     private var chargingSince = mapOf<Entity, SimpleTimeMark>()
 
     @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
-    fun onArmorChange(event: EntityEquipmentChangeEvent<Entity>) {
+    private fun onEntityEquipmentChange(event: EntityEquipmentChangeEvent<LivingEntity>) {
         if (!config.voltWarning) return
         if (event.isHead && getVoltState(event.entity) == VoltState.DOING_LIGHTNING &&
             event.entity.distanceSqToPlayer() <= LIGHTNING_DISTANCE * LIGHTNING_DISTANCE
@@ -56,7 +56,7 @@ object VoltHighlighter {
 
     @OptIn(AllEntitiesGetter::class)
     @HandleEvent(onlyOnIsland = IslandType.THE_RIFT)
-    fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
+    private fun onRenderWorld(event: SkyHanniRenderWorldEvent) {
         if (!(config.voltRange || config.voltMoodMeter)) return
         for (entity in EntityUtils.getEntities<LivingEntity>()) {
             val state = getVoltState(entity).takeIf { it != VoltState.NO_VOLT } ?: continue
@@ -113,7 +113,7 @@ object VoltHighlighter {
 
     @HandleEvent
     @Suppress("AvoidBritishSpelling")
-    fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
+    private fun onConfigFix(event: ConfigUpdaterMigrator.ConfigFixEvent) {
         event.move(82, "rift.area.dreadfarm.voltCrux.voltColour", "rift.area.dreadfarm.voltCrux.voltColor")
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/westvillage/VerminHighlighter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/westvillage/VerminHighlighter.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.features.rift.area.westvillage
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
+import at.hannibal2.skyhanni.data.ElectionApi.derpy
 import at.hannibal2.skyhanni.events.ItemInHandChangeEvent
 import at.hannibal2.skyhanni.events.entity.EntityEnterWorldEvent
 import at.hannibal2.skyhanni.events.entity.EntityEquipmentChangeEvent
@@ -37,7 +38,7 @@ object VerminHighlighter {
     }
 
     @HandleEvent
-    private fun onEntityMaxHealthUpdate(event: EntityMaxHealthUpdateEvent) {
+    private fun onEntityMaxHealthUpdate(event: EntityMaxHealthUpdateEvent<LivingEntity>) {
         if (shouldDiscover()) tryAdd(event.entity)
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/rift/area/westvillage/VerminHighlighter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/rift/area/westvillage/VerminHighlighter.kt
@@ -1,7 +1,6 @@
 package at.hannibal2.skyhanni.features.rift.area.westvillage
 
 import at.hannibal2.skyhanni.api.event.HandleEvent
-import at.hannibal2.skyhanni.data.ElectionApi.derpy
 import at.hannibal2.skyhanni.events.ItemInHandChangeEvent
 import at.hannibal2.skyhanni.events.entity.EntityEnterWorldEvent
 import at.hannibal2.skyhanni.events.entity.EntityEquipmentChangeEvent

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinLivingEntity.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinLivingEntity.java
@@ -1,6 +1,6 @@
 package at.hannibal2.skyhanni.mixins.transformers;
 
-import at.hannibal2.skyhanni.events.AttributeWatcherUpdateEvent;
+import at.hannibal2.skyhanni.events.entity.EntityAttributeUpdateEvent;
 import at.hannibal2.skyhanni.events.entity.EntityDeathEvent;
 import at.hannibal2.skyhanni.events.entity.EntityEquipmentChangeEvent;
 import net.minecraft.core.Holder;
@@ -29,6 +29,6 @@ public abstract class MixinLivingEntity {
 
     @Inject(method = "onAttributeUpdated", at = @At("TAIL"))
     public void onAttributeUpdated(Holder<Attribute> attribute, CallbackInfo ci) {
-        new AttributeWatcherUpdateEvent<>((LivingEntity) (Object) this, attribute).post();
+        new EntityAttributeUpdateEvent<>((LivingEntity) (Object) this, attribute).post();
     }
 }

--- a/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinLivingEntity.java
+++ b/src/main/java/at/hannibal2/skyhanni/mixins/transformers/MixinLivingEntity.java
@@ -1,11 +1,13 @@
 package at.hannibal2.skyhanni.mixins.transformers;
 
+import at.hannibal2.skyhanni.events.AttributeWatcherUpdateEvent;
 import at.hannibal2.skyhanni.events.entity.EntityDeathEvent;
 import at.hannibal2.skyhanni.events.entity.EntityEquipmentChangeEvent;
+import net.minecraft.core.Holder;
 import net.minecraft.world.damagesource.DamageSource;
-import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -22,6 +24,11 @@ public abstract class MixinLivingEntity {
 
     @Inject(method = "setItemSlot", at = @At("TAIL"))
     public void setItemStack(EquipmentSlot equipment, ItemStack itemStack, CallbackInfo ci) {
-        new EntityEquipmentChangeEvent<>((Entity) (Object) this, equipment.getId(), itemStack).post();
+        new EntityEquipmentChangeEvent<>((LivingEntity) (Object) this, equipment.getId(), itemStack).post();
+    }
+
+    @Inject(method = "onAttributeUpdated", at = @At("TAIL"))
+    public void onAttributeUpdated(Holder<Attribute> attribute, CallbackInfo ci) {
+        new AttributeWatcherUpdateEvent<>((LivingEntity) (Object) this, attribute).post();
     }
 }


### PR DESCRIPTION
## What
Makes an event to listen on attribute changes, and then if the attribute changed is max health. then it will send the event.
Much better then doing an onTick. and it resolves the existing TODO.
Also fixed some entity events that come from LivingEntity mixin, still using Entity even though that's impossible.

## Changelog Technical Details
+ Made Entity Max Health update detection run on update instead of on each tick. - Avrg