### PR TITLE
Fix: Damage Indicator For Dummy

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/data/mob/IslandExceptions.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/IslandExceptions.kt
@@ -96,20 +96,27 @@ object IslandExceptions {
         armorStand: ArmorStand?,
         baseEntity: LivingEntity,
     ): MobData.MobResult? {
-        val dummyArmorStand = sequenceOf(armorStand)
-            .plus(MobUtils.getArmorStandByRangeAll(baseEntity, 4.0))
-            .filterNotNull()
-            .firstOrNull { MobFilter.dummyMobNamePattern.matches(it.cleanName) }
 
-        if (dummyArmorStand != null) {
-            return MobData.MobResult.found(
-                Mob(
-                    baseEntity = baseEntity,
-                    category = MobCategory.SPECIAL,
-                    armorStand = dummyArmorStand,
-                    name = "Dummy",
-                ),
-            )
+        // Dummy can either have 2m or Int.MAX_VALUE
+        if (baseEntity.baseMaxHealth >= 2_000_000) {
+            val dummyMob = sequenceOf(armorStand)
+                .plus(MobUtils.getArmorStandByRangeAll(baseEntity, 4.0))
+                .filterNotNull()
+                .firstNotNullOfOrNull { stand ->
+                    MobFilter.dummyMobNamePattern.matchMatcher(stand.cleanName) {
+                        Mob(
+                            baseEntity = baseEntity,
+                            category = MobCategory.SPECIAL,
+                            armorStand = stand,
+                            name = "Dummy",
+                            hypixelTypes = group("types"),
+                        )
+                    }
+                }
+
+            if (dummyMob != null) {
+                return MobData.MobResult.found(dummyMob)
+            }
         }
 
         if (armorStand?.isDefaultValue() != false) {

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/IslandExceptions.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/IslandExceptions.kt
@@ -95,14 +95,29 @@ object IslandExceptions {
     private fun privateIsland(
         armorStand: ArmorStand?,
         baseEntity: LivingEntity,
-    ) = when {
-        armorStand?.isDefaultValue() != false ->
-            if (baseEntity.getLorenzVec().distanceChebyshevIgnoreY(LocationUtils.playerLocation()) < 15.0) {
+    ): MobData.MobResult? {
+        val dummyArmorStand = armorStand ?: MobUtils.getClosestArmorStand(baseEntity, 4.0)
+        if (dummyArmorStand != null && MobFilter.dummyMobNamePattern.matches(dummyArmorStand.cleanName)) {
+            return MobData.MobResult.found(
+                Mob(
+                    baseEntity = baseEntity,
+                    category = MobCategory.SPECIAL,
+                    armorStand = dummyArmorStand,
+                    name = "Dummy",
+                ),
+            )
+        }
+
+        if (armorStand?.isDefaultValue() != false) {
+            return if (baseEntity.getLorenzVec().distanceChebyshevIgnoreY(LocationUtils.playerLocation()) < 15.0) {
                 // TODO fix to always include Valid Mobs on Private Island
                 MobData.MobResult.found(MobFactories.minionMob(baseEntity))
-            } else MobData.MobResult.notYetFound
+            } else {
+                MobData.MobResult.notYetFound
+            }
+        }
 
-        else -> null
+        return null
     }
 
     private fun theRift(

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/IslandExceptions.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/IslandExceptions.kt
@@ -97,6 +97,7 @@ object IslandExceptions {
         baseEntity: LivingEntity,
     ) = when {
 
+        // Dummy can have either 2b or Int.MAX_VALUE health
         baseEntity.baseMaxHealth >= 2_000_000_000 -> MobData.MobResult.found(
             Mob(
                 baseEntity = baseEntity,

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/IslandExceptions.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/IslandExceptions.kt
@@ -96,8 +96,12 @@ object IslandExceptions {
         armorStand: ArmorStand?,
         baseEntity: LivingEntity,
     ): MobData.MobResult? {
-        val dummyArmorStand = armorStand ?: MobUtils.getClosestArmorStand(baseEntity, 4.0)
-        if (dummyArmorStand != null && MobFilter.dummyMobNamePattern.matches(dummyArmorStand.cleanName)) {
+        val dummyArmorStand = sequenceOf(armorStand)
+            .plus(MobUtils.getArmorStandByRangeAll(baseEntity, 4.0))
+            .filterNotNull()
+            .firstOrNull { MobFilter.dummyMobNamePattern.matches(it.cleanName) }
+
+        if (dummyArmorStand != null) {
             return MobData.MobResult.found(
                 Mob(
                     baseEntity = baseEntity,

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/IslandExceptions.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/IslandExceptions.kt
@@ -95,40 +95,25 @@ object IslandExceptions {
     private fun privateIsland(
         armorStand: ArmorStand?,
         baseEntity: LivingEntity,
-    ): MobData.MobResult? {
+    ): MobData.MobResult? = when {
 
-        // Dummy can either have 2m or Int.MAX_VALUE
-        if (baseEntity.baseMaxHealth >= 2_000_000) {
-            val dummyMob = sequenceOf(armorStand)
-                .plus(MobUtils.getArmorStandByRangeAll(baseEntity, 4.0))
-                .filterNotNull()
-                .firstNotNullOfOrNull { stand ->
-                    MobFilter.dummyMobNamePattern.matchMatcher(stand.cleanName) {
-                        Mob(
-                            baseEntity = baseEntity,
-                            category = MobCategory.SPECIAL,
-                            armorStand = stand,
-                            name = "Dummy",
-                            hypixelTypes = group("mobTypes"),
-                        )
-                    }
-                }
+        baseEntity.baseMaxHealth >= 2_000_000_000 -> MobData.MobResult.found(
+            Mob(
+                baseEntity = baseEntity,
+                category = MobCategory.SPECIAL,
+                name = "Dummy",
+            )
+        )
 
-            if (dummyMob != null) {
-                return MobData.MobResult.found(dummyMob)
-            }
-        }
-
-        if (armorStand?.isDefaultValue() != false) {
-            return if (baseEntity.getLorenzVec().distanceChebyshevIgnoreY(LocationUtils.playerLocation()) < 15.0) {
+        armorStand?.isDefaultValue() != false ->
+            if (baseEntity.getLorenzVec().distanceChebyshevIgnoreY(LocationUtils.playerLocation()) < 15.0) {
                 // TODO fix to always include Valid Mobs on Private Island
                 MobData.MobResult.found(MobFactories.minionMob(baseEntity))
             } else {
                 MobData.MobResult.notYetFound
             }
-        }
 
-        return null
+        else -> null
     }
 
     private fun theRift(

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/IslandExceptions.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/IslandExceptions.kt
@@ -96,16 +96,11 @@ object IslandExceptions {
         armorStand: ArmorStand?,
         baseEntity: LivingEntity,
     ) = when {
-
         // Dummy can have either 2b or Int.MAX_VALUE health
         // This does not check for the armor stand name because that is sometimes
         // delayed when switching mobs for the dummy too quickly
         baseEntity.baseMaxHealth >= 2_000_000_000 -> MobData.MobResult.found(
-            Mob(
-                baseEntity = baseEntity,
-                category = MobCategory.SPECIAL,
-                name = "Dummy",
-            )
+            MobFactories.special(baseEntity, "Dummy", armorStand)
         )
 
         armorStand?.isDefaultValue() != false ->

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/IslandExceptions.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/IslandExceptions.kt
@@ -95,7 +95,7 @@ object IslandExceptions {
     private fun privateIsland(
         armorStand: ArmorStand?,
         baseEntity: LivingEntity,
-    ): MobData.MobResult? = when {
+    ) = when {
 
         baseEntity.baseMaxHealth >= 2_000_000_000 -> MobData.MobResult.found(
             Mob(
@@ -109,9 +109,7 @@ object IslandExceptions {
             if (baseEntity.getLorenzVec().distanceChebyshevIgnoreY(LocationUtils.playerLocation()) < 15.0) {
                 // TODO fix to always include Valid Mobs on Private Island
                 MobData.MobResult.found(MobFactories.minionMob(baseEntity))
-            } else {
-                MobData.MobResult.notYetFound
-            }
+            } else MobData.MobResult.notYetFound
 
         else -> null
     }

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/IslandExceptions.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/IslandExceptions.kt
@@ -109,7 +109,7 @@ object IslandExceptions {
                             category = MobCategory.SPECIAL,
                             armorStand = stand,
                             name = "Dummy",
-                            hypixelTypes = group("types"),
+                            hypixelTypes = group("mobTypes"),
                         )
                     }
                 }

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/IslandExceptions.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/IslandExceptions.kt
@@ -98,6 +98,8 @@ object IslandExceptions {
     ) = when {
 
         // Dummy can have either 2b or Int.MAX_VALUE health
+        // This does not check for the armor stand name because that is sometimes
+        // delayed when switching mobs for the dummy too quickly
         baseEntity.baseMaxHealth >= 2_000_000_000 -> MobData.MobResult.found(
             Mob(
                 baseEntity = baseEntity,

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/MobFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/MobFilter.kt
@@ -161,10 +161,11 @@ object MobFilter {
     /**
      * REGEX-TEST:  Dummy 2B❤
      * REGEX-TEST:  Dummy 2B❤
+     * REGEX-TEST:  Dummy 2B❤
      */
     val dummyMobNamePattern by patternGroup.pattern(
         "pattern.privateisland.dummy",
-        ".*Dummy.*",
+        "(?<types>.*) Dummy 2B❤",
     )
 
     internal val RAT_SKULL_TEXTURE by SkullTextureHolder.texture("MOB_RAT")

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/MobFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/MobFilter.kt
@@ -158,16 +158,6 @@ object MobFilter {
         "^§8\\[§7Lv\\d+§8] §.(?<name>Horse|Armadillo|Skeleton Horse|Pig|Rat)$",
     )
 
-    /**
-     * REGEX-TEST:  Dummy 2B❤
-     * REGEX-TEST:  Dummy 2B❤
-     * REGEX-TEST:  Dummy 2B❤
-     */
-    val dummyMobNamePattern by patternGroup.pattern(
-        "pattern.privateisland.dummy",
-        "(?<mobTypes>.*) Dummy 2B❤",
-    )
-
     internal val RAT_SKULL_TEXTURE by SkullTextureHolder.texture("MOB_RAT")
     private val HELLWISP_TENTACLE_SKULL_TEXTURE by SkullTextureHolder.texture("HELLWISP_TENTACLE")
     private val RIFT_EYE_SKULL1_TEXTURE by SkullTextureHolder.texture("RIFT_EYE_1")

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/MobFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/MobFilter.kt
@@ -164,7 +164,7 @@ object MobFilter {
      */
     val dummyMobNamePattern by patternGroup.pattern(
         "pattern.privateisland.dummy",
-        ".* Dummy .*",
+        ".*Dummy.*",
     )
 
     internal val RAT_SKULL_TEXTURE by SkullTextureHolder.texture("MOB_RAT")

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/MobFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/MobFilter.kt
@@ -165,7 +165,7 @@ object MobFilter {
      */
     val dummyMobNamePattern by patternGroup.pattern(
         "pattern.privateisland.dummy",
-        "(?<types>.*) Dummy 2B❤",
+        "(?<mobTypes>.*) Dummy 2B❤",
     )
 
     internal val RAT_SKULL_TEXTURE by SkullTextureHolder.texture("MOB_RAT")

--- a/src/main/java/at/hannibal2/skyhanni/data/mob/MobFilter.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/mob/MobFilter.kt
@@ -158,6 +158,15 @@ object MobFilter {
         "^§8\\[§7Lv\\d+§8] §.(?<name>Horse|Armadillo|Skeleton Horse|Pig|Rat)$",
     )
 
+    /**
+     * REGEX-TEST:  Dummy 2B❤
+     * REGEX-TEST:  Dummy 2B❤
+     */
+    val dummyMobNamePattern by patternGroup.pattern(
+        "pattern.privateisland.dummy",
+        ".* Dummy .*",
+    )
+
     internal val RAT_SKULL_TEXTURE by SkullTextureHolder.texture("MOB_RAT")
     private val HELLWISP_TENTACLE_SKULL_TEXTURE by SkullTextureHolder.texture("HELLWISP_TENTACLE")
     private val RIFT_EYE_SKULL1_TEXTURE by SkullTextureHolder.texture("RIFT_EYE_1")

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/MobFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/MobFinder.kt
@@ -88,31 +88,31 @@ class MobFinder {
         RiftApi.inRift() -> tryAddRift(mob)
         GardenApi.inGarden() -> tryAddGarden(mob)
         IslandType.PRIVATE_ISLAND.isInIsland() && mob.name == "Dummy" -> EntityResult(bossType = BossType.DUMMY)
-        else -> {
-            when (mob.baseEntity) {
-                /*
-                 * Note that the order does matter here.
-                 * For example, if you put EntityZombie before EntityPigZombie,
-                 * EntityPigZombie will never be reached because EntityPigZombie extends EntityZombie.
-                 * Please take this into consideration if you are to modify this.
-                 */
-                is RemotePlayer -> tryAddEntityOtherPlayerMP(mob)
-                is IronGolem -> tryAddEntityIronGolem(mob)
-                is ZombifiedPiglin -> tryAddEntityPigZombie(mob)
-                is MagmaCube -> tryAddEntityMagmaCube(mob)
-                is EnderMan -> tryAddEntityEnderman(mob)
-                is AbstractSkeleton -> tryAddEntitySkeleton(mob)
-                is Guardian -> tryAddEntityGuardian(mob)
-                is Zombie -> tryAddEntityZombie(mob)
-                is WitherBoss -> tryAddEntityWither(mob)
-                is EnderDragon -> tryAddEntityDragon(mob)
-                is Spider -> tryAddEntitySpider(mob)
-                is Horse -> tryAddEntityHorse(mob)
-                is Blaze -> tryAddEntityBlaze(mob)
-                is Wolf -> tryAddEntityWolf(mob)
-                else -> null
-            }
-        }
+        else -> tryAddByEntityType(mob)
+    }
+
+    /**
+     * Note that the order does matter here.
+     * For example, if you put [Zombie] before [ZombifiedPiglin],
+     * [ZombifiedPiglin] will never be reached because it extends [Zombie].
+     * Please take this into consideration if you are to modify this.
+     */
+    private fun tryAddByEntityType(mob: Mob): EntityResult? = when (mob.baseEntity) {
+        is RemotePlayer -> tryAddEntityOtherPlayerMP(mob)
+        is IronGolem -> tryAddEntityIronGolem(mob)
+        is ZombifiedPiglin -> tryAddEntityPigZombie(mob)
+        is MagmaCube -> tryAddEntityMagmaCube(mob)
+        is EnderMan -> tryAddEntityEnderman(mob)
+        is AbstractSkeleton -> tryAddEntitySkeleton(mob)
+        is Guardian -> tryAddEntityGuardian(mob)
+        is Zombie -> tryAddEntityZombie(mob)
+        is WitherBoss -> tryAddEntityWither(mob)
+        is EnderDragon -> tryAddEntityDragon(mob)
+        is Spider -> tryAddEntitySpider(mob)
+        is Horse -> tryAddEntityHorse(mob)
+        is Blaze -> tryAddEntityBlaze(mob)
+        is Wolf -> tryAddEntityWolf(mob)
+        else -> null
     }
 
     private fun tryAddGarden(mob: Mob): EntityResult? {

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/MobFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/MobFinder.kt
@@ -355,7 +355,8 @@ class MobFinder {
             EntityResult(bossType = BossType.GAIA_CONSTRUCT)
         }
         // TODO use Lord Jawbus Name
-        mob.baseEntity.hasMaxHealth(100_000_000) -> {
+        IslandType.CRIMSON_ISLE.isInIsland() &&
+            mob.baseEntity.hasMaxHealth(100_000_000) -> {
             EntityResult(bossType = BossType.LORD_JAWBUS)
         }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/MobFinder.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/combat/damageindicator/MobFinder.kt
@@ -87,33 +87,30 @@ class MobFinder {
         DungeonApi.inDungeon() -> tryAddDungeon(mob)
         RiftApi.inRift() -> tryAddRift(mob)
         GardenApi.inGarden() -> tryAddGarden(mob)
+        IslandType.PRIVATE_ISLAND.isInIsland() && mob.name == "Dummy" -> EntityResult(bossType = BossType.DUMMY)
         else -> {
-            if (mob.name == "Dummy") {
-                EntityResult(bossType = BossType.DUMMY)
-            } else {
-                when (val entity = mob.baseEntity) {
-                    /*
-                     * Note that the order does matter here.
-                     * For example, if you put EntityZombie before EntityPigZombie,
-                     * EntityPigZombie will never be reached because EntityPigZombie extends EntityZombie.
-                     * Please take this into consideration if you are to modify this.
-                     */
-                    is RemotePlayer -> tryAddEntityOtherPlayerMP(mob)
-                    is IronGolem -> tryAddEntityIronGolem(mob)
-                    is ZombifiedPiglin -> tryAddEntityPigZombie(mob)
-                    is MagmaCube -> tryAddEntityMagmaCube(mob)
-                    is EnderMan -> tryAddEntityEnderman(mob)
-                    is AbstractSkeleton -> tryAddEntitySkeleton(mob)
-                    is Guardian -> tryAddEntityGuardian(mob)
-                    is Zombie -> tryAddEntityZombie(mob)
-                    is WitherBoss -> tryAddEntityWither(mob)
-                    is EnderDragon -> tryAddEntityDragon(mob)
-                    is Spider -> tryAddEntitySpider(mob)
-                    is Horse -> tryAddEntityHorse(mob)
-                    is Blaze -> tryAddEntityBlaze(mob)
-                    is Wolf -> tryAddEntityWolf(mob)
-                    else -> null
-                }
+            when (mob.baseEntity) {
+                /*
+                 * Note that the order does matter here.
+                 * For example, if you put EntityZombie before EntityPigZombie,
+                 * EntityPigZombie will never be reached because EntityPigZombie extends EntityZombie.
+                 * Please take this into consideration if you are to modify this.
+                 */
+                is RemotePlayer -> tryAddEntityOtherPlayerMP(mob)
+                is IronGolem -> tryAddEntityIronGolem(mob)
+                is ZombifiedPiglin -> tryAddEntityPigZombie(mob)
+                is MagmaCube -> tryAddEntityMagmaCube(mob)
+                is EnderMan -> tryAddEntityEnderman(mob)
+                is AbstractSkeleton -> tryAddEntitySkeleton(mob)
+                is Guardian -> tryAddEntityGuardian(mob)
+                is Zombie -> tryAddEntityZombie(mob)
+                is WitherBoss -> tryAddEntityWither(mob)
+                is EnderDragon -> tryAddEntityDragon(mob)
+                is Spider -> tryAddEntitySpider(mob)
+                is Horse -> tryAddEntityHorse(mob)
+                is Blaze -> tryAddEntityBlaze(mob)
+                is Wolf -> tryAddEntityWolf(mob)
+                else -> null
             }
         }
     }


### PR DESCRIPTION
## What
They changed the dummy mob quite a bit.
I added proper mob detection for the dummy, and just used that.

This also means the iron golem dummy is no longer considered to be "Lord Jawbus"
Also mob highlighting for runic and zelot counted the dummy

I don't feel like this is worthy of 3 changelog fixes for this smth.

## Changelog Fixes
+ Fixed Damage Indicator not working on the Dummy. - Avrg